### PR TITLE
Fix for reload button crash

### DIFF
--- a/src/OSCALLoader.js
+++ b/src/OSCALLoader.js
@@ -59,6 +59,7 @@ export default function OSCALLoader(props) {
   };
 
   const handleReloadClick = (event) => {
+    setIsLoaded(false);
     loadOscalData(oscalUrl);
   };
 


### PR DESCRIPTION
The OSCAL SSP and Profile Viewer both crashed when the reload button was pressed.
This was because the isLoaded variable was not being reset to false, so the loader was not correctly loading the controls.
This line resets the variable to false and fixes the crashes.