### PR TITLE
Update GitHub Actions for publishing to GitHub npm registry

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -2,7 +2,8 @@ name: Publish to GitHub Packages
 on:
   push:
     branches:
-      - develop
+      - EGRC-492
+    workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -1,8 +1,7 @@
 name: Publish to GitHub Packages
 on:
   push:
-    branches:
-      - EGRC-492
+    branches: [develop]
     workflow_dispatch:
 
 jobs:

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "oscal-viewer",
+  "name": "@EasyDynamics/oscal-viewer",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "oscal-viewer",
+      "name": "@EasyDynamics/oscal-viewer",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "file:../node_modules/@testing-library/jest-dom",
@@ -24,6 +24,7 @@
       }
     },
     "..": {
+      "name": "@EasyDynamics/oscal-react-library",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oscal-viewer",
+  "name": "@EasyDynamics/oscal-viewer",
   "homepage": ".",
   "version": "0.1.0",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "oscal-react-library",
+  "name": "@EasyDynamics/oscal-react-library",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "@EasyDynamics/oscal-react-library",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oscal-react-library",
+  "name": "@EasyDynamics/oscal-react-library",
   "version": "0.1.0",
   "author": "EasyDynamics",
   "license": "MIT",


### PR DESCRIPTION
Changed the name of the repo in order to publish to the GitHub npm registry.
Also set the Actions to trigger on a push to this branch; this should be changed back to trigger on push to develop before this can be merged.