### PR TITLE
Create Storybook Stories for Metadata, Responsible Roles, and System Components

### DIFF
--- a/src/stories/OSCALMetadata.stories.js
+++ b/src/stories/OSCALMetadata.stories.js
@@ -10,6 +10,8 @@ const Template = (args) => <OSCALMetadata {...args} />;
 
 export const Default = Template.bind({});
 
+export const MetadataRoles = Template.bind({});
+
 const exampleMetadata = {
   title: "Test Title",
   "last-modified": "7/12/2021",
@@ -24,6 +26,36 @@ const exampleMetadata = {
   ],
 };
 
+const exampleMetadataRoles = {
+  title: "Test Title",
+  "last-modified": "7/12/2021",
+  version: "Revision 5",
+  "oscal-version": "1.0.0",
+  roles: [
+    {
+      id: "creator",
+      title: "Document creator",
+    },
+  ],
+  parties: [
+    {
+      uuid: "party-1",
+      type: "organization",
+      name: "Some group of people",
+    },
+  ],
+  "responsible-parties": [
+    {
+      "role-id": "creator",
+      "party-uuids": ["party-1"],
+    },
+  ],
+};
+
 Default.args = {
   metadata: exampleMetadata,
+};
+
+MetadataRoles.args = {
+  metadata: exampleMetadataRoles,
 };

--- a/src/stories/OSCALMetadata.stories.js
+++ b/src/stories/OSCALMetadata.stories.js
@@ -10,9 +10,18 @@ const Template = (args) => <OSCALMetadata {...args} />;
 
 export const Default = Template.bind({});
 
