### PR TITLE
Fix console warnings

### DIFF
--- a/src/OSCALControlImplementationImplReq.js
+++ b/src/OSCALControlImplementationImplReq.js
@@ -113,6 +113,7 @@ export default function OSCALControlImplementationImplReq(props) {
   }
   // Setup UI of Control Implemention with verticle tabs and a tab panel to
   // display control implementation, which are both wrapped in a card
+
   return (
     <Card className={`${classes.OSCALImplReq} ${classes.OSCALImplChildLevel}`}>
       <CardContent>
@@ -130,6 +131,7 @@ export default function OSCALControlImplementationImplReq(props) {
                 label={component.title}
                 {...a11yProps(index)}
                 className={classes.tabButton}
+                key={component.uuid}
               />
             ))}
           </Tabs>
@@ -138,6 +140,7 @@ export default function OSCALControlImplementationImplReq(props) {
               value={value}
               index={index}
               className={classes.tabPanelScrollable}
+              key={component.uuid}
             >
               <OSCALControl
                 control={getControlOrSubControl(


### PR DESCRIPTION
This as well as commits in #48 fixes console warnings that occured when running `npm run test` and when using the viewer. 


#### Note
`Warning: findDOMNode is deprecated in StrictMode.` still appears on the browser when running locally. This seems to be due to Material-UI components we are using. This might be dealt with in an [v5](https://github.com/mui-org/material-ui/issues/20012) of Material-UI, but that version has not been released yet. `StrictMode` is typically used for development builds anyway, so this might not effect a released build. 
