### PR TITLE
Make Dependabot ask for reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    reviewers:
+      - "EasyDynamics/easygrc-reviewers"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
+    reviewers:
+      - "EasyDynamics/easygrc-reviewers"


### PR DESCRIPTION
This will ensure that the team actually gets added as reviewers. Keeping
the team up-to-date in GitHub is preferable to requiring us to update
the Dependabot configuration file as the team changes over time.