+export const MetadataParties = Template.bind({});
+
 export const MetadataRoles = Template.bind({});
 
 const exampleMetadata = {
+  title: "Test Title",
+  "last-modified": "7/12/2021",
+  version: "Revision 5",
+  "oscal-version": "1.0.0",
+};
+
+const exampleMetadataParties = {
   title: "Test Title",
   "last-modified": "7/12/2021",
   version: "Revision 5",
@@ -54,6 +63,10 @@ const exampleMetadataRoles = {
 
 Default.args = {
   metadata: exampleMetadata,
+};
+
+MetadataParties.args = {
+  metadata: exampleMetadataParties,
 };
 
 MetadataRoles.args = {

--- a/src/stories/OSCALMetadata.stories.js
+++ b/src/stories/OSCALMetadata.stories.js
@@ -1,0 +1,29 @@
+import React from "react";
+import OSCALMetadata from "../components/OSCALMetadata";
+
+export default {
+  title: "Components/Metadata",
+  component: OSCALMetadata,
+};
+
+const Template = (args) => <OSCALMetadata {...args} />;
+
+export const Default = Template.bind({});
+
+const exampleMetadata = {
+  title: "Test Title",
+  "last-modified": "7/12/2021",
+  version: "Revision 5",
+  "oscal-version": "1.0.0",
+  parties: [
+    {
+      uuid: "party-1",
+      type: "organization",
+      name: "Some group of people",
+    },
+  ],
+};
+
+Default.args = {
+  metadata: exampleMetadata,
+};

--- a/src/stories/OSCALResponsibleRoles.stories.js
+++ b/src/stories/OSCALResponsibleRoles.stories.js
@@ -1,0 +1,31 @@
+import React from "react";
+import OSCALResponsibleRoles from "../components/OSCALResponsibleRoles";
+
+export default {
+  title: "Components/Responsible Roles",
+  component: OSCALResponsibleRoles,
+};
+
+const Template = (args) => <OSCALResponsibleRoles {...args} />;
+
+export const Default = Template.bind({});
+
+const exampleResponsibleRoles = [
+  {
+    "party-uuids": ["party-1"],
+    "role-id": "provider",
+  },
+];
+
+const exampleParties = [
+  {
+    uuid: "party-1",
+    type: "organization",
+    name: "Some group of people",
+  },
+];
+
+Default.args = {
+  responsibleRoles: exampleResponsibleRoles,
+  parties: exampleParties,
+};

--- a/src/stories/OSCALSystemCharacteristics.stories.js
+++ b/src/stories/OSCALSystemCharacteristics.stories.js
@@ -1,0 +1,18 @@
+import React from "react";
+import OSCALSystemCharacteristics from "../components/OSCALSystemCharacteristics";
+import { systemCharacteristicsTestData } from "../components/OSCALSystemCharacteristics.test";
+
+export default {
+  title: "Components/System Characteristics",
+  component: OSCALSystemCharacteristics,
+};
+
+const Template = (args) => <OSCALSystemCharacteristics {...args} />;
+
+export const Default = Template.bind({});
+
+const exampleSystemCharacteristics = systemCharacteristicsTestData;
+
+Default.args = {
+  systemCharacteristics: exampleSystemCharacteristics,
+};

--- a/src/stories/OSCALSystemImplementation.stories.js
+++ b/src/stories/OSCALSystemImplementation.stories.js
@@ -13,6 +13,8 @@ export const Default = Template.bind({});
 
 export const SystemImplementationLastModified = Template.bind({});
 
+export const SystemImplementationWithoutCompProps = Template.bind({});
+
 const exampleSystemImplementation = {
   remarks: "Example system implementation remarks.",
   users: {
@@ -127,6 +129,55 @@ const exampleSystemImplementationLastModified = {
   ],
 };
 
+const exampleSystemImplementationWithoutCompProps = {
+  remarks: "Example system implementation remarks.",
+  users: {
+    "user-1": {
+      title: "User 1",
+      "role-ids": ["asset-administrator"],
+      annotations: [
+        {
+          name: "type",
+          value: "internal",
+        },
+      ],
+    },
+  },
+  components: {
+    "component-1": {
+      title: "Example Component",
+      description: "An example component.",
+      status: {
+        state: "operational",
+      },
+      type: "software",
+      "responsible-roles": responsibleRolesTestData,
+    },
+  },
+  "inventory-items": [
+    {
+      uuid: "inventory-item-1",
+      description: "An inventory item.",
+      props: [
+        {
+          name: "asset-id",
+          value: "asset-id-inventory-item",
+        },
+      ],
+      "responsible-parties": {
+        "asset-administrator": {
+          "party-uuids": ["party-1"],
+        },
+      },
+      "implemented-components": [
+        {
+          "component-uuid": "component-1",
+        },
+      ],
+    },
+  ],
+};
+
 const exampleParties = [
   {
     uuid: "party-1",
@@ -142,5 +193,10 @@ Default.args = {
 
 SystemImplementationLastModified.args = {
   systemImplementation: exampleSystemImplementationLastModified,
+  parties: exampleParties,
+};
+
+SystemImplementationWithoutCompProps.args = {
+  systemImplementation: exampleSystemImplementationWithoutCompProps,
   parties: exampleParties,
 };

--- a/src/stories/OSCALSystemImplementation.stories.js
+++ b/src/stories/OSCALSystemImplementation.stories.js
@@ -1,0 +1,80 @@
+import React from "react";
+import OSCALSystemImplementation from "../components/OSCALSystemImplementation";
+import { responsibleRolesTestData } from "../components/OSCALResponsibleRoles.test";
+
+export default {
+  title: "Components/System Implementation",
+  component: OSCALSystemImplementation,
+};
+
+const Template = (args) => <OSCALSystemImplementation {...args} />;
+
+export const Default = Template.bind({});
+
+const exampleSystemImplementation = {
+  remarks: "Example system implementation remarks.",
+  users: {
+    "user-1": {
+      title: "User 1",
+      "role-ids": ["asset-administrator"],
+      annotations: [
+        {
+          name: "type",
+          value: "internal",
+        },
+      ],
+    },
+  },
+  components: {
+    "component-1": {
+      title: "Example Component",
+      description: "An example component.",
+      status: {
+        state: "operational",
+      },
+      type: "software",
+      props: [
+        {
+          name: "version",
+          value: "1.1",
+        },
+      ],
+      "responsible-roles": responsibleRolesTestData,
+    },
+  },
+  "inventory-items": [
+    {
+      uuid: "inventory-item-1",
+      description: "An inventory item.",
+      props: [
+        {
+          name: "asset-id",
+          value: "asset-id-inventory-item",
+        },
+      ],
+      "responsible-parties": {
+        "asset-administrator": {
+          "party-uuids": ["party-1"],
+        },
+      },
+      "implemented-components": [
+        {
+          "component-uuid": "component-1",
+        },
+      ],
+    },
+  ],
+};
+
+const exampleParties = [
+  {
+    uuid: "party-1",
+    type: "organization",
+    name: "Some group of people",
+  },
+];
+
+Default.args = {
+  systemImplementation: exampleSystemImplementation,
+  parties: exampleParties,
+};

--- a/src/stories/OSCALSystemImplementation.stories.js
+++ b/src/stories/OSCALSystemImplementation.stories.js
@@ -13,7 +13,7 @@ export const Default = Template.bind({});
 
 export const SystemImplementationLastModified = Template.bind({});
 
-export const SystemImplementationWithoutCompProps = Template.bind({});
+export const SystemImplementationVersion = Template.bind({});
 
 const exampleSystemImplementation = {
   remarks: "Example system implementation remarks.",
@@ -37,10 +37,59 @@ const exampleSystemImplementation = {
         state: "operational",
       },
       type: "software",
+      "responsible-roles": responsibleRolesTestData,
+    },
+  },
+  "inventory-items": [
+    {
+      uuid: "inventory-item-1",
+      description: "An inventory item.",
       props: [
         {
-          name: "version",
-          value: "1.1",
+          name: "asset-id",
+          value: "asset-id-inventory-item",
+        },
+      ],
+      "responsible-parties": {
+        "asset-administrator": {
+          "party-uuids": ["party-1"],
+        },
+      },
+      "implemented-components": [
+        {
+          "component-uuid": "component-1",
+        },
+      ],
+    },
+  ],
+};
+
+const exampleSystemImplementationLastModified = {
+  remarks: "Example system implementation remarks.",
+  users: {
+    "user-1": {
+      title: "User 1",
+      "role-ids": ["asset-administrator"],
+      annotations: [
+        {
+          name: "type",
+          value: "internal",
+        },
+      ],
+    },
+  },
+  components: {
+    "component-1": {
+      title: "Example Component",
+      description: "An example component.",
+      status: {
+        state: "operational",
+      },
+      type: "software",
+      props: [
+        {
+          name: "last-modified-date",
+          value: "20210712",
         },
       ],
       "responsible-roles": responsibleRolesTestData,
@@ -70,7 +119,7 @@ const exampleSystemImplementation = {
   ],
 };
 
-const exampleSystemImplementationLastModified = {
+const exampleSystemImplementationVersion = {
   remarks: "Example system implementation remarks.",
   users: {
     "user-1": {
@@ -129,55 +178,6 @@ const exampleSystemImplementationLastModified = {
   ],
 };
 
-const exampleSystemImplementationWithoutCompProps = {
-  remarks: "Example system implementation remarks.",
-  users: {
-    "user-1": {
-      title: "User 1",
-      "role-ids": ["asset-administrator"],
-      annotations: [
-        {
-          name: "type",
-          value: "internal",
-        },
-      ],
-    },
-  },
-  components: {
-    "component-1": {
-      title: "Example Component",
-      description: "An example component.",
-      status: {
-        state: "operational",
-      },
-      type: "software",
-      "responsible-roles": responsibleRolesTestData,
-    },
-  },
-  "inventory-items": [
-    {
-      uuid: "inventory-item-1",
-      description: "An inventory item.",
-      props: [
-        {
-          name: "asset-id",
-          value: "asset-id-inventory-item",
-        },
-      ],
-      "responsible-parties": {
-        "asset-administrator": {
-          "party-uuids": ["party-1"],
-        },
-      },
-      "implemented-components": [
-        {
-          "component-uuid": "component-1",
-        },
-      ],
-    },
-  ],
-};
-
 const exampleParties = [
   {
     uuid: "party-1",
@@ -196,7 +196,7 @@ SystemImplementationLastModified.args = {
   parties: exampleParties,
 };
 
-SystemImplementationWithoutCompProps.args = {
-  systemImplementation: exampleSystemImplementationWithoutCompProps,
+SystemImplementationVersion.args = {
+  systemImplementation: exampleSystemImplementationVersion,
   parties: exampleParties,
 };

--- a/src/stories/OSCALSystemImplementation.stories.js
+++ b/src/stories/OSCALSystemImplementation.stories.js
@@ -11,6 +11,8 @@ const Template = (args) => <OSCALSystemImplementation {...args} />;
 
 export const Default = Template.bind({});
 
+export const SystemImplementationLastModified = Template.bind({});
+
 const exampleSystemImplementation = {
   remarks: "Example system implementation remarks.",
   users: {
@@ -66,6 +68,65 @@ const exampleSystemImplementation = {
   ],
 };
 
+const exampleSystemImplementationLastModified = {
+  remarks: "Example system implementation remarks.",
+  users: {
+    "user-1": {
+      title: "User 1",
+      "role-ids": ["asset-administrator"],
+      annotations: [
+        {
+          name: "type",
+          value: "internal",
+        },
+      ],
+    },
+  },
+  components: {
+    "component-1": {
+      title: "Example Component",
+      description: "An example component.",
+      status: {
+        state: "operational",
+      },
+      type: "software",
+      props: [
+        {
+          name: "version",
+          value: "1.1",
+        },
+        {
+          name: "last-modified-date",
+          value: "20210712",
+        },
+      ],
+      "responsible-roles": responsibleRolesTestData,
+    },
+  },
+  "inventory-items": [
+    {
+      uuid: "inventory-item-1",
+      description: "An inventory item.",
+      props: [
+        {
+          name: "asset-id",
+          value: "asset-id-inventory-item",
+        },
+      ],
+      "responsible-parties": {
+        "asset-administrator": {
+          "party-uuids": ["party-1"],
+        },
+      },
+      "implemented-components": [
+        {
+          "component-uuid": "component-1",
+        },
+      ],
+    },
+  ],
+};
+
 const exampleParties = [
   {
     uuid: "party-1",
@@ -76,5 +137,10 @@ const exampleParties = [
 
 Default.args = {
   systemImplementation: exampleSystemImplementation,
+  parties: exampleParties,
+};
+
+SystemImplementationLastModified.args = {
+  systemImplementation: exampleSystemImplementationLastModified,
   parties: exampleParties,
 };


### PR DESCRIPTION
Added .stories.js files to the components directory
for each component. Component stories were written 
in a modular approach with the default story containing 
only the required props for the component and 
then in each variation of the component optional props were added. 

To view the Storybook page, run:
`npm install`
`npm run storybook`
in the root directory.