### PR TITLE
Pass Control Id into Control Part to Render Modifications

### DIFF
--- a/src/components/OSCALControl.js
+++ b/src/components/OSCALControl.js
@@ -83,6 +83,7 @@ export default function OSCALControl(props) {
             <OSCALControlPart
               part={part}
               control={props.control}
+              controlId={props.control.id}
               parameters={props.control.params}
               implReqStatements={props.implReqStatements}
               componentId={props.componentId}

--- a/src/components/OSCALControl.test.js
+++ b/src/components/OSCALControl.test.js
@@ -2,9 +2,23 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import OSCALControl from "./OSCALControl";
 import OSCALControlImplementation from "./OSCALControlImplementation";
+import OSCALProfile from "./OSCALProfile";
 import { controlImplTestData, exampleControl } from "../test-data/ControlsData";
 import { exampleComponents } from "../test-data/ComponentsData";
 import { profileModifySmtTestData } from "../test-data/ModificationsData";
+import profileTestData from "../test-data/ProfileData";
+import { parentUrlTestData } from "../test-data/Urls";
+
+async function testIfModificationsDisplayed(modificationName) {
+  const modButton = await screen.findByRole(
+    "button",
+    { name: modificationName },
+    { timeout: 10000 }
+  );
+  fireEvent.click(modButton);
+  expect(await screen.findByText("Modifications")).toBeVisible();
+  expect(await screen.findByText("Adds")).toBeVisible();
+}
 
 test("OSCALCatalog displays controls", () => {
   const testControl = { id: "ac-1" };
@@ -22,13 +36,16 @@ test("OSCALControl displays statement modifications", async () => {
       modifications={profileModifySmtTestData}
     />
   );
+  await testIfModificationsDisplayed("control-1_smt modifications");
+});
 
-  const modButton = await screen.findByRole(
-    "button",
-    { name: "control-1_smt modifications" },
-    { timeout: 10000 }
+test("OSCALControl displays profile control modifications", async () => {
+  render(
+    <OSCALProfile
+      profile={profileTestData}
+      parentUrl={parentUrlTestData}
+      onResolutionComplete={() => {}}
+    />
   );
-  fireEvent.click(modButton);
-  expect(await screen.findByText("Modifications")).toBeVisible();
-  expect(await screen.findByText("Adds")).toBeVisible();
+  await testIfModificationsDisplayed("ac-1 modifications");
 });

--- a/src/components/OSCALControl.test.js
+++ b/src/components/OSCALControl.test.js
@@ -13,7 +13,7 @@ test("OSCALCatalog displays controls", () => {
   expect(result).toBeVisible();
 });
 
-test("OSCALControl displays _smt modifications", async () => {
+test("OSCALControl displays statement modifications", async () => {
   render(
     <OSCALControlImplementation
       controlImplementation={controlImplTestData}

--- a/src/components/OSCALControl.test.js
+++ b/src/components/OSCALControl.test.js
@@ -1,10 +1,34 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import OSCALControl from "./OSCALControl";
+import OSCALControlImplementation from "./OSCALControlImplementation";
+import { controlImplTestData, exampleControl } from "../test-data/ControlsData";
+import { exampleComponents } from "../test-data/ComponentsData";
+import { profileModifySmtTestData } from "../test-data/ModificationsData";
 
 test("OSCALCatalog displays controls", () => {
   const testControl = { id: "ac-1" };
   render(<OSCALControl control={testControl} />);
   const result = screen.getByText("ac-1");
   expect(result).toBeVisible();
+});
+
+test("OSCALControl displays _smt modifications", async () => {
+  render(
+    <OSCALControlImplementation
+      controlImplementation={controlImplTestData}
+      components={exampleComponents}
+      controls={[exampleControl]}
+      modifications={profileModifySmtTestData}
+    />
+  );
+
+  const modButton = await screen.findByRole(
+    "button",
+    { name: "control-1_smt modifications" },
+    { timeout: 10000 }
+  );
+  fireEvent.click(modButton);
+  expect(await screen.findByText("Modifications")).toBeVisible();
+  expect(await screen.findByText("Adds")).toBeVisible();
 });

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import OSCALControlImplementation from "./OSCALControlImplementation";
 import getByTextIncludingChildern from "./oscal-utils/TestUtils";

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -58,12 +58,12 @@ export default function testOSCALControlImplementationImplReq(
     ).toBeInTheDocument();
   });
 
-  test(`${parentElementName} displays top level modifications`, async () => {
+  test(`${parentElementName} displays modifications`, async () => {
     renderer();
 
     const modButton = await screen.findByRole(
       "button",
-      { name: "control-1_smt modifications" },
+      { name: "control-1 modifications" },
       { timeout: 10000 }
     );
     fireEvent.click(modButton);

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -58,19 +58,6 @@ export default function testOSCALControlImplementationImplReq(
     ).toBeInTheDocument();
   });
 
-  test(`${parentElementName} displays modifications`, async () => {
-    renderer();
-
-    const modButton = await screen.findByRole(
-      "button",
-      { name: "control-1 modifications" },
-      { timeout: 10000 }
-    );
-    fireEvent.click(modButton);
-    expect(await screen.findByText("Modifications")).toBeVisible();
-    expect(await screen.findByText("Adds")).toBeVisible();
-  });
-
   test(`${parentElementName} does not display control modifications`, async () => {
     render(
       <OSCALControlImplementation

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -58,12 +58,12 @@ export default function testOSCALControlImplementationImplReq(
     ).toBeInTheDocument();
   });
 
-  test(`${parentElementName} displays modifications`, async () => {
+  test(`${parentElementName} displays top level modifications`, async () => {
     renderer();
 
     const modButton = await screen.findByRole(
       "button",
-      { name: "control-1 modifications" },
+      { name: "control-1_smt modifications" },
       { timeout: 10000 }
     );
     fireEvent.click(modButton);

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -30,18 +30,6 @@ function testOSCALProfile(parentElementName, renderer) {
     expect(result).toBeVisible();
   });
 
-  test(`${parentElementName} displays control modifications`, async () => {
-    renderer();
-    const modButton = await screen.findByRole(
-      "button",
-      { name: "ac-1 modifications" },
-      { timeout: 10000 }
-    );
-    fireEvent.click(modButton);
-    expect(await screen.findByText("Modifications")).toBeVisible();
-    expect(await screen.findByText("Adds")).toBeVisible();
-  });
-
   test(`${parentElementName} displays parameter constraints`, async () => {
     renderer();
     const result = await screen.findAllByText(

--- a/src/test-data/ModificationsData.js
+++ b/src/test-data/ModificationsData.js
@@ -42,6 +42,19 @@ export const exampleModificationAltersTopLevel = [
     "control-id": "control-1",
     adds: [
       {
+        "by-id": "control-1",
+        position: "starting",
+        props,
+      },
+    ],
+  },
+];
+
+const exampleModificationAltersSmt = [
+  {
+    "control-id": "control-1",
+    adds: [
+      {
         "by-id": "control-1_smt",
         position: "starting",
         props,
@@ -53,4 +66,9 @@ export const exampleModificationAltersTopLevel = [
 export const profileModifyTestData = {
   "set-parameters": exampleModificationSetParameters,
   alters: exampleModificationAltersTopLevel,
+};
+
+export const profileModifySmtTestData = {
+  "set-parameters": exampleModificationSetParameters,
+  alters: exampleModificationAltersSmt,
 };

--- a/src/test-data/ModificationsData.js
+++ b/src/test-data/ModificationsData.js
@@ -42,7 +42,7 @@ export const exampleModificationAltersTopLevel = [
     "control-id": "control-1",
     adds: [
       {
-        "by-id": "control-1",
+        "by-id": "control-1_smt",
         position: "starting",
         props,
       },


### PR DESCRIPTION
Modified the OSCALControl file to add a missing `controlId` prop to ControlPart. This was causing some control modifications to not be displayed and we want all control modifications to be visible to the viewer.

Additionally, test data and the test were modified to test these changes. Previously, the test for displaying control modifications in the `OSCALControlImplementationImplReq.test` test file was not testing anything different than the test for displaying control modifications in the `OSCALProfile.test` test file. There was that redundancy despite `OSCALControlImplementationImplReq.test` using `profileModifyTestData`, created for the purpose of testing whether top-level control modifications would be displayed. That test data, and subsequently the test file, were modified to test if a modifications for a control implementation ending in `_smt` were properly displayed. The distinction of `_smt` is important, as it is a top-level control modification and its appearance in a control's modifications, coupled with the missing `controlId` prop, caused the control modification to not be displayed.