### PR TITLE
Update SSP and Component Definition to Display Profile Modifications

### DIFF
--- a/src/components/OSCALComponentDefinitionControlImplementation.js
+++ b/src/components/OSCALComponentDefinitionControlImplementation.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
@@ -6,6 +6,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { List, ListItem, ListItemText } from "@material-ui/core";
 import OSCALControlImplementationImplReq from "./OSCALControlImplementationImplReq";
+import getProfileModifications from "./oscal-utils/OSCALProfileUtils";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -28,6 +29,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function OSCALComponentDefinitionControlImplementation(props) {
   const classes = useStyles();
+  const [modifications, setModifications] = useState(props.modifications);
 
   return (
     <div className={classes.paper}>
@@ -43,32 +45,46 @@ export default function OSCALComponentDefinitionControlImplementation(props) {
             </Grid>
             <Grid item xs={12}>
               <List>
-                {props.controlImplementations.map((controlImpl) => (
-                  <ListItem key={controlImpl.uuid}>
-                    <ListItemText>
-                      {controlImpl.description}
-                      <Grid item xs={12}>
-                        <List
-                          className={
-                            classes.OSCALControlImplementationImplReqList
-                          }
-                        >
-                          {controlImpl["implemented-requirements"].map(
-                            (implementedRequirement) => (
-                              <OSCALControlImplementationImplReq
-                                implementedRequirement={implementedRequirement}
-                                components={props.components}
-                                controls={props.controls}
-                                childLevel={0}
-                                key={implementedRequirement.uuid}
-                              />
-                            )
-                          )}
-                        </List>
-                      </Grid>
-                    </ListItemText>
-                  </ListItem>
-                ))}
+                {props.controlImplementations.map((controlImpl) => {
+                  // Get modifications from source if it is profile
+                  if (!modifications) {
+                    getProfileModifications(
+                      controlImpl.source,
+                      props.parentUrl,
+                      setModifications
+                    );
+                  }
+
+                  return (
+                    <ListItem key={controlImpl.uuid}>
+                      <ListItemText>
+                        {controlImpl.description}
+                        <Grid item xs={12}>
+                          <List
+                            className={
+                              classes.OSCALControlImplementationImplReqList
+                            }
+                          >
+                            {controlImpl["implemented-requirements"].map(
+                              (implementedRequirement) => (
+                                <OSCALControlImplementationImplReq
+                                  implementedRequirement={
+                                    implementedRequirement
+                                  }
+                                  components={props.components}
+                                  controls={props.controls}
+                                  childLevel={0}
+                                  key={implementedRequirement.uuid}
+                                  modifications={modifications}
+                                />
+                              )
+                            )}
+                          </List>
+                        </Grid>
+                      </ListItemText>
+                    </ListItem>
+                  );
+                })}
               </List>
             </Grid>
           </Grid>

--- a/src/components/OSCALComponentDefinitionControlImplementation.js
+++ b/src/components/OSCALComponentDefinitionControlImplementation.js
@@ -6,7 +6,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { List, ListItem, ListItemText } from "@material-ui/core";
 import OSCALControlImplementationImplReq from "./OSCALControlImplementationImplReq";
-import getProfileModifications from "./oscal-utils/OSCALProfileUtils";
+import fetchProfileModifications from "./oscal-utils/OSCALProfileUtils";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -46,9 +46,10 @@ export default function OSCALComponentDefinitionControlImplementation(props) {
             <Grid item xs={12}>
               <List>
                 {props.controlImplementations.map((controlImpl) => {
-                  // Get modifications from source if it is profile
+                  // Fetch modifications from a source
+                  // Pass a set() function to set modifications
                   if (!modifications) {
-                    getProfileModifications(
+                    fetchProfileModifications(
                       controlImpl.source,
                       props.parentUrl,
                       setModifications

--- a/src/components/OSCALComponentDefinitionControlImplementation.test.js
+++ b/src/components/OSCALComponentDefinitionControlImplementation.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import OSCALComponentDefinitionControlImplementation from "./OSCALComponentDefinitionControlImplementation";
 import getByTextIncludingChildern from "./oscal-utils/TestUtils";
 import { controlsData } from "../test-data/ControlsData";
@@ -7,6 +7,43 @@ import {
   componentDefinitionControlImplementationTestData,
   componentDefinitionTestData,
 } from "../test-data/ComponentsData";
+
+const profileModifyTestData = {
+  "set-parameters": [
+    {
+      "param-id": "control-1_prm_1",
+      constraints: [
+        {
+          description: "at least every 3 years",
+        },
+      ],
+    },
+    {
+      "param-id": "control-1_prm_2",
+      constraints: [
+        {
+          description: "at least annually",
+        },
+      ],
+    },
+  ],
+  alters: [
+    {
+      "control-id": "control-1",
+      adds: [
+        {
+          position: "starting",
+          props: [
+            {
+              name: "priority",
+              value: "P1",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 
 test("OSCALComponentDefinitionControlImplementation displays component implementation description", () => {
   render(
@@ -46,4 +83,46 @@ test("OSCALComponentDefinitionControlImplementation displays component parameter
     "Does something with < control 1 / parameter 1 label > and < control 1 / parameter 2 label >"
   );
   expect(resultByProse).toBeVisible();
+});
+
+test(`OSCALComponentDefinitionControlImplementation does not display control modifications`, async () => {
+  render(
+    <OSCALComponentDefinitionControlImplementation
+      controlImplementations={componentDefinitionControlImplementationTestData}
+      components={componentDefinitionTestData.components}
+      controls={controlsData}
+    />
+  );
+  expect(
+    await screen.findByText("Control Implementations", {
+      timeout: 10000,
+    })
+  ).toBeInTheDocument();
+
+  expect(() =>
+    screen.findByRole("button").toThrow("Unable to find an element")
+  );
+});
+
+test(`OSCALComponentDefinitionControlImplementation displays control modifications`, async () => {
+  render(
+    <OSCALComponentDefinitionControlImplementation
+      controlImplementations={componentDefinitionControlImplementationTestData}
+      components={componentDefinitionTestData.components}
+      controls={controlsData}
+      modifications={profileModifyTestData}
+    />
+  );
+
+  expect(
+    await screen.findByText("Control Implementations", {
+      timeout: 10000,
+    })
+  ).toBeInTheDocument();
+
+  const modButton = await screen.findByRole("button", { timeout: 10000 });
+
+  fireEvent.click(modButton);
+  expect(await screen.findByText("Modifications")).toBeVisible();
+  expect(await screen.findByText("Adds")).toBeVisible();
 });

--- a/src/components/OSCALComponentDefinitionControlImplementation.test.js
+++ b/src/components/OSCALComponentDefinitionControlImplementation.test.js
@@ -7,43 +7,7 @@ import {
   componentDefinitionControlImplementationTestData,
   componentDefinitionTestData,
 } from "../test-data/ComponentsData";
-
-const profileModifyTestData = {
-  "set-parameters": [
-    {
-      "param-id": "control-1_prm_1",
-      constraints: [
-        {
-          description: "at least every 3 years",
-        },
-      ],
-    },
-    {
-      "param-id": "control-1_prm_2",
-      constraints: [
-        {
-          description: "at least annually",
-        },
-      ],
-    },
-  ],
-  alters: [
-    {
-      "control-id": "control-1",
-      adds: [
-        {
-          position: "starting",
-          props: [
-            {
-              name: "priority",
-              value: "P1",
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
+import { profileModifyTestData } from "../test-data/ModificationsData";
 
 test("OSCALComponentDefinitionControlImplementation displays component implementation description", () => {
   render(

--- a/src/components/OSCALControlImplementation.js
+++ b/src/components/OSCALControlImplementation.js
@@ -60,6 +60,7 @@ export default function OSCALControlImplementation(props) {
                       controls={props.controls}
                       childLevel={0}
                       key={implementedRequirement.uuid}
+                      modifications={props.modifications}
                     />
                   )
                 )}

--- a/src/components/OSCALControlImplementationImplReq.js
+++ b/src/components/OSCALControlImplementationImplReq.js
@@ -112,6 +112,12 @@ export default function OSCALControlImplementationImplReq(props) {
     implReqStatements = [];
   }
 
+  // Error check modifications
+  const modAlters = !props.modifications ? null : props.modifications.alters;
+  const modParams = !props.modifications
+    ? null
+    : props.modifications["set-parameters"];
+
   // Setup UI of Control Implemention with verticle tabs and a tab panel to
   // display control implementation, which are both wrapped in a card
   return (
@@ -150,7 +156,8 @@ export default function OSCALControlImplementationImplReq(props) {
                 childLevel={0}
                 implReqStatements={implReqStatements}
                 componentId={component.uuid}
-                modifications={props.modifications}
+                modificationAlters={modAlters}
+                modificationSetParameters={modParams}
               />
             </TabPanel>
           ))}

--- a/src/components/OSCALControlImplementationImplReq.js
+++ b/src/components/OSCALControlImplementationImplReq.js
@@ -111,9 +111,9 @@ export default function OSCALControlImplementationImplReq(props) {
   if (!implReqStatements) {
     implReqStatements = [];
   }
+
   // Setup UI of Control Implemention with verticle tabs and a tab panel to
   // display control implementation, which are both wrapped in a card
-
   return (
     <Card className={`${classes.OSCALImplReq} ${classes.OSCALImplChildLevel}`}>
       <CardContent>
@@ -150,6 +150,7 @@ export default function OSCALControlImplementationImplReq(props) {
                 childLevel={0}
                 implReqStatements={implReqStatements}
                 componentId={component.uuid}
+                modifications={props.modifications}
               />
             </TabPanel>
           ))}

--- a/src/components/OSCALControlImplementationImplReq.js
+++ b/src/components/OSCALControlImplementationImplReq.js
@@ -113,10 +113,8 @@ export default function OSCALControlImplementationImplReq(props) {
   }
 
   // Error check modifications
-  const modAlters = !props.modifications ? null : props.modifications.alters;
-  const modParams = !props.modifications
-    ? null
-    : props.modifications["set-parameters"];
+  const modAlters = props.modifications?.alters || null;
+  const modParams = props.modifications?.["set-parameters"] || null;
 
   // Setup UI of Control Implemention with verticle tabs and a tab panel to
   // display control implementation, which are both wrapped in a card

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import OSCALControlImplementation from "./OSCALControlImplementation";
 import getByTextIncludingChildern from "./oscal-utils/TestUtils";
@@ -8,47 +8,127 @@ import { exampleComponents } from "../test-data/ComponentsData";
 
 const controlsTestData = [exampleControl];
 
-test("OSCALControlImplementationImplReq displays control ID", () => {
+const componentsTestData = [
+  {
+    uuid: "component-1",
+    title: "Component 1 Title",
+  },
+];
+
+const profileModifyTestData = {
+  "set-parameters": [
+    {
+      "param-id": "control-1_prm_1",
+      constraints: [
+        {
+          description: "at least every 3 years",
+        },
+      ],
+    },
+    {
+      "param-id": "control-1_prm_2",
+      constraints: [
+        {
+          description: "at least annually",
+        },
+      ],
+    },
+  ],
+  alters: [
+    {
+      "control-id": "control-1",
+      adds: [
+        {
+          position: "starting",
+          props: [
+            {
+              name: "priority",
+              value: "P1",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function controlImplementationImplReqRenderer() {
   render(
     <OSCALControlImplementation
       controlImplementation={controlImplTestData}
       components={exampleComponents}
       controls={controlsTestData}
+      modifications={profileModifyTestData}
     />
   );
-  const result = screen.getByText("control-1");
-  expect(result).toBeVisible();
-});
+}
 
-test("OSCALControlImplementationImplReq displays component parameters in control prose", () => {
-  render(
-    <OSCALControlImplementation
-      controlImplementation={controlImplTestData}
-      components={exampleComponents}
-      controls={controlsTestData}
-    />
-  );
-  const result = getByTextIncludingChildern(
-    "Does something with control 1 / component 1 / parameter 1 value and control 1 / component 1 / parameter 2 value"
-  );
-  expect(result).toBeVisible();
-});
+export default function testOSCALControlImplementationImplReq(
+  parentElementName,
+  renderer
+) {
+  test(`${parentElementName} displays control ID`, () => {
+    renderer();
+    const result = screen.getByText("control-1");
+    expect(result).toBeVisible();
+  });
 
-test("OSCALControlImplementationImplReq displays component implementation description", async () => {
-  render(
-    <OSCALControlImplementation
-      controlImplementation={controlImplTestData}
-      components={exampleComponents}
-      controls={controlsTestData}
-    />
-  );
+  test(`${parentElementName} displays component parameters in control prose`, () => {
+    renderer();
+    const result = getByTextIncludingChildern(
+      "Does something with control 1 / component 1 / parameter 1 value and control 1 / component 1 / parameter 2 value"
+    );
+    expect(result).toBeVisible();
+  });
 
-  userEvent.hover(
-    screen.getByRole("link", {
-      name: "Component 1 description of implementing control 1",
-    })
-  );
-  expect(
-    await screen.findByText("Component 1 description of implementing control 1")
-  ).toBeInTheDocument();
-});
+  test(`${parentElementName} displays component implementation description`, async () => {
+    renderer();
+
+    userEvent.hover(
+      screen.getByRole("link", {
+        name: "Component 1 description of implementing control 1",
+      })
+    );
+    expect(
+      await screen.findByText(
+        "Component 1 description of implementing control 1"
+      )
+    ).toBeInTheDocument();
+  });
+
+  test(`${parentElementName} displays component modifications`, async () => {
+    renderer();
+
+    const modButton = await screen.findByRole(
+      "button",
+      { name: "control-1 modifications" },
+      { timeout: 10000 }
+    );
+    fireEvent.click(modButton);
+    expect(await screen.findByText("Modifications")).toBeVisible();
+    expect(await screen.findByText("Adds")).toBeVisible();
+  });
+
+  test(`${parentElementName} does not display control modifications`, async () => {
+    render(
+      <OSCALControlImplementation
+        controlImplementation={controlImplTestData}
+        components={componentsTestData}
+        controls={controlsTestData}
+      />
+    );
+    expect(
+      await screen.findByText("Control Implementation", {
+        timeout: 10000,
+      })
+    ).toBeInTheDocument();
+    expect(() =>
+      screen.findByRole("button").toThrow("Unable to find an element")
+    );
+  });
+}
+
+testOSCALControlImplementationImplReq(
+  "OSCALControlImplementationImplReq",
+  controlImplementationImplReqRenderer
+);

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -5,6 +5,7 @@ import OSCALControlImplementation from "./OSCALControlImplementation";
 import getByTextIncludingChildern from "./oscal-utils/TestUtils";
 import { controlImplTestData, exampleControl } from "../test-data/ControlsData";
 import { exampleComponents } from "../test-data/ComponentsData";
+import { profileModifyTestData } from "../test-data/ModificationsData";
 
 const controlsTestData = [exampleControl];
 
@@ -14,43 +15,6 @@ const componentsTestData = [
     title: "Component 1 Title",
   },
 ];
-
-const profileModifyTestData = {
-  "set-parameters": [
-    {
-      "param-id": "control-1_prm_1",
-      constraints: [
-        {
-          description: "at least every 3 years",
-        },
-      ],
-    },
-    {
-      "param-id": "control-1_prm_2",
-      constraints: [
-        {
-          description: "at least annually",
-        },
-      ],
-    },
-  ],
-  alters: [
-    {
-      "control-id": "control-1",
-      adds: [
-        {
-          position: "starting",
-          props: [
-            {
-              name: "priority",
-              value: "P1",
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
 
 const emptyProfileModifyTestData = {};
 

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -4,17 +4,13 @@ import userEvent from "@testing-library/user-event";
 import OSCALControlImplementation from "./OSCALControlImplementation";
 import getByTextIncludingChildern from "./oscal-utils/TestUtils";
 import { controlImplTestData, exampleControl } from "../test-data/ControlsData";
-import { exampleComponents } from "../test-data/ComponentsData";
+import {
+  exampleComponents,
+  componentsTestData,
+} from "../test-data/ComponentsData";
 import { profileModifyTestData } from "../test-data/ModificationsData";
 
 const controlsTestData = [exampleControl];
-
-const componentsTestData = [
-  {
-    uuid: "component-1",
-    title: "Component 1 Title",
-  },
-];
 
 const emptyProfileModifyTestData = {};
 

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -52,6 +52,8 @@ const profileModifyTestData = {
   ],
 };
 
+const emptyProfileModifyTestData = {};
+
 function controlImplementationImplReqRenderer() {
   render(
     <OSCALControlImplementation
@@ -115,6 +117,7 @@ export default function testOSCALControlImplementationImplReq(
         controlImplementation={controlImplTestData}
         components={componentsTestData}
         controls={controlsTestData}
+        modifications={emptyProfileModifyTestData}
       />
     );
     expect(

--- a/src/components/OSCALSsp.js
+++ b/src/components/OSCALSsp.js
@@ -6,7 +6,7 @@ import OSCALSystemImplementation from "./OSCALSystemImplementation";
 import OSCALControlImplementation from "./OSCALControlImplementation";
 import OSCALSspResolveProfile from "./oscal-utils/OSCALSspResolver";
 import OSCALBackMatter from "./OSCALBackMatter";
-import getProfileModifications from "./oscal-utils/OSCALProfileUtils";
+import fetchProfileModifications from "./oscal-utils/OSCALProfileUtils";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -57,9 +57,10 @@ export default function OSCALSsp(props) {
   if (!isLoaded) {
     controlImpl = null;
   } else {
-    // Get modifications from imported profile
+    // Fetch modifications from imported profile
+    // Pass a set() function to set modifications
     if (!modifications) {
-      getProfileModifications(
+      fetchProfileModifications(
         ssp["import-profile"].href,
         props.parentUrl,
         setModifications

--- a/src/components/OSCALSsp.js
+++ b/src/components/OSCALSsp.js
@@ -6,6 +6,7 @@ import OSCALSystemImplementation from "./OSCALSystemImplementation";
 import OSCALControlImplementation from "./OSCALControlImplementation";
 import OSCALSspResolveProfile from "./oscal-utils/OSCALSspResolver";
 import OSCALBackMatter from "./OSCALBackMatter";
+import getProfileModifications from "./oscal-utils/OSCALProfileUtils";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -18,6 +19,7 @@ const useStyles = makeStyles((theme) => ({
 export default function OSCALSsp(props) {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
+  const [modifications, setModifications] = useState(props.modifications);
   const classes = useStyles();
 
   const ssp = props["system-security-plan"];
@@ -46,11 +48,20 @@ export default function OSCALSsp(props) {
   if (!isLoaded) {
     controlImpl = null;
   } else {
+    // Get modifications from imported profile
+    if (!modifications) {
+      getProfileModifications(
+        ssp["import-profile"].href,
+        props.parentUrl,
+        setModifications
+      );
+    }
     controlImpl = (
       <OSCALControlImplementation
         controlImplementation={ssp["control-implementation"]}
         components={ssp["system-implementation"].components}
         controls={ssp.resolvedControls}
+        modifications={modifications}
       />
     );
   }

--- a/src/components/OSCALSsp.js
+++ b/src/components/OSCALSsp.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import OSCALMetadata from "./OSCALMetadata";
 import OSCALSystemCharacteristics from "./OSCALSystemCharacteristics";
@@ -21,6 +21,7 @@ export default function OSCALSsp(props) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [modifications, setModifications] = useState(props.modifications);
   const classes = useStyles();
+  const unmounted = useRef(false);
 
   const ssp = props["system-security-plan"];
 
@@ -34,13 +35,21 @@ export default function OSCALSsp(props) {
       ssp,
       props.parentUrl,
       () => {
-        setIsLoaded(true);
+        if (!unmounted.current) {
+          setIsLoaded(true);
+        }
       },
       () => {
-        setError(error);
-        setIsLoaded(true);
+        if (!unmounted.current) {
+          setError(error);
+          setIsLoaded(true);
+        }
       }
     );
+
+    return () => {
+      unmounted.current = true;
+    };
   }, []);
 
   let controlImpl;

--- a/src/components/oscal-utils/OSCALProfileUtils.js
+++ b/src/components/oscal-utils/OSCALProfileUtils.js
@@ -1,0 +1,34 @@
+/**
+ * Fixes source url if it does not properly link to a profile.
+ *
+ * @param {string} sourceURL url to fetch profile from
+ * @param {string} parentUrl parent url to fix sourceUrl
+ * @returns the correct source url
+ */
+export function fixProfileUrl(sourceUrl, parentUrl) {
+  if (!sourceUrl?.startsWith("http")) {
+    return `${parentUrl}/../${sourceUrl}`;
+  }
+  return sourceUrl;
+}
+
+/**
+ * Gets the modifications from a profile at a given sourceURL.
+ *
+ * @param {string} sourceURL url to fetch profile from
+ * @param {string} parentUrl parent url to fix sourceUrl
+ * @param {function} setModifications set method for modifications
+ */
+export default function getProfileModifications(
+  sourceUrl,
+  parentUrl,
+  setModifications
+) {
+  const getProfile = (profileUrl) =>
+    fetch(profileUrl)
+      .then((res) => res.json())
+      .then((result) => setModifications(result.profile.modify));
+
+  const profileUrl = fixProfileUrl(sourceUrl, parentUrl);
+  getProfile(profileUrl);
+}

--- a/src/components/oscal-utils/OSCALProfileUtils.js
+++ b/src/components/oscal-utils/OSCALProfileUtils.js
@@ -29,7 +29,7 @@ export default async function fetchProfileModifications(
   fetch(profileUrl)
     .then((res) => res.json())
     .then(
-      (result) => setModifications(result.profile.modify),
+      (result) => setModifications(result?.profile?.modify),
       () => null
     );
 }

--- a/src/components/oscal-utils/OSCALProfileUtils.js
+++ b/src/components/oscal-utils/OSCALProfileUtils.js
@@ -13,25 +13,23 @@ export function fixProfileUrl(sourceUrl, parentUrl) {
 }
 
 /**
- * Gets the modifications from a profile at a given sourceURL.
+ * Fetches & sets the modifications from a profile at a given sourceURL.
  *
  * @param {string} sourceURL url to fetch profile from
  * @param {string} parentUrl parent url to fix sourceUrl
  * @param {function} setModifications set method for modifications
  */
-export default function getProfileModifications(
+export default async function fetchProfileModifications(
   sourceUrl,
   parentUrl,
   setModifications
 ) {
-  const getProfile = (profileUrl) =>
-    fetch(profileUrl)
-      .then((res) => res.json())
-      .then(
-        (result) => setModifications(result.profile.modify),
-        () => null
-      );
-
   const profileUrl = fixProfileUrl(sourceUrl, parentUrl);
-  getProfile(profileUrl);
+
+  fetch(profileUrl)
+    .then((res) => res.json())
+    .then(
+      (result) => setModifications(result.profile.modify),
+      () => null
+    );
 }

--- a/src/components/oscal-utils/OSCALProfileUtils.js
+++ b/src/components/oscal-utils/OSCALProfileUtils.js
@@ -27,7 +27,10 @@ export default function getProfileModifications(
   const getProfile = (profileUrl) =>
     fetch(profileUrl)
       .then((res) => res.json())
-      .then((result) => setModifications(result.profile.modify));
+      .then(
+        (result) => setModifications(result.profile.modify),
+        () => null
+      );
 
   const profileUrl = fixProfileUrl(sourceUrl, parentUrl);
   getProfile(profileUrl);

--- a/src/test-data/ComponentsData.js
+++ b/src/test-data/ComponentsData.js
@@ -103,6 +103,13 @@ export const exampleComponentStories = [
   },
 ];
 
+export const componentsTestData = [
+  {
+    uuid: "component-1",
+    title: "Component 1 Title",
+  },
+];
+
 export const exampleComponentDefinitionComponent = {
   uuid: "b036a6ac-6cff-4066-92bc-74ddfd9ad6fa",
   type: "software",

--- a/src/test-data/ModificationsData.js
+++ b/src/test-data/ModificationsData.js
@@ -51,38 +51,6 @@ export const exampleModificationAltersTopLevel = [
 ];
 
 export const profileModifyTestData = {
-  "set-parameters": [
-    {
-      "param-id": "control-1_prm_1",
-      constraints: [
-        {
-          description: "at least every 3 years",
-        },
-      ],
-    },
-    {
-      "param-id": "control-1_prm_2",
-      constraints: [
-        {
-          description: "at least annually",
-        },
-      ],
-    },
-  ],
-  alters: [
-    {
-      "control-id": "control-1",
-      adds: [
-        {
-          position: "starting",
-          props: [
-            {
-              name: "priority",
-              value: "P1",
-            },
-          ],
-        },
-      ],
-    },
-  ],
+  "set-parameters": exampleModificationSetParameters,
+  alters: exampleModificationAltersTopLevel,
 };

--- a/src/test-data/ModificationsData.js
+++ b/src/test-data/ModificationsData.js
@@ -49,3 +49,40 @@ export const exampleModificationAltersTopLevel = [
     ],
   },
 ];
+
+export const profileModifyTestData = {
+  "set-parameters": [
+    {
+      "param-id": "control-1_prm_1",
+      constraints: [
+        {
+          description: "at least every 3 years",
+        },
+      ],
+    },
+    {
+      "param-id": "control-1_prm_2",
+      constraints: [
+        {
+          description: "at least annually",
+        },
+      ],
+    },
+  ],
+  alters: [
+    {
+      "control-id": "control-1",
+      adds: [
+        {
+          position: "starting",
+          props: [
+            {
+              name: "priority",
+              value: "P1",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
This adds the ability to view modifications on `SSP` & `Component` viewers. `OSCALProfileUtils` is used to fetch the `modify` attribute of a given `Profile`. This also implements some of changes to displaying modifications from #114, but with the `SSP` & `Component`. Tests were also added to check that the modifications only appear when they should. 

This will close #75 