### PR TITLE
Move OSCAL Viewer Package to GitHub Releases

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -16,10 +16,6 @@ jobs:
         uses: actions/delete-package-versions@v1
         with:
           package-name: oscal-react-library
-      - name: Delete previous oscal-viewer version
-        uses: actions/delete-package-versions@v1
-        with:
-          package-name: oscal-viewer
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup NodeJS
@@ -31,13 +27,12 @@ jobs:
       - name: Update Npm
         run: npm install -g npm@latest
       - name: Build and Publish Library
-        run:
-          npm ci && npm publish
+        run: |
+          npm ci
+          cd example
+          npm ci
+          npm run build
+          cd ..
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Build and Publish OSCAL Viewer
-        run:
-          cd example && npm ci && npm run build && npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-

--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -29,10 +29,6 @@ jobs:
       - name: Build and Publish Library
         run: |
           npm ci
-          cd example
-          npm ci
-          npm run build
-          cd ..
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           cd example
           npm ci
           npm run build
-          zip viewer.zip build
+          zip viewer.zip build/*
 
       - name: Create a GitHub Release
         uses: softprops/action-gh-release@v1
@@ -79,9 +79,9 @@ jobs:
       # Should only run when triggered for a feature - for bug fixes
       # this should be done manually since a merge might be needed.
       - name: Push Changes
-        if: ${{ github.event.inputs.type  == 'feature' }}
+        #if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
-          git push origin main
+#git push origin main
           git push -u origin tag-${{ env.PKG_VERSION }}
           npm version preminor
           cd example

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Create a New Release
 on:
+  push:
+    branches: [EGRC-492-package]
   workflow_dispatch:
     inputs:
       release-type:
@@ -46,7 +48,7 @@ jobs:
       # Increment the version to the next bug fix
       # Push the new version to the develop branch
       - name: Set Version (Bug Fix)
-        if: ${{ github.event.inputs.release-type == 'bug' }}
+        #if: ${{ github.event.inputs.release-type == 'bug' }}
         run: |
           npm version patch
           cd example

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Set Version (Feature)
         if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
+          git config --global user.email "info@easydynamics.com"
+          git config --global user.name "${{ github.actor }}"
           npm version minor
           cd example
           npm version minor
@@ -45,6 +47,8 @@ jobs:
       - name: Set Version (Bug Fix)
         # if: ${{ github.event.inputs.type == 'bug' }}
         run: |
+          git config --global user.email "info@easydynamics.com"
+          git config --global user.name "${{ github.actor }}"
           npm version patch
           cd example
           npm version patch
@@ -52,7 +56,9 @@ jobs:
 
       # Output the new package version to environment variable
       - name: Get Package Version
-        run: echo "PKG_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV
+        run: |
+          echo "PKG_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV
+          echo ${{ env.PKG_VERSION }}
 
       - name: Build OSCAL Viewer
         working-directory: example

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Create a New Release
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version number of this release'
+        required: true
 
 jobs:
   release:
@@ -20,14 +24,13 @@ jobs:
       - name: Update Npm
         run: npm install -g npm@latest
 
-      # Increment version to next major version.
+      # Set package to the specified version
       # Store version as an environment variable for later steps to use.
       - name: Set Version of this Release
         run: |
-          npm version major
+          npm version ${{ github.event.inputs.version }}
           cd example
-          npm version major
-          echo "PKG_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV
+          npm version ${{ github.event.inputs.version }}
 
       - name: Build OSCAL Viewer
         working-directory: example
@@ -40,7 +43,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name:
-            ${{ env.PKG_VERSION }}
+            ${{ github.event.inputs.version }}
           files:
             example/viewer.zip
 
@@ -48,6 +51,6 @@ jobs:
       - name: Push to Main and Tag Branch
         run: |
           git add package.json package-lock.json example/package.json example/package-lock.json
-          git commit -m "Create Release Version ${{ env.PKG_VERSION }}"
+          git commit -m "Create Release Version ${{ github.event.inputs.version }}"
           git push origin main
-          git push -u origin tag-${{ env.PKG_VERSION }}
+          git push -u origin tag-${{ github.event.inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,6 @@ jobs:
       - name: Push Changes
         #if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
-#git push origin main
           git push -u origin tag-${{ env.PKG_VERSION }}
           npm version preminor
           cd example

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,15 @@ jobs:
             example/viewer.zip
 
       # Commit the new version and push changes to main, as well as a "tag-{version}" branch
-      - name: Push to Main and Tag Branch
+      # And push a new preminor version to develop.
+      # Should only run when triggered for a feature - for bug fixes
+      # this should be done manually since a merge might be needed.
+      - name: Push Changes
+        if: ${{ github.event.inputs.type }} == 'feature'
         run: |
-          git add package.json package-lock.json example/package.json example/package-lock.json
-          git commit -m "Create Release Version ${{ env.PKG_VERSION }}"
           git push origin main
           git push -u origin tag-${{ env.PKG_VERSION }}
+          npm version preminor
+          cd example
+          npm version preminor
+          git push origin develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,11 @@ jobs:
     name: Create a New Release
     runs-on: ubuntu-20.04
     steps:
+      # Check out develop branch
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          ref: develop
 
       - name: Setup NodeJS
         uses: actions/setup-node@v2
@@ -27,6 +30,7 @@ jobs:
       - name: Update Npm
         run: npm install -g npm@latest
 
+      # Increment the version to the next minor release
       - name: Set Version (Feature)
         if: ${{ github.event.inputs.type }} == 'feature'
         run: |
@@ -34,12 +38,15 @@ jobs:
           cd example
           npm version minor
 
+      # Increment the version to the next bug fix
+      # Push the new version to the develop branch
       - name: Set Version (Bug Fix)
         if: ${{ github.event.inputs.type }} == 'bug'
         run: |
           npm version patch
           cd example
           npm version patch
+          git push origin develop
 
       # Output the new package version to environment variable
       - name: Get Package Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Build OSCAL Viewer
         run: |
+          npm ci
           cd example
           npm ci
           npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           files:
             example/viewer.zip
 
-      # Commit the new version and push changes to main, as well as a "tag-{version}" branch
+      # Commit the new version and push changes to main
       # And push a new preminor version to develop.
       # Should only run when triggered for a feature - for bug fixes
       # this should be done manually since a merge might be needed.
@@ -80,7 +80,6 @@ jobs:
         if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
           git push origin develop:main
-          git push origin develop:tag-${{ env.PKG_VERSION }}
           git add package.json package-lock.json example/package.json example/package-lock.json
           git commit -m "Build Viewer for Release ${{ env.PKG_VERSION }}"
           npm version preminor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Create a New Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version number of this release
+        required: true
+
+jobs:
+  release:
+    name: Create a New Release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://npm.pkg.github.com/
+          cache: npm
+
+      - name: Update Npm
+        run: npm install -g npm@latest
+
+      - name: Build OSCAL Viewer
+        working-directory: example
+        run: |
+          npm ci
+          npm run build
+
+      - name: Push to Main
+        run: //
+
+      - name: Push to Tag Branch
+        run: //
+
+      - name: Create a GitHub Release
+        run: //
+
+      - name: Upload the Production Build to the Release
+        run: 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           zip viewer.zip build/*
 
       - name: Create a GitHub Release
-        #if: ${{ github.event.inputs.type  == 'feature' }}
+        if: ${{ github.event.inputs.type  == 'feature' }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name:
@@ -83,7 +83,9 @@ jobs:
         #if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
           git push origin develop:tag-${{ env.PKG_VERSION }}
+          git add package.json package-lock.json example/package.json example/package-lock.json
+          git commit -m "Build Viewer for Release ${{ env.PKG_VERSION }}"
           npm version preminor
           cd example
           npm version preminor
-          git push origin develop
+          git push origin develop:test-${{ env.PKG_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release:
     # Validate the input type before running
-    # if: ${{ github.event.inputs.type }} == 'feature' || ${{ github.event.inputs.type }} == 'bug'
+    # if: ${{ github.event.inputs.type == 'feature' || github.event.inputs.type == 'bug' }}
     name: Create a New Release
     runs-on: ubuntu-20.04
     steps:
@@ -34,7 +34,7 @@ jobs:
 
       # Increment the version to the next minor release
       - name: Set Version (Feature)
-        if: ${{ github.event.inputs.type }} == 'feature'
+        if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
           npm version minor
           cd example
@@ -43,7 +43,7 @@ jobs:
       # Increment the version to the next bug fix
       # Push the new version to the develop branch
       - name: Set Version (Bug Fix)
-        # if: ${{ github.event.inputs.type }} == 'bug'
+        # if: ${{ github.event.inputs.type == 'bug' }}
         run: |
           npm version patch
           cd example
@@ -74,7 +74,7 @@ jobs:
       # Should only run when triggered for a feature - for bug fixes
       # this should be done manually since a merge might be needed.
       - name: Push Changes
-        if: ${{ github.event.inputs.type }} == 'feature'
+        if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
           git push origin main
           git push -u origin tag-${{ env.PKG_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,5 @@
 name: Create a New Release
 on:
-  push:
-    branches: [EGRC-492-package]
   workflow_dispatch:
     inputs:
       type:
@@ -12,7 +10,7 @@ on:
 jobs:
   release:
     # Validate the input type before running
-    # if: ${{ github.event.inputs.type == 'feature' || github.event.inputs.type == 'bug' }}
+    if: ${{ github.event.inputs.type == 'feature' || github.event.inputs.type == 'bug' }}
     name: Create a New Release
     runs-on: ubuntu-20.04
     steps:
@@ -45,14 +43,14 @@ jobs:
       # Increment the version to the next bug fix
       # Push the new version to the develop branch
       - name: Set Version (Bug Fix)
-        # if: ${{ github.event.inputs.type == 'bug' }}
+        if: ${{ github.event.inputs.type == 'bug' }}
         run: |
           git config --global user.email "info@easydynamics.com"
           git config --global user.name "${{ github.actor }}"
           npm version patch
           cd example
           npm version patch
-        # git push origin develop
+          git push origin develop
 
       # Output the new package version to environment variable
       - name: Get Package Version
@@ -67,7 +65,6 @@ jobs:
           zip viewer.zip build/*
 
       - name: Create a GitHub Release
-        if: ${{ github.event.inputs.type  == 'feature' }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name:
@@ -80,12 +77,13 @@ jobs:
       # Should only run when triggered for a feature - for bug fixes
       # this should be done manually since a merge might be needed.
       - name: Push Changes
-        #if: ${{ github.event.inputs.type  == 'feature' }}
+        if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
+          git push origin develop:main
           git push origin develop:tag-${{ env.PKG_VERSION }}
           git add package.json package-lock.json example/package.json example/package-lock.json
           git commit -m "Build Viewer for Release ${{ env.PKG_VERSION }}"
           npm version preminor
           cd example
           npm version preminor
-          git push origin develop:test-${{ env.PKG_VERSION }}
+          git push origin develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,11 @@ jobs:
 
       # Output the new package version to environment variable
       - name: Get Package Version
-        run: |
-          echo "PKG_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV
-          echo ${{ env.PKG_VERSION }}
+        run: echo "PKG_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV
 
       - name: Build OSCAL Viewer
-        working-directory: example
         run: |
+          cd example
           npm ci
           npm run build
           zip viewer.zip build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
           zip viewer.zip build/*
 
       - name: Create a GitHub Release
+        #if: ${{ github.event.inputs.type  == 'feature' }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name:
@@ -81,7 +82,7 @@ jobs:
       - name: Push Changes
         #if: ${{ github.event.inputs.type  == 'feature' }}
         run: |
-          git push -u origin tag-${{ env.PKG_VERSION }}
+          git push origin develop:tag-${{ env.PKG_VERSION }}
           npm version preminor
           cd example
           npm version preminor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: Create a New Release
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: The version number of this release
-        required: true
 
 jobs:
   release:
@@ -24,20 +20,34 @@ jobs:
       - name: Update Npm
         run: npm install -g npm@latest
 
+      # Increment version to next major version.
+      # Store version as an environment variable for later steps to use.
+      - name: Set Version of this Release
+        run: |
+          npm version major
+          cd example
+          npm version major
+          echo "PKG_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV
+
       - name: Build OSCAL Viewer
         working-directory: example
         run: |
           npm ci
           npm run build
-
-      - name: Push to Main
-        run: //
-
-      - name: Push to Tag Branch
-        run: //
+          zip viewer.zip build
 
       - name: Create a GitHub Release
-        run: //
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name:
+            ${{ env.PKG_VERSION }}
+          files:
+            example/viewer.zip
 
-      - name: Upload the Production Build to the Release
-        run: 
+      # Commit the new version and push changes to main, as well as a "tag-{version}" branch
+      - name: Push to Main and Tag Branch
+        run: |
+          git add package.json package-lock.json example/package.json example/package-lock.json
+          git commit -m "Create Release Version ${{ env.PKG_VERSION }}"
+          git push origin main
+          git push -u origin tag-${{ env.PKG_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
           npm version patch
           cd example
           npm version patch
-          git push origin develop
 
       # Output the new package version to environment variable
       - name: Get Package Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,15 @@ name: Create a New Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'The version number of this release'
+      type:
+        description:
+          'The version type of this release. Must be either "feature" or "bug", representing a new feature release or a bug fix release, respectively,'
         required: true
 
 jobs:
   release:
+    # Validate the input type before running
+    if: ${{ github.event.inputs.type }} == 'feature' || ${{ github.event.inputs.type }} == 'bug'
     name: Create a New Release
     runs-on: ubuntu-20.04
     steps:
@@ -24,13 +27,23 @@ jobs:
       - name: Update Npm
         run: npm install -g npm@latest
 
-      # Set package to the specified version
-      # Store version as an environment variable for later steps to use.
-      - name: Set Version of this Release
+      - name: Set Version (Feature)
+        if: ${{ github.event.inputs.type }} == 'feature'
         run: |
-          npm version ${{ github.event.inputs.version }}
+          npm version minor
           cd example
-          npm version ${{ github.event.inputs.version }}
+          npm version minor
+
+      - name: Set Version (Bug Fix)
+        if: ${{ github.event.inputs.type }} == 'bug'
+        run: |
+          npm version patch
+          cd example
+          npm version patch
+
+      # Output the new package version to environment variable
+      - name: Get Package Version
+        run: echo "PKG_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV
 
       - name: Build OSCAL Viewer
         working-directory: example
@@ -43,7 +56,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name:
-            ${{ github.event.inputs.version }}
+            ${{ env.PKG_VERSION }}
           files:
             example/viewer.zip
 
@@ -51,6 +64,6 @@ jobs:
       - name: Push to Main and Tag Branch
         run: |
           git add package.json package-lock.json example/package.json example/package-lock.json
-          git commit -m "Create Release Version ${{ github.event.inputs.version }}"
+          git commit -m "Create Release Version ${{ env.PKG_VERSION }}"
           git push origin main
-          git push -u origin tag-${{ github.event.inputs.version }}
+          git push -u origin tag-${{ env.PKG_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Create a New Release
 on:
+  push:
+    branches: [EGRC-492-package]
   workflow_dispatch:
     inputs:
       type:
@@ -10,7 +12,7 @@ on:
 jobs:
   release:
     # Validate the input type before running
-    if: ${{ github.event.inputs.type }} == 'feature' || ${{ github.event.inputs.type }} == 'bug'
+    # if: ${{ github.event.inputs.type }} == 'feature' || ${{ github.event.inputs.type }} == 'bug'
     name: Create a New Release
     runs-on: ubuntu-20.04
     steps:
@@ -41,12 +43,12 @@ jobs:
       # Increment the version to the next bug fix
       # Push the new version to the develop branch
       - name: Set Version (Bug Fix)
-        if: ${{ github.event.inputs.type }} == 'bug'
+        # if: ${{ github.event.inputs.type }} == 'bug'
         run: |
           npm version patch
           cd example
           npm version patch
-          git push origin develop
+        # git push origin develop
 
       # Output the new package version to environment variable
       - name: Get Package Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,15 @@ name: Create a New Release
 on:
   workflow_dispatch:
     inputs:
-      type:
+      release-type:
         description:
-          'The version type of this release. Must be either "feature" or "bug", representing a new feature release or a bug fix release, respectively,'
+          'The type of release; either a new feature (minor version) or bug fix (patch version)'
         required: true
+        type: choice
+        options: [feature, bug]
 
 jobs:
   release:
-    # Validate the input type before running
-    if: ${{ github.event.inputs.type == 'feature' || github.event.inputs.type == 'bug' }}
     name: Create a New Release
     runs-on: ubuntu-20.04
     steps:
@@ -30,12 +30,15 @@ jobs:
       - name: Update Npm
         run: npm install -g npm@latest
 
-      # Increment the version to the next minor release
-      - name: Set Version (Feature)
-        if: ${{ github.event.inputs.type  == 'feature' }}
+      - name: Set Up Git User Info
         run: |
           git config --global user.email "info@easydynamics.com"
           git config --global user.name "${{ github.actor }}"
+
+      # Increment the version to the next minor release
+      - name: Set Version (Feature)
+        if: ${{ github.event.inputs.release-type  == 'feature' }}
+        run: |
           npm version minor
           cd example
           npm version minor
@@ -43,10 +46,8 @@ jobs:
       # Increment the version to the next bug fix
       # Push the new version to the develop branch
       - name: Set Version (Bug Fix)
-        if: ${{ github.event.inputs.type == 'bug' }}
+        if: ${{ github.event.inputs.release-type == 'bug' }}
         run: |
-          git config --global user.email "info@easydynamics.com"
-          git config --global user.name "${{ github.actor }}"
           npm version patch
           cd example
           npm version patch
@@ -77,7 +78,7 @@ jobs:
       # Should only run when triggered for a feature - for bug fixes
       # this should be done manually since a merge might be needed.
       - name: Push Changes
-        if: ${{ github.event.inputs.type  == 'feature' }}
+        if: ${{ github.event.inputs.release-type  == 'feature' }}
         run: |
           git push origin develop:main
           git add package.json package-lock.json example/package.json example/package-lock.json

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -25,7 +25,7 @@
     },
     "..": {
       "name": "@EasyDynamics/oscal-react-library",
-      "version": "0.1.19",
+      "version": "0.2.0-0",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.11.4",

--- a/example/package.json
+++ b/example/package.json
@@ -2,13 +2,11 @@
   "name": "@EasyDynamics/oscal-viewer",
   "homepage": ".",
   "version": "0.2.0-0",
+  "private": "true",
   "repository": {
     "type": "git",
     "url": "https://github.com/EasyDynamics/oscal-react-library.git",
     "directory": "example"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
     "start": "node ../node_modules/react-scripts/bin/react-scripts.js start",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "prettier": "^2.2.1"
   },
   "files": [
-    "dist"
+    "dist",
+    "build"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "prettier": "^2.2.1"
   },
   "files": [
-    "dist",
-    "example/build"
+    "dist"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,6 @@
   },
   "files": [
     "dist",
-    "build"
+    "example/build"
   ]
 }


### PR DESCRIPTION
Move the production build of the Oscal Viewer, previously contained in a
separate `oscal-viewer` package, into the `oscal-react-library` package,
and remove the viewer package.

This fixes issues with the oscal-viewer package, which was previously
set up only for offline development by using local paths in its dependencies,
which are not compatible with publishing to an online registry.
Moving everything into one package allows for the end user to install both the
Viewer and its dependencies all in one place.