### PR TITLE
Modify Profile Test to Fix Intermittent Failures

### DIFF
--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -28,12 +28,13 @@ function profileRenderer() {
 }
 
 function testOSCALProfile(parentElementName, renderer) {
+  jest.setTimeout(6000);
   test(`${parentElementName} displays controls`, async () => {
     act(() => {
       renderer();
     });
     const result = await waitFor(() => screen.getByText("ac-1"), {
-      timeout: 10000,
+      timeout: 5000,
     });
     expect(result).toBeVisible();
   });
@@ -43,7 +44,7 @@ function testOSCALProfile(parentElementName, renderer) {
     const modButton = await screen.findByRole(
       "button",
       { name: "ac-1 modifications" },
-      { timeout: 10000 }
+      { timeout: 5000 }
     );
     fireEvent.click(modButton);
     expect(await screen.findByText("Modifications")).toBeVisible();
@@ -54,7 +55,7 @@ function testOSCALProfile(parentElementName, renderer) {
     renderer();
     const result = await screen.findAllByText(
       "< organization-defined frequency >",
-      { timeout: 10000 }
+      { timeout: 5000 }
     );
     fireEvent.mouseOver(result[0]);
     expect(await screen.findByText("at least every 3 years")).toBeVisible();

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import { OSCALProfileLoader } from "./OSCALLoader";
 import OSCALProfile from "./OSCALProfile";
 import testOSCALMetadata from "./OSCALMetadata.test";
@@ -26,7 +26,7 @@ function testOSCALProfile(parentElementName, renderer) {
     act(() => {
       renderer();
     });
-    const result = await screen.findByText("ac-1", { timeout: 10000 });
+    const result = await waitFor(() => screen.getByText("ac-1"), {timeout: 10000});
     expect(result).toBeVisible();
   });
 

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -1,5 +1,11 @@
 import React from "react";
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
 import { OSCALProfileLoader } from "./OSCALLoader";
 import OSCALProfile from "./OSCALProfile";
 import testOSCALMetadata from "./OSCALMetadata.test";
@@ -26,7 +32,9 @@ function testOSCALProfile(parentElementName, renderer) {
     act(() => {
       renderer();
     });
-    const result = await waitFor(() => screen.getByText("ac-1"), {timeout: 10000});
+    const result = await waitFor(() => screen.getByText("ac-1"), {
+      timeout: 10000,
+    });
     expect(result).toBeVisible();
   });
 

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -41,9 +41,8 @@ function testOSCALProfile(parentElementName, renderer) {
 
   test(`${parentElementName} displays control modifications`, async () => {
     renderer();
-    const modButton = await screen.findByRole(
-      "button",
-      { name: "ac-1 modifications" },
+    const modButton = await waitFor(
+      () => screen.getByRole("button", { name: "ac-1 modifications" }),
       { timeout: 5000 }
     );
     fireEvent.click(modButton);
@@ -53,8 +52,8 @@ function testOSCALProfile(parentElementName, renderer) {
 
   test(`${parentElementName} displays parameter constraints`, async () => {
     renderer();
-    const result = await screen.findAllByText(
-      "< organization-defined frequency >",
+    const result = await waitFor(
+      () => screen.getAllByText("< organization-defined frequency >"),
       { timeout: 5000 }
     );
     fireEvent.mouseOver(result[0]);

--- a/src/test-data/ComponentsData.js
+++ b/src/test-data/ComponentsData.js
@@ -63,6 +63,7 @@ export const componentDefinitionTestData = {
   metadata: metadataTestData,
   components: {
     "component-1": {
+      uuid: "component-1",
       type: "Example Type",
       title: "Example Component",
       description: "An example component.",


### PR DESCRIPTION
Changed the profile test to use waitFor() instead of an await
on findByText().
Occasionally, certain conditions caused findByText() to throw an error,
likely due to the long load times for the imported controls in the
profile viewer. The errors caused the tests to fail even though the
code should pass.
This change should resolve these errors as waitFor() retries getByText()
until it does not throw an error, more resiliently handling the
conditions that caused findByText() to throw errors.