### PR TITLE
Fix errors during loading OSCAL documents

### DIFF
--- a/src/components/OSCALLoaderForm.js
+++ b/src/components/OSCALLoaderForm.js
@@ -47,7 +47,7 @@ export default function OSCALLoaderForm(props) {
   };
 
   useEffect(() => {
-    findAllObjects();
+    if (props.isRestMode) findAllObjects();
     return () => {
       unmounted.current = true;
     };

--- a/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/src/components/oscal-utils/OSCALProfileResolver.js
@@ -77,7 +77,7 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
           inheritedOSCALObject.inherited = [];
 
           modifications["set-parameters"].push(
-            ...result.profile.modify["set-parameters"]
+            ...(result.profile.modify["set-parameters"] ?? [])
           );
           modifications.alters.push(...result.profile.modify.alters);
 


### PR DESCRIPTION
There is an error where an HTTP request that should only occur during
REST mode is enabled. This resulted in an HTTP 404 response (that
actually was perceived as a 200 OK) with an HTML body attempting to be
parsed as JSON. This caused failures up the entire stack. This ensures
we only make that call during REST mode.

Another small error is fixed that only appeared locally. This seems to
be caused by using the spread operator (`...`) on `undefined`.

Closes #239