### PR TITLE
Check for Media Type in Profile Resolver

### DIFF
--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -120,7 +120,7 @@ export default function OSCALBackMatter(props) {
               {resource.rlinks &&
                 resource.rlinks.map((rlink) => (
                   <Chip
-                    key={resource.uuid}
+                    key={rlink.href}
                     label={getMediaType(rlink)}
                     component="a"
                     href={getAbsoluteUrl(rlink, props.parentUrl)}

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -12,7 +12,6 @@ import testOSCALMetadata from "./OSCALMetadata.test";
 import testOSCALBackMatter from "./OSCALBackMatter.test";
 import { parentUrlTestData } from "../test-data/Urls";
 import profileTestData from "../test-data/ProfileData";
-import getUriFromBackMatterByHref from "./oscal-utils/OSCALBackMatterUtils";
 
 test("OSCALProfile loads", () => {
   render(<OSCALProfileLoader />);
@@ -61,21 +60,6 @@ function testOSCALProfile(parentElementName, renderer) {
     expect(await screen.findByText("at least every 3 years")).toBeVisible();
   });
 }
-
-function testProfileResolver() {
-  test("Profile imports all contain a valid catalog", () =>
-    profileTestData.imports.forEach((imp) =>
-      expect(
-        typeof getUriFromBackMatterByHref(
-          profileTestData["back-matter"],
-          imp.href,
-          parentUrlTestData
-        )
-      ).toBe("string")
-    ));
-}
-
-testProfileResolver();
 
 testOSCALMetadata("OSCALProfile", profileRenderer);
 

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -12,6 +12,7 @@ import testOSCALMetadata from "./OSCALMetadata.test";
 import testOSCALBackMatter from "./OSCALBackMatter.test";
 import { parentUrlTestData } from "../test-data/Urls";
 import profileTestData from "../test-data/ProfileData";
+import getUriFromBackMatterByHref from "./oscal-utils/OSCALBackMatterUtils";
 
 test("OSCALProfile loads", () => {
   render(<OSCALProfileLoader />);
@@ -60,6 +61,21 @@ function testOSCALProfile(parentElementName, renderer) {
     expect(await screen.findByText("at least every 3 years")).toBeVisible();
   });
 }
+
+function testProfileResolver() {
+  test("Profile imports all contain a valid catalog", () =>
+    profileTestData.imports.forEach((imp) =>
+      expect(
+        typeof getUriFromBackMatterByHref(
+          profileTestData["back-matter"],
+          imp.href,
+          parentUrlTestData
+        )
+      ).toBe("string")
+    ));
+}
+
+testProfileResolver();
 
 testOSCALMetadata("OSCALProfile", profileRenderer);
 

--- a/src/components/oscal-utils/OSCALBackMatterUtils.js
+++ b/src/components/oscal-utils/OSCALBackMatterUtils.js
@@ -36,12 +36,15 @@ export default function getUriFromBackMatterByHref(
   // Dig into back-matter to look for absolute href
   const importUuid = href.substring(1);
 
-  const foundResource = backMatter.resources.find(
-    (resource) => resource.uuid === importUuid
-  );
+  const foundLink = backMatter.resources
+    .find((resource) => resource.uuid === importUuid)
+    ?.rlinks.find(
+      (rlink) => rlink["media-type"] === "application/oscal.catalog+json"
+    );
 
-  if (!foundResource) {
+  if (!foundLink) {
     throw new Error("resource not found for href");
   }
-  return fixJsonUrls(getAbsoluteUrl(foundResource.rlinks[0], parentUrl));
+
+  return fixJsonUrls(getAbsoluteUrl(foundLink, parentUrl));
 }

--- a/src/test-data/BackMatterData.js
+++ b/src/test-data/BackMatterData.js
@@ -21,6 +21,10 @@ export const backMatterTestData = {
           href: revFourCatalog,
           "media-type": "application/oscal.catalog+json",
         },
+        {
+          href,
+          "media-type": "application/something.else",
+        },
       ],
     },
     {


### PR DESCRIPTION
Modify the profile resolver to check for the `media-type` value
when grabbing a resource from back matter. This is a fix for
an issue where the first rlink in each resource was found even if there
were multiple links. This potentially could have lead to the wrong link
being grabbed and thus failing to load the resource.