### PR TITLE
Improve Profile Viewer performance & user experience

### DIFF
--- a/src/components/OSCALControl.js
+++ b/src/components/OSCALControl.js
@@ -52,10 +52,10 @@ export default function OSCALControl(props) {
   const classes = useStyles(props);
 
   let modificationDisplay;
-  if (props.modifications) {
+  if (props.modificationAlters) {
     modificationDisplay = (
       <OSCALControlModification
-        modifications={props.modifications}
+        modificationAlters={props.modificationAlters}
         controlId={props.control.id}
       />
     );
@@ -78,11 +78,12 @@ export default function OSCALControl(props) {
           props.control.parts.map((part, index) => (
             <OSCALControlPart
               part={part}
+              control={props.control}
               parameters={props.control.params}
               implReqStatements={props.implReqStatements}
               componentId={props.componentId}
-              control={props.control}
-              modifications={props.modifications}
+              modificationAlters={props.modificationAlters}
+              modificationSetParameters={props.modificationSetParameters}
               key={part.id ?? `part-${index}`}
             />
           ))}
@@ -90,9 +91,10 @@ export default function OSCALControl(props) {
           props.control.controls.map((control) => (
             <OSCALControl
               control={control}
-              includeControlIds={props.includeControlIds}
-              modifications={props.modifications}
               parameters={control.params}
+              includeControlIds={props.includeControlIds}
+              modificationAlters={props.modificationAlters}
+              modificationSetParameters={props.modificationSetParameters}
               childLevel={props.childLevel + 1}
               key={control.id}
             />

--- a/src/components/OSCALControlModification.js
+++ b/src/components/OSCALControlModification.js
@@ -25,11 +25,7 @@ const useStyles = makeStyles(() => ({
  * @param {String} controlPartId Control part ID to match
  * @returns html object
  */
-const getAlterAddsOrRemovesDisplay = (
-  addsElements,
-  addsLabel,
-  controlPartId
-) => {
+function getAlterAddsOrRemovesDisplay(addsElements, addsLabel, controlPartId) {
   if (!addsElements?.length) {
     return null;
   }
@@ -57,7 +53,7 @@ const getAlterAddsOrRemovesDisplay = (
       {typographies}
     </DialogContent>
   );
-};
+}
 
 /**
  * Check if an element has a valid id.
@@ -68,14 +64,14 @@ const getAlterAddsOrRemovesDisplay = (
  * @param {String} field Field of Add/Remove element to check
  * @returns true if element matches controlPartID, OR if this should render a top-level modification
  */
-const isRelevantId = (controlPartId, controlId, element, field) => {
+function isRelevantId(controlPartId, controlId, element, field) {
   if (!element[field]) {
     // If by-id of this modification is undefined, check if it can be rendered at the top level
     return controlPartId === controlId;
   }
   // otherwise check if by-id matches this control part's ID
   return element[field] === controlPartId;
-};
+}
 
 /**
  * Get the modifications from the adds/removes list.
@@ -86,7 +82,7 @@ const isRelevantId = (controlPartId, controlId, element, field) => {
  * @param {String} modText String to display type of modification
  * @returns an HTML element
  */
-const getModifications = (controlPartId, controlId, modList, modText) => {
+function getModifications(controlPartId, controlId, modList, modText) {
   // Add everything with ids that match controlPartId
 
   /* TODO: Differences in implementations of the OSCAL standard makes
@@ -104,11 +100,11 @@ const getModifications = (controlPartId, controlId, modList, modText) => {
     getAlterAddsOrRemovesDisplay(controlParts, modText, controlPartId),
     controlParts.length,
   ];
-};
+}
 
 export default function OSCALControlModification(props) {
   // Finds the control-id within alters and matches it with a resolved control
-  const alter = props.modifications?.alters?.find(
+  const alter = props.modificationAlters?.find(
     (element) => element["control-id"] === props.controlId
   );
 

--- a/src/components/OSCALControlPart.js
+++ b/src/components/OSCALControlPart.js
@@ -24,7 +24,8 @@ const getPartLabel = (props) =>
 export default function OSCALControlPart(props) {
   // Don't display assessment if we're displaying a control implementation
   if (
-    (props.implReqStatements || props.modifications) &&
+    (props.implReqStatements ||
+      (props.modificationSetParameters && props.modificationAlters)) &&
     (props.part.name === "objective" || props.part.name === "assessment")
   ) {
     return null;
@@ -37,19 +38,16 @@ export default function OSCALControlPart(props) {
   }
 
   let modificationDisplay;
-  // Passing all of the modifications works, but could be made
-  // more efficient later on.
-  if (props.modifications) {
+  if (props.modificationAlters) {
     modificationDisplay = (
       <OSCALControlModification
-        modifications={props.modifications}
+        modificationAlters={props.modificationAlters}
         controlPartId={props.part.id}
         controlId={props.controlId}
       />
     );
   }
 
-  const isStatement = props.part.name === "statement";
   const label = getPartLabel(props.part.props);
 
   let replacedProse;
@@ -62,7 +60,7 @@ export default function OSCALControlPart(props) {
         implReqStatements={props.implReqStatements}
         statementId={props.part.id}
         componentId={props.componentId}
-        modifications={props.modifications}
+        modificationSetParameters={props.modificationSetParameters}
         modificationDisplay={modificationDisplay}
       />
     );
@@ -72,18 +70,17 @@ export default function OSCALControlPart(props) {
         label={label}
         prose={props.part.prose}
         parameters={props.parameters}
-        modifications={props.modifications}
+        modificationSetParameters={props.modificationSetParameters}
         modificationDisplay={modificationDisplay}
       />
     );
   }
 
-  let className;
-  if (isStatement) {
-    className = classes.OSCALControlStatement;
-  } else {
-    className = classes.OSCALControlPart;
-  }
+  // Set classname to control statement when part name is "statement"
+  const className =
+    props.part.name === "statement"
+      ? classes.OSCALControlStatement
+      : classes.OSCALControlPart;
 
   return (
     <div className={className}>
@@ -96,8 +93,9 @@ export default function OSCALControlPart(props) {
             parameters={props.parameters}
             implReqStatements={props.implReqStatements}
             componentId={props.componentId}
+            modificationAlters={props.modificationAlters}
+            modificationSetParameters={props.modificationSetParameters}
             key={part.id}
-            modifications={props.modifications}
           />
         ))}
     </div>

--- a/src/components/OSCALControlPart.js
+++ b/src/components/OSCALControlPart.js
@@ -24,7 +24,9 @@ const getPartLabel = (props) =>
 export default function OSCALControlPart(props) {
   // Don't display assessment if we're displaying a control implementation
   if (
-    (props.implReqStatements || props.modificationSetParameters) &&
+    (props.implReqStatements ||
+      props.modificationSetParameters ||
+      props.modificationAlters) &&
     (props.part.name === "objective" || props.part.name === "assessment")
   ) {
     return null;

--- a/src/components/OSCALControlPart.js
+++ b/src/components/OSCALControlPart.js
@@ -24,8 +24,7 @@ const getPartLabel = (props) =>
 export default function OSCALControlPart(props) {
   // Don't display assessment if we're displaying a control implementation
   if (
-    (props.implReqStatements ||
-      (props.modificationSetParameters && props.modificationAlters)) &&
+    (props.implReqStatements || props.modificationSetParameters) &&
     (props.part.name === "objective" || props.part.name === "assessment")
   ) {
     return null;

--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { styled, withTheme, makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
@@ -77,20 +77,24 @@ function getParameterValue(statementByComponent, parameterId) {
 
 /**
  * Builds the display of constraints for the given parameterId
- * @param {Object} modifications
+ * @param {Object} modificationSetParameters
  * @param {String} parameterId
  * @returns the parameter label
  */
-function getConstraintsDisplay(modifications, parameterId) {
-  if (!modifications || !modifications["set-parameters"] || !parameterId) {
+function getConstraintsDisplay(modificationSetParameters, parameterId) {
+  // Error check parameters for null
+  if (!modificationSetParameters || !parameterId) {
     return "";
   }
-  const foundParameterSetting = modifications["set-parameters"].find(
+  // Search for matching parameter id
+  const foundParameterSetting = modificationSetParameters.find(
     (parameterSetting) => parameterSetting["param-id"] === parameterId
   );
+  // Error check constriants
   if (!foundParameterSetting?.constraints) {
     return "";
   }
+  // Provide list of constraints
   const constraintDescriptions = [];
   foundParameterSetting.constraints.forEach((constraint) => {
     constraintDescriptions.push(constraint.description);
@@ -134,13 +138,22 @@ function SegmentTooltipWrapper(props) {
  * Builds the display of a segment of placeholder label text within prose
  * @param {Array} parameters
  * @param {String} parameterId
- * @param {Object} modifications
+ * @param {Object} modificationSetParameters
  * @param {String} key
  * @returns the parameter label segment component
  */
-function getParameterLabelSegment(parameters, parameterId, modifications, key) {
-  const parameterLabel = getParameterLabel(parameters, parameterId);
-  const constraintsDisplay = getConstraintsDisplay(modifications, parameterId);
+function getParameterLabelSegment(
+  parameters,
+  parameterId,
+  modificationSetParameters,
+  key
+) {
+  const parameterLabel = useCallback(
+    getParameterLabel(parameters, parameterId)
+  );
+  const constraintsDisplay = useCallback(
+    getConstraintsDisplay(modificationSetParameters, parameterId)
+  );
   if (!constraintsDisplay) {
     return (
       <ParamLabel component="span" key={`param-label-key-${key}`}>
@@ -164,18 +177,22 @@ function getParameterLabelSegment(parameters, parameterId, modifications, key) {
  * Builds the display of a segment of placeholder value text within prose
  * @param {Object} statementByComponent
  * @param {String} parameterId
- * @param {Object} modifications
+ * @param {Object} modificationSetParameters
  * @param {String} key
  * @returns the parameter value segment component
  */
 function getParameterValueSegment(
   statementByComponent,
   parameterId,
-  modifications,
+  modificationSetParameters,
   key
 ) {
-  const parameterValue = getParameterValue(statementByComponent, parameterId);
-  const constraintsDisplay = getConstraintsDisplay(modifications, parameterId);
+  const parameterValue = useCallback(
+    getParameterValue(statementByComponent, parameterId)
+  );
+  const constraintsDisplay = useCallback(
+    getConstraintsDisplay(modificationSetParameters, parameterId)
+  );
   if (!constraintsDisplay.length) {
     return (
       <ParamValue component="span" key={`param-value-key-${key}`}>
@@ -222,12 +239,12 @@ export function OSCALReplacedProseWithParameterLabel(props) {
         .split(RegExp(prosePlaceholderRegexpString, "g"))
         .map((segment, index) => {
           if (index % 2 === 0) {
-            return getTextSegment(segment, index.toString());
+            return useCallback(getTextSegment(segment, index.toString()));
           }
           return getParameterLabelSegment(
             props.parameters,
             segment,
-            props.modifications,
+            props.modificationSetParameters,
             index.toString()
           );
         })}
@@ -276,12 +293,12 @@ export function OSCALReplacedProseWithByComponentParameterValue(props) {
         .split(RegExp(prosePlaceholderRegexpString, "g"))
         .map((segment, index) => {
           if (index % 2 === 0) {
-            return getTextSegment(segment, index.toString());
+            return useCallback(getTextSegment(segment, index.toString()));
           }
           return getParameterValueSegment(
             statementByComponent,
             segment,
-            props.modifications,
+            props.modificationSetParameters,
             index.toString()
           );
         })}

--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -35,7 +35,7 @@ const useStyles = makeStyles(() => ({
  * @param {String} parameterId
  * @returns the parameter label
  */
-const getParameterLabel = (parameters, parameterId) => {
+function getParameterLabel(parameters, parameterId) {
   const parameter = parameters.find(
     (testParameter) => testParameter.id === parameterId
   );
@@ -50,7 +50,7 @@ const getParameterLabel = (parameters, parameterId) => {
     return `< ${parameter.select.choice.join(" | ")} >`;
   }
   return `< ${parameterId} >`;
-};
+}
 
 /**
  * Finds a parameter setting in a component statement
@@ -104,7 +104,7 @@ function getConstraintsDisplay(modifications, parameterId) {
  * @param {String} key
  * @returns the text segment component
  */
-const getTextSegment = (text, key) => {
+function getTextSegment(text, key) {
   if (!text) {
     return null;
   }
@@ -113,7 +113,7 @@ const getTextSegment = (text, key) => {
       {text}
     </Typography>
   );
-};
+}
 
 /**
  * Wraps a placeholder display in a styled tooltip
@@ -138,12 +138,7 @@ function SegmentTooltipWrapper(props) {
  * @param {String} key
  * @returns the parameter label segment component
  */
-const getParameterLabelSegment = (
-  parameters,
-  parameterId,
-  modifications,
-  key
-) => {
+function getParameterLabelSegment(parameters, parameterId, modifications, key) {
   const parameterLabel = getParameterLabel(parameters, parameterId);
   const constraintsDisplay = getConstraintsDisplay(modifications, parameterId);
   if (!constraintsDisplay) {
@@ -163,7 +158,7 @@ const getParameterLabelSegment = (
       </ParamLabel>
     </SegmentTooltipWrapper>
   );
-};
+}
 
 /**
  * Builds the display of a segment of placeholder value text within prose
@@ -173,12 +168,12 @@ const getParameterLabelSegment = (
  * @param {String} key
  * @returns the parameter value segment component
  */
-const getParameterValueSegment = (
+function getParameterValueSegment(
   statementByComponent,
   parameterId,
   modifications,
   key
-) => {
+) {
   const parameterValue = getParameterValue(statementByComponent, parameterId);
   const constraintsDisplay = getConstraintsDisplay(modifications, parameterId);
   if (!constraintsDisplay.length) {
@@ -198,7 +193,7 @@ const getParameterValueSegment = (
       </ParamValue>
     </SegmentTooltipWrapper>
   );
-};
+}
 
 /**
  * Replaces the parameter placeholders in the given prose with the given label

--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { styled, withTheme, makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
@@ -148,11 +148,10 @@ function getParameterLabelSegment(
   modificationSetParameters,
   key
 ) {
-  const parameterLabel = useCallback(
-    getParameterLabel(parameters, parameterId)
-  );
-  const constraintsDisplay = useCallback(
-    getConstraintsDisplay(modificationSetParameters, parameterId)
+  const parameterLabel = getParameterLabel(parameters, parameterId);
+  const constraintsDisplay = getConstraintsDisplay(
+    modificationSetParameters,
+    parameterId
   );
   if (!constraintsDisplay) {
     return (
@@ -187,11 +186,10 @@ function getParameterValueSegment(
   modificationSetParameters,
   key
 ) {
-  const parameterValue = useCallback(
-    getParameterValue(statementByComponent, parameterId)
-  );
-  const constraintsDisplay = useCallback(
-    getConstraintsDisplay(modificationSetParameters, parameterId)
+  const parameterValue = getParameterValue(statementByComponent, parameterId);
+  const constraintsDisplay = getConstraintsDisplay(
+    modificationSetParameters,
+    parameterId
   );
   if (!constraintsDisplay.length) {
     return (
@@ -239,7 +237,7 @@ export function OSCALReplacedProseWithParameterLabel(props) {
         .split(RegExp(prosePlaceholderRegexpString, "g"))
         .map((segment, index) => {
           if (index % 2 === 0) {
-            return useCallback(getTextSegment(segment, index.toString()));
+            return getTextSegment(segment, index.toString());
           }
           return getParameterLabelSegment(
             props.parameters,
@@ -293,7 +291,7 @@ export function OSCALReplacedProseWithByComponentParameterValue(props) {
         .split(RegExp(prosePlaceholderRegexpString, "g"))
         .map((segment, index) => {
           if (index % 2 === 0) {
-            return useCallback(getTextSegment(segment, index.toString()));
+            return getTextSegment(segment, index.toString());
           }
           return getParameterValueSegment(
             statementByComponent,

--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -90,7 +90,7 @@ function getConstraintsDisplay(modificationSetParameters, parameterId) {
   const foundParameterSetting = modificationSetParameters.find(
     (parameterSetting) => parameterSetting["param-id"] === parameterId
   );
-  // Error check constriants
+  // Error check constraints
   if (!foundParameterSetting?.constraints) {
     return "";
   }

--- a/src/components/OSCALControlProse.test.js
+++ b/src/components/OSCALControlProse.test.js
@@ -37,12 +37,15 @@ const modificationsTestData = {
 };
 
 function proseParamLabelsRenderer() {
+  const modificationSetParametersTestData = Object.values(
+    modificationsTestData["set-parameters"]
+  );
   render(
     <OSCALReplacedProseWithParameterLabel
       label={labelTestData}
       prose={proseTestData}
       parameters={parametersTestData}
-      modifications={modificationsTestData}
+      modificationSetParameters={modificationSetParametersTestData}
     />
   );
 }

--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useRef } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import List from "@material-ui/core/List";
 import ListSubheader from "@material-ui/core/ListSubheader";
+import Skeleton from "@material-ui/lab/Skeleton";
+import CardContent from "@material-ui/core/CardContent";
 import OSCALMetadata from "./OSCALMetadata";
 import OSCALControl from "./OSCALControl";
 import OSCALBackMatter from "./OSCALBackMatter";
@@ -15,12 +17,21 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+/**
+ * Displays a given OSCAL Profile is an easily consumable format. According to NIST, a profile
+ * represents the baseline of selected controls from one or more control catalogs.
+ * For more information see: https://pages.nist.gov/OSCAL/concepts/layer/control/profile/
+ *
+ * @param {Object} props
+ * @returns The OSCAL profile component
+ */
 export default function OSCALProfile(props) {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const classes = useStyles();
   const unmounted = useRef(false);
 
+  // Using oscal-utils resolves the profile, provides are error when failure
   useEffect(() => {
     OSCALResolveProfile(
       props.profile,
@@ -43,42 +54,52 @@ export default function OSCALProfile(props) {
     };
   }, []);
 
+  // Flatten controls and IDs into single array
   const includeControlIds = props.profile.imports
     .flatMap((imp) => imp["include-controls"])
     .flatMap((includeControl) => includeControl["with-ids"]);
 
-  let profileImports;
+  // Imports resolved controls when loaded. When loading, displays a basic skeleton placeholder
+  // of the content.
+  const profileImports = (
+    <List
+      className={classes.OSCALControlList}
+      subheader={
+        <ListSubheader
+          className={classes.OSCALMetadataPartiesHeader}
+          component="div"
+          id="oscal-profile-importedControls"
+          disableSticky
+        >
+          Imported Controls
+        </ListSubheader>
+      }
+    >
+      {!isLoaded
+        ? [...Array(3)].map(() => (
+            <CardContent>
+              <span style={{ marginTop: 5, display: "flex", gap: "1em" }}>
+                <Skeleton variant="text" width="25em" height="3em" />
+                <Skeleton variant="circle" width="3em" height="3em" />
+              </span>
+              <Skeleton variant="text" width="10em" height="2.5em" />
+              <Skeleton variant="rect" width="100%" height={115} />
+              <Skeleton variant="text" width="6.5em" height="3.5em" />
+            </CardContent>
+          ))
+        : props.profile.resolvedControls.map((control) => (
+            <OSCALControl
+              control={control}
+              includeControlIds={includeControlIds}
+              modifications={props.profile.modify}
+              childLevel={0}
+              key={`control-${control.id}`}
+            />
+          ))}
+    </List>
+  );
 
-  if (!isLoaded) {
-    profileImports = null;
-  } else {
-    profileImports = (
-      <List
-        className={classes.OSCALControlList}
-        subheader={
-          <ListSubheader
-            className={classes.OSCALMetadataPartiesHeader}
-            component="div"
-            id="oscal-profile-importedControls"
-            disableSticky
-          >
-            Imported Controls
-          </ListSubheader>
-        }
-      >
-        {props.profile.resolvedControls.map((control) => (
-          <OSCALControl
-            control={control}
-            includeControlIds={includeControlIds}
-            modifications={props.profile.modify}
-            childLevel={0}
-            key={`control-${control.id}`}
-          />
-        ))}
-      </List>
-    );
-  }
-
+  // Display Metadata and BackMatter components at bottom of Profile
   return (
     <div className={classes.paper}>
       <OSCALMetadata metadata={props.profile.metadata} />

--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -31,7 +31,7 @@ export default function OSCALProfile(props) {
   const classes = useStyles();
   const unmounted = useRef(false);
 
-  // Using oscal-utils resolves the profile, provides are error when failure
+  // Resolved profile using oscal-utils. Provides error when failure.
   useEffect(() => {
     OSCALResolveProfile(
       props.profile,
@@ -60,16 +60,22 @@ export default function OSCALProfile(props) {
     .flatMap((includeControl) => includeControl["with-ids"]);
 
   // Create arrays of modification alter & set-parameters attributes
-  const modificationAlters = Object.values(props.profile.modify.alters);
-  const modificationSetParameters = Object.values(
-    props.profile.modify["set-parameters"]
-  );
+  let modificationSetParameters = null;
+  let modificationAlters = null;
+  if (props.profile.modify.alters) {
+    modificationAlters = Object.values(props.profile.modify.alters);
+  }
+  if (props.profile.modify["set-parameters"]) {
+    modificationSetParameters = Object.values(
+      props.profile.modify["set-parameters"]
+    );
+  }
 
   /**
    * Display a basic skeleton placeholder, resembling the control cards.
    *
    * @param {number} index
-   * @returns Provides a SkeletonBox
+   * @returns Provides a skeleton card
    */
   function renderSkeletonCard(index) {
     return (

--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -18,6 +18,29 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 /**
+ * Display a basic skeleton placeholder, resembling the control cards.
+ *
+ * @param {number} index
+ * @returns Provides a skeleton card
+ */
+function renderSkeletonCard(index) {
+  return (
+    <CardContent key={`skeleton-card-${index}`}>
+      <span
+        style={{ marginTop: 5, display: "flex", gap: "1em" }}
+        key="controls load 0"
+      >
+        <Skeleton variant="text" width="25em" height="3em" />
+        <Skeleton variant="circle" width="3em" height="3em" />
+      </span>
+      <Skeleton variant="text" width="10em" height="2.5em" />
+      <Skeleton variant="rect" width="100%" height={115} />
+      <Skeleton variant="text" width="6.5em" height="3.5em" />
+    </CardContent>
+  );
+}
+
+/**
  * Displays a given OSCAL Profile is an easily consumable format. According to NIST, a profile
  * represents the baseline of selected controls from one or more control catalogs.
  * For more information see: https://pages.nist.gov/OSCAL/concepts/layer/control/profile/
@@ -59,44 +82,8 @@ export default function OSCALProfile(props) {
     .flatMap((imp) => imp["include-controls"])
     .flatMap((includeControl) => includeControl["with-ids"]);
 
-  // Create arrays of modification alter & set-parameters attributes
-  let modificationSetParameters = null;
-  let modificationAlters = null;
-  if (props.profile.modify.alters) {
-    modificationAlters = Object.values(props.profile.modify.alters);
-  }
-  if (props.profile.modify["set-parameters"]) {
-    modificationSetParameters = Object.values(
-      props.profile.modify["set-parameters"]
-    );
-  }
-
-  /**
-   * Display a basic skeleton placeholder, resembling the control cards.
-   *
-   * @param {number} index
-   * @returns Provides a skeleton card
-   */
-  function renderSkeletonCard(index) {
-    return (
-      <CardContent key={`skeleton-card-${index}`}>
-        <span
-          style={{ marginTop: 5, display: "flex", gap: "1em" }}
-          key="controls load 0"
-        >
-          <Skeleton variant="text" width="25em" height="3em" />
-          <Skeleton variant="circle" width="3em" height="3em" />
-        </span>
-        <Skeleton variant="text" width="10em" height="2.5em" />
-        <Skeleton variant="rect" width="100%" height={115} />
-        <Skeleton variant="text" width="6.5em" height="3.5em" />
-      </CardContent>
-    );
-  }
-  // Determine number of skeleton cards to show
-  const skeletonCards = 3;
-
-  // Import resolved controls when loaded. When loading, display a basic skeleton placeholder.
+  // Import resolved controls when loaded. When loading, display a basic skeleton placeholder
+  // resembling the content.
   const profileImports = (
     <List
       className={classes.OSCALControlList}
@@ -112,15 +99,13 @@ export default function OSCALProfile(props) {
       }
     >
       {!isLoaded
-        ? [...Array(skeletonCards)].map((_val, index) =>
-            renderSkeletonCard(index)
-          )
+        ? [...Array(3)].map((_val, index) => renderSkeletonCard(index))
         : props.profile.resolvedControls.map((control) => (
             <OSCALControl
               control={control}
               includeControlIds={includeControlIds}
-              modificationAlters={modificationAlters}
-              modificationSetParameters={modificationSetParameters}
+              modificationAlters={props.profile.modify.alters}
+              modificationSetParameters={props.profile.modify["set-parameters"]}
               childLevel={0}
               key={`control-${control.id}`}
             />

--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -65,8 +65,32 @@ export default function OSCALProfile(props) {
     props.profile.modify["set-parameters"]
   );
 
-  // Import resolved controls when loaded. When loading, display a basic skeleton placeholder
-  // resembling the content.
+  /**
+   * Display a basic skeleton placeholder, resembling the control cards.
+   *
+   * @param {number} index
+   * @returns Provides a SkeletonBox
+   */
+  function renderSkeletonCard(index) {
+    return (
+      <CardContent key={`skeleton-card-${index}`}>
+        <span
+          style={{ marginTop: 5, display: "flex", gap: "1em" }}
+          key="controls load 0"
+        >
+          <Skeleton variant="text" width="25em" height="3em" />
+          <Skeleton variant="circle" width="3em" height="3em" />
+        </span>
+        <Skeleton variant="text" width="10em" height="2.5em" />
+        <Skeleton variant="rect" width="100%" height={115} />
+        <Skeleton variant="text" width="6.5em" height="3.5em" />
+      </CardContent>
+    );
+  }
+  // Determine number of skeleton cards to show
+  const skeletonCards = 3;
+
+  // Import resolved controls when loaded. When loading, display a basic skeleton placeholder.
   const profileImports = (
     <List
       className={classes.OSCALControlList}
@@ -82,17 +106,9 @@ export default function OSCALProfile(props) {
       }
     >
       {!isLoaded
-        ? [...Array(3)].map(() => (
-            <CardContent>
-              <span style={{ marginTop: 5, display: "flex", gap: "1em" }}>
-                <Skeleton variant="text" width="25em" height="3em" />
-                <Skeleton variant="circle" width="3em" height="3em" />
-              </span>
-              <Skeleton variant="text" width="10em" height="2.5em" />
-              <Skeleton variant="rect" width="100%" height={115} />
-              <Skeleton variant="text" width="6.5em" height="3.5em" />
-            </CardContent>
-          ))
+        ? [...Array(skeletonCards)].map((_val, index) =>
+            renderSkeletonCard(index)
+          )
         : props.profile.resolvedControls.map((control) => (
             <OSCALControl
               control={control}

--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -54,13 +54,19 @@ export default function OSCALProfile(props) {
     };
   }, []);
 
-  // Flatten controls and IDs into single array
+  // Flatten controls and IDs into single key, value structure
   const includeControlIds = props.profile.imports
     .flatMap((imp) => imp["include-controls"])
     .flatMap((includeControl) => includeControl["with-ids"]);
 
-  // Imports resolved controls when loaded. When loading, displays a basic skeleton placeholder
-  // of the content.
+  // Create arrays of modification alter & set-parameters attributes
+  const modificationAlters = Object.values(props.profile.modify.alters);
+  const modificationSetParameters = Object.values(
+    props.profile.modify["set-parameters"]
+  );
+
+  // Import resolved controls when loaded. When loading, display a basic skeleton placeholder
+  // resembling the content.
   const profileImports = (
     <List
       className={classes.OSCALControlList}
@@ -91,7 +97,8 @@ export default function OSCALProfile(props) {
             <OSCALControl
               control={control}
               includeControlIds={includeControlIds}
-              modifications={props.profile.modify}
+              modificationAlters={modificationAlters}
+              modificationSetParameters={modificationSetParameters}
               childLevel={0}
               key={`control-${control.id}`}
             />


### PR DESCRIPTION
Due to lengthy rendering, the Profile Viewer takes a long period of time to show elements on the page. In order to improve the user experience, a skeleton framework has been added to display on the page while rendering the resolved controls. To improve performance, a few areas of `OSCALProfile`, `OSCALControl`, & underlying components have been optimized. Most notably, the `modifications` data sent between components have been slimmed down.

- resolves #74