### PR TITLE
Include Production Build of Viewer in Package

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -39,5 +39,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
+  ],
+  "files": [
+	  "build"
   ]
 }


### PR DESCRIPTION
Modify package.json to reduce the unnecessary inclusion of source code
in the OSCAL Viewer GitHub Package and instead include the built
production build, which will be used by the pipeline and the end-user.