### PR TITLE
Fix Zip Command in Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           cd example
           npm ci
           npm run build
-          zip viewer.zip build/*
+          zip -r viewer.zip ./build/
 
       - name: Create a GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Use the -r flag to recursively add all files to the .zip, which
previously was missing necessary files of the OSCAL Viewer.