### PR TITLE
Handle Nested Groups

### DIFF
--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -55,9 +55,9 @@ export default function OSCALCatalogGroup(props) {
       </ListItem>
       <Collapse in={open} timeout="auto" unmountOnExit>
         <List className={classes.OSCALControlList}>
-          {group.groups?.map((innerGroup) =>
-            renderGroup(innerGroup, level + 1)
-          )}
+          {group.groups?.map((innerGroup) => (
+            <OSCALCatalogGroup group={innerGroup} key={innerGroup.id} />
+          ))}
           {group.controls?.map((control) => (
             <OSCALControl
               control={control}

--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -42,26 +42,26 @@ export default function OSCALCatalogGroup(props) {
     return hash;
   };
 
-  const renderGroup = (group, level) => (
+  return (
     <>
-      <ListItem key={groupKey(group)} button onClick={handleClick}>
-        <ListItemAvatar key={`${groupKey(group)}-avatar`}>
+      <ListItem key={groupKey(props.group)} button onClick={handleClick}>
+        <ListItemAvatar key={`${groupKey(props.group)}-avatar`}>
           <Avatar variant="rounded">
             <FolderIcon />
           </Avatar>
         </ListItemAvatar>
-        <ListItemText primary={group.title} />
+        <ListItemText primary={props.group.title} />
         {open ? <ExpandLess /> : <ExpandMore />}
       </ListItem>
       <Collapse in={open} timeout="auto" unmountOnExit>
         <List className={classes.OSCALControlList}>
-          {group.groups?.map((innerGroup) => (
+          {props.group.groups?.map((innerGroup) => (
             <OSCALCatalogGroup group={innerGroup} key={innerGroup.id} />
           ))}
-          {group.controls?.map((control) => (
+          {props.group.controls?.map((control) => (
             <OSCALControl
               control={control}
-              childLevel={level}
+              childLevel={0}
               key={`control-${control.id}`}
             />
           ))}
@@ -69,6 +69,4 @@ export default function OSCALCatalogGroup(props) {
       </Collapse>
     </>
   );
-
-  return renderGroup(props.group, 0);
 }

--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -26,23 +26,42 @@ export default function OSCALCatalogGroup(props) {
     setOpen(!open);
   };
 
-  return (
+  // Groups may not necessarily have an ID (it is not required per the spec);
+  // therefore, we need to be able to come up with a semi-constant ID. All
+  // groups will have a title. We can (poorly) hash that hopefully that will
+  // be good enough.
+  const groupKey = (group) => {
+    if (group.id) {
+      return group.id;
+    }
+    let hash = 7;
+    // eslint-disable-next-line no-restricted-syntax
+    for (const char of group.title) {
+      hash = 31 * hash + char.charCodeAt(0);
+    }
+    return hash;
+  };
+
+  const renderGroup = (group, level) => (
     <>
-      <ListItem key={props.group.id} button onClick={handleClick}>
-        <ListItemAvatar key={`${props.group.id}-avatar`}>
+      <ListItem key={groupKey(group)} button onClick={handleClick}>
+        <ListItemAvatar key={`${groupKey(group)}-avatar`}>
           <Avatar variant="rounded">
             <FolderIcon />
           </Avatar>
         </ListItemAvatar>
-        <ListItemText primary={props.group.title} />
+        <ListItemText primary={group.title} />
         {open ? <ExpandLess /> : <ExpandMore />}
       </ListItem>
       <Collapse in={open} timeout="auto" unmountOnExit>
         <List className={classes.OSCALControlList}>
-          {props.group.controls.map((control) => (
+          {group.groups?.map((innerGroup) =>
+            renderGroup(innerGroup, level + 1)
+          )}
+          {group.controls?.map((control) => (
             <OSCALControl
               control={control}
-              childLevel={0}
+              childLevel={level}
               key={`control-${control.id}`}
             />
           ))}
@@ -50,4 +69,6 @@ export default function OSCALCatalogGroup(props) {
       </Collapse>
     </>
   );
+
+  return renderGroup(props.group, 0);
 }

--- a/src/components/OSCALCatalogGroup.test.js
+++ b/src/components/OSCALCatalogGroup.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import OSCALCatalogGroup from "./OSCALCatalogGroup";
 
 test("OSCALCatalog displays control groups", () => {
@@ -12,4 +12,27 @@ test("OSCALCatalog displays control groups", () => {
   render(<OSCALCatalogGroup group={testGroup} />);
   const result = screen.getByText("Access Control");
   expect(result).toBeVisible();
+});
+
+test("OSCALCatalog displays nested control groups", () => {
+  const testGroup = {
+    id: "parent-group",
+    class: "family",
+    title: "Parent Group",
+    groups: [
+      {
+        id: "ac",
+        class: "family",
+        title: "Access Control",
+        controls: [{ id: "ac-1" }],
+      },
+    ],
+  };
+  render(<OSCALCatalogGroup group={testGroup} />);
+  const parentGroup = screen.getByText("Parent Group");
+  fireEvent.click(parentGroup);
+  const childGroup = screen.getByText("Access Control");
+  fireEvent.click(childGroup);
+  const control = screen.getByText("ac-1");
+  expect(control).toBeVisible();
 });

--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -41,7 +41,7 @@ function getParameterLabel(parameters, parameterId) {
   );
 
   if (!parameter) {
-    return null;
+    return `< ${parameterId} >`;
   }
   if (parameter.label) {
     return `< ${parameter.label} >`;


### PR DESCRIPTION
Closes #227 

Note that the basic catalog [references a missing param of `s1.1.1-prm11`](https://github.com/usnistgov/oscal-content/blob/master/examples/catalog/json/basic-catalog.json#L70) (reported at usnistgov/oscal-content#93) so the code was updated to just display that id as the parameter label if no parameter is found.