### PR TITLE
WIP: Alternate approach to EGRC-463 / #128 / #144

### DIFF
--- a/src/components/OSCALCatalog.js
+++ b/src/components/OSCALCatalog.js
@@ -16,6 +16,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function OSCALCatalog(props) {
   const classes = useStyles();
+  props.onResolutionComplete();
 
   return (
     <div className={classes.paper}>

--- a/src/components/OSCALComponentDefinition.js
+++ b/src/components/OSCALComponentDefinition.js
@@ -25,10 +25,12 @@ export default function OSCALComponentDefinition(props) {
       props.parentUrl,
       () => {
         setIsLoaded(true);
+        props.onResolutionComplete();
       },
       (errorReturned) => {
         setError(errorReturned);
         setIsLoaded(true);
+        props.onResolutionComplete();
       }
     );
   }, []);

--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -29,6 +29,7 @@ const defaultOscalSspUrl =
 export default function OSCALLoader(props) {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
+  const [isResolutionComplete, setIsResolutionComplete] = useState(true);
   const [oscalData, setOscalData] = useState([]);
   const [oscalUrl, setOscalUrl] = useState(props.oscalUrl);
   const unmounted = useRef(false);
@@ -59,8 +60,16 @@ export default function OSCALLoader(props) {
   };
 
   const handleReloadClick = () => {
-    setIsLoaded(false);
-    loadOscalData(oscalUrl);
+    // Only reload if we're done loading
+    if (isLoaded && isResolutionComplete) {;
+      setIsLoaded(false);
+      setIsResolutionComplete(false);
+      loadOscalData(oscalUrl);
+    }
+  };
+
+  const onResolutionComplete = () => {
+    setIsResolutionComplete(true);
   };
 
   // Note: the empty deps array [] means
@@ -82,6 +91,7 @@ export default function OSCALLoader(props) {
         oscalUrl={oscalUrl}
         onUrlChange={handleChange}
         onReloadClick={handleReloadClick}
+        isResolutionComplete={isResolutionComplete}
       />
     );
   }
@@ -92,7 +102,7 @@ export default function OSCALLoader(props) {
   } else if (!isLoaded) {
     result = <CircularProgress />;
   } else {
-    result = props.renderer(oscalData, oscalUrl);
+    result = props.renderer(oscalData, oscalUrl, onResolutionComplete);
   }
 
   return (
@@ -114,11 +124,12 @@ export function getRequestedUrl() {
 }
 
 export function OSCALCatalogLoader(props) {
-  const renderer = (oscalData, oscalUrl) => (
+  const renderer = (oscalData, oscalUrl, onResolutionComplete) => (
     <OSCALCatalog
       catalog={oscalData.catalog}
       parentUrl={oscalUrl}
       onError={onError}
+      onResolutionComplete={onResolutionComplete}
     />
   );
   return (
@@ -132,11 +143,12 @@ export function OSCALCatalogLoader(props) {
 }
 
 export function OSCALSSPLoader(props) {
-  const renderer = (oscalData, oscalUrl) => (
+  const renderer = (oscalData, oscalUrl, onResolutionComplete) => (
     <OSCALSsp
       system-security-plan={oscalData["system-security-plan"]}
       parentUrl={oscalUrl}
       onError={onError}
+      onResolutionComplete={onResolutionComplete}
     />
   );
   return (
@@ -150,11 +162,12 @@ export function OSCALSSPLoader(props) {
 }
 
 export function OSCALComponentLoader(props) {
-  const renderer = (oscalData, oscalUrl) => (
+  const renderer = (oscalData, oscalUrl, onResolutionComplete) => (
     <OSCALComponentDefinition
       componentDefinition={oscalData["component-definition"]}
       parentUrl={oscalUrl}
       onError={onError}
+      onResolutionComplete={onResolutionComplete}
     />
   );
   return (
@@ -167,8 +180,12 @@ export function OSCALComponentLoader(props) {
   );
 }
 export function OSCALProfileLoader(props) {
-  const renderer = (oscalData, oscalUrl) => (
-    <OSCALProfile profile={oscalData.profile} parentUrl={oscalUrl} />
+  const renderer = (oscalData, oscalUrl, onResolutionComplete) => (
+    <OSCALProfile
+      profile={oscalData.profile}
+      parentUrl={oscalUrl}
+      onResolutionComplete={onResolutionComplete}
+    />
   );
   return (
     <OSCALLoader

--- a/src/components/OSCALLoaderForm.js
+++ b/src/components/OSCALLoaderForm.js
@@ -43,6 +43,7 @@ export default function OSCALLoaderForm(props) {
               color="primary"
               endIcon={<ReplayIcon>send</ReplayIcon>}
               onClick={props.onReloadClick}
+              disabled={!props.isResolutionComplete}
             >
               Reload
             </Button>

--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -62,12 +62,14 @@ export default function OSCALProfile(props) {
       () => {
         if (!unmounted.current) {
           setIsLoaded(true);
+          props.onResolutionComplete();
         }
       },
       () => {
         if (!unmounted.current) {
           setError(error);
           setIsLoaded(true);
+          props.onResolutionComplete();
         }
       }
     );

--- a/src/components/OSCALSsp.js
+++ b/src/components/OSCALSsp.js
@@ -37,12 +37,14 @@ export default function OSCALSsp(props) {
       () => {
         if (!unmounted.current) {
           setIsLoaded(true);
+          props.onResolutionComplete();
         }
       },
       () => {
         if (!unmounted.current) {
           setError(error);
           setIsLoaded(true);
+          props.onResolutionComplete();
         }
       }
     );


### PR DESCRIPTION
A slightly different approach to #128 / #144 that lets `OSCALLoader` handle state changes, passes that on to the `OSCALLoaderForm`, and passes an `onResolutionComplete` function to the OSCAL objects which are responsible for calling it when their resolution is done.