### PR TITLE
 Run Build in Packages Workflow

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -1,7 +1,7 @@
 name: Publish to GitHub Packages
 on:
   push:
-    branches: [EGRC-492-package]
+    branches: [develop]
   workflow_dispatch:
     
 jobs:


### PR DESCRIPTION
Add the `npm run build` command to the gh-packages workflow to add the production build to the oscal viewer package.