### PR TITLE
EGRC-271: OSCAL Viewer Sub-Component Tests Execute Multiple Times

### DIFF
--- a/src/OSCALMetadata.test.js
+++ b/src/OSCALMetadata.test.js
@@ -39,6 +39,6 @@ export function testOSCALMetadata(parentElementName, renderer) {
   });
 }
 
-if (!require.main || require.main.id.endsWith("OSCALMetadata.test.js")) {
+if (!require.main) {
   testOSCALMetadata('OSCALMetadata', metadataRenderer);
 }

--- a/src/OSCALSystemCharacteristics.test.js
+++ b/src/OSCALSystemCharacteristics.test.js
@@ -106,6 +106,6 @@ export function testOSCALSystemCharacteristics(parentElementName, renderer) {
         expect(result).toHaveValue('other');
     });
 }
-if (!require.main || require.main.id.endsWith("OSCALSystemCharacteristics.test.js")) {
+if (!require.main) {
   testOSCALSystemCharacteristics('OSCALSystemCharacteristics', systemCharacteristicsRenderer);
 }

--- a/src/OSCALSystemImplementation.test.js
+++ b/src/OSCALSystemImplementation.test.js
@@ -131,6 +131,6 @@ export function testOSCALSystemImplementation(parentElementName, renderer) {
     });
 }
 
-if (!require.main || require.main.id.endsWith("OSCALSystemImplementation.test.js")) {
+if (!require.main) {
   testOSCALSystemImplementation('OSCALSystemImplementation', systemImplementationRenderer);
 }


### PR DESCRIPTION
Added check for execution as a module in sub-component tests