### PR TITLE
Correctly reload SSP Viewer with the reload button.

### DIFF
--- a/src/OSCALLoader.js
+++ b/src/OSCALLoader.js
@@ -56,6 +56,7 @@ export default function OSCALLoader(props) {
   };
 
   const handleReloadClick = (event) => {
+    setIsLoaded(false);
     loadOscalData(oscalUrl);
   };
 


### PR DESCRIPTION
OSCALLoader.js initially sets the variable isLoaded to false, and uses this variable
to resolve the controls for an SSP. This caused a crash as referenced in EGRC-298.
OSCALLoader.js now resets isLoaded to false when the reload button is pressed.
SSP Viewer reload button is now working as intended.