### PR TITLE
Fix broken Component Control Implementation display

### DIFF
--- a/src/OSCALControlImplementation.js
+++ b/src/OSCALControlImplementation.js
@@ -27,10 +27,10 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 /**
- * Creates the control implementation. This function sets up the
- * header and outer grid elements and calls OSCALControlImplementationReqList.
+ * Creates the control implementation by setting up the header and outer grid elements
+ * and calls OSCALControlImplementationReqList.
  *
- * @param {*} props
+ * @param {object} props SSP properties
  * @returns The corresponding Control Implementation
  */
 export default function OSCALControlImplementation(props) {

--- a/src/OSCALControlImplementationImplReq.js
+++ b/src/OSCALControlImplementationImplReq.js
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
 /**
  * Sets up elements of the tab panel.
  *
- * @param {*} props
+ * @param {object} props SSP properties
  * @returns The corresponding tab panel
  */
 function TabPanel(props) {
@@ -81,8 +81,8 @@ TabPanel.propTypes = {
 /**
  * Makes a component dynamic and fit it's associated tab.
  *
- * @param {*} index The given index of a component
- * @returns A components dynamic attributes
+ * @param {number} index The given index of a component
+ * @returns A component's dynamic attributes
  */
 function a11yProps(index) {
   return {
@@ -94,13 +94,12 @@ function a11yProps(index) {
 /**
  * Creates the internal elements of Control Implementation.
  *
- * @param {*} props
- * @returns The corresponding Control Implemenation Request
+ * @param {object} props SSP properties
+ * @returns The corresponding Control Implementation Request
  */
 export default function OSCALControlImplementationImplReq(props) {
   const classes = useStyles(props);
   const [value, setValue] = React.useState(0);
-
   // Updates panel based on tab state change
   const handleChange = (event, newValue) => {
     setValue(newValue);

--- a/src/OSCALControlImplementationImplReq.test.js
+++ b/src/OSCALControlImplementationImplReq.test.js
@@ -22,23 +22,19 @@ const controlImplTestData = {
               "set-parameters": [
                 {
                   "param-id": "control-1_prm_1",
-                  values: [
-                    "control 1 / component 1 / parameter 1 value"
-                  ],
+                  values: ["control 1 / component 1 / parameter 1 value"],
                 },
                 {
                   "param-id": "control-1_prm_2",
-                  values: [
-                    "control 1 / component 1 / parameter 2 value"
-                  ]
+                  values: ["control 1 / component 1 / parameter 2 value"],
                 },
-              ]
+              ],
             },
-          ]
+          ],
         },
-      ]
-    }
-  ]
+      ],
+    },
+  ],
 };
 const componentsTestData = [
   {
@@ -53,12 +49,12 @@ const controlsTestData = [
     params: [
       {
         id: "control-1_prm_1",
-        label: "control 1 / parameter 1 label"
+        label: "control 1 / parameter 1 label",
       },
       {
         id: "control-1_prm_2",
-        label: "control 1 / parameter 2 label"
-      }
+        label: "control 1 / parameter 2 label",
+      },
     ],
     parts: [
       {
@@ -72,14 +68,15 @@ const controlsTestData = [
             props: [
               {
                 name: "label",
-                value: "a."
-              }
+                value: "a.",
+              },
             ],
-            prose: "Does something with {{ insert: param, control-1_prm_1 }} and {{ insert: param, control-1_prm_2 }}"
+            prose:
+              "Does something with {{ insert: param, control-1_prm_1 }} and {{ insert: param, control-1_prm_2 }}",
           },
-        ]
+        ],
       },
-    ]
+    ],
   },
 ];
 
@@ -117,7 +114,7 @@ test("OSCALControlImplementationImplReq displays component implementation descri
       controls={controlsTestData}
     />
   );
-  
+
   userEvent.hover(screen.getByRole("link", { name: "a." }));
   expect(
     await screen.findByText("Component 1 description of implementing control 1")


### PR DESCRIPTION
Due to the recent changes from NIST, the System Security Plan (SSP) Viewer wasn't properly displaying the component control implementations correctly. When selecting the tabs on the left side of the Control Implementation, the panel would remain the same, rather than showing highlighted statements. The main issue was found in`OSCALControlPart` when selecting statements, and `by-components`, `statements`, and `set-parameters` collections were matched with a key that returned undefined. In the past these collections of objects were using the grouping scheme `"BY_KEY"`, which have been recently changed to `"ARRAY"`. In `OSCALControlParts`, the mapping to keys has been removed and objects from these collections are referenced with their respective uuid and id attributes. Highlighted statements now appear, as well as hoverable hyperlinks in the Control Implementation. The `OSCALControlImplemenationImplReq` tests data have also been updated to reflect NIST's json files.