### PR TITLE
EGRC-405: Workaround for Broken Example Component Definition

### DIFF
--- a/src/OSCALLoader.js
+++ b/src/OSCALLoader.js
@@ -29,7 +29,7 @@ const defaultOscalCatalogUrl =
 const defaultOscalSspUrl =
   "https://raw.githubusercontent.com/usnistgov/oscal-content/master/examples/ssp/json/ssp-example.json";
 const defaultOSCALComponentUrl =
-  "https://raw.githubusercontent.com/usnistgov/oscal-content/master/examples/component-definition/json/example-component.json";
+  "https://raw.githubusercontent.com/EasyDynamics/oscal-content/manual-fix-of-component-paths/examples/component-definition/json/example-component.json";
 
 export default function OSCALLoader(props) {
   const [error, setError] = useState(null);


### PR DESCRIPTION
Changed default component definition URL to workaround URL.

Note that the component definition viewer will still not load until some of the changes around URL fixing in #48 are merged.