### PR TITLE
Fix tests when GA ID present

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -73,8 +73,11 @@ function App() {
   };
 
   if (process.env.REACT_APP_GOOGLE_ANALYTICS) {
-    ReactGA.initialize(process.env.REACT_APP_GOOGLE_ANALYTICS);
+    ReactGA.initialize(process.env.REACT_APP_GOOGLE_ANALYTICS, {
+      testMode: process.env.NODE_ENV === "test",
+    });
   }
+
   const location = useLocation();
   useEffect(() => {
     if (process.env.REACT_APP_GOOGLE_ANALYTICS) {


### PR DESCRIPTION
`jest` automatically sets `NODE_ENV` to `"test"` so this should just work. This wasn't caught outside the pipeline because the deployment pipeline is the only place where we set the GOOGLE_ANALYTICS env var.