### PR TITLE
Added check for bad response in fetch call

### DIFF
--- a/src/components/OSCALLoaderForm.js
+++ b/src/components/OSCALLoaderForm.js
@@ -27,7 +27,10 @@ export default function OSCALLoaderForm(props) {
     fetch(
       `${process.env.REACT_APP_REST_BASE_URL}/${props.oscalObjectType.restPath}`
     )
-      .then((res) => res.json())
+      .then((response) => {
+        if (!response.ok) throw new Error(response.status);
+        else return response.json();
+      })
       .then(
         (result) => {
           if (!unmounted.current) {


### PR DESCRIPTION
Closes #229

See above for how to reproduce locally.

Given the current dependence of our end-to-end tests on a fixed deployment configuration/, it would be difficult to add an automated test for this edge case.  If/when we move towards a more robust pipeline for different environments/configurations we can revisit a pipeline test here.