### PR TITLE
Fix Viewer Crashing on Load of Wrong OSCAL Doc Type

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Alert from "@material-ui/lab/Alert";
+
+export function defaultFormatter(error) {
+  return (
+    <Alert severity="error">
+      Yikes! Something went wrong loading the OSCAL data. Sorry, we&apos;ll look
+      into it. ({error.message})
+    </Alert>
+  );
+}
+
+export class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.errorFormatter = props.errorFormatter ?? defaultFormatter;
+    this.state = { error: undefined };
+  }
+
+  componentDidCatch(error) {
+    this.setState({ error });
+  }
+
+  render() {
+    if (this.state.error !== undefined) {
+      return this.errorFormatter(this.state.error);
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Alert from "@material-ui/lab/Alert";
 
-export function defaultFormatter(error) {
+function defaultFormatter(error) {
   return (
     <Alert severity="error">
       Yikes! Something went wrong loading the OSCAL data. Sorry, we&apos;ll look
@@ -10,7 +10,7 @@ export function defaultFormatter(error) {
   );
 }
 
-export class ErrorBoundary extends React.Component {
+class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
     this.errorFormatter = props.errorFormatter ?? defaultFormatter;
@@ -28,3 +28,4 @@ export class ErrorBoundary extends React.Component {
     return this.props.children;
   }
 }
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -25,7 +25,7 @@ class ErrorBoundary extends React.Component {
     if (this.state.error !== undefined) {
       return this.errorFormatter(this.state.error);
     }
-    return this.props.children;
+    return this.props.children || null;
   }
 }
 export default ErrorBoundary;

--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -99,6 +99,29 @@ function restPatch(
     );
 }
 
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error });
+    console.error({ ...this.state, errorInfo });
+  }
+
+  render() {
+    if (this.state.error !== undefined) {
+      return onError(this.state.error);
+    }
+    return this.props.children;
+  }
+}
+
 export default function OSCALLoader(props) {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -225,7 +248,7 @@ export default function OSCALLoader(props) {
   return (
     <>
       {form}
-      {result}
+      <ErrorBoundary>{result}</ErrorBoundary>
     </>
   );
 }

--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -1,18 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
-import Alert from "@material-ui/lab/Alert";
 import CircularProgress from "@material-ui/core/CircularProgress";
+import { ErrorBoundary } from "./ErrorBoundary";
 import OSCALSsp from "./OSCALSsp";
 import OSCALCatalog from "./OSCALCatalog";
 import OSCALComponentDefinition from "./OSCALComponentDefinition";
 import OSCALProfile from "./OSCALProfile";
 import OSCALLoaderForm from "./OSCALLoaderForm";
-
-const onError = (error) => (
-  <Alert severity="error">
-    Yikes! Something went wrong loading the OSCAL data. Sorry, we&apos;ll look
-    into it. ({error.message})
-  </Alert>
-);
 
 const oscalObjectTypes = {
   catalog: {
@@ -97,29 +90,6 @@ function restPatch(
         );
       }
     );
-}
-
-class ErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { error: undefined };
-  }
-
-  static getDerivedStateFromError(error) {
-    return { error };
-  }
-
-  componentDidCatch(error, errorInfo) {
-    this.setState({ error });
-    console.error({ ...this.state, errorInfo });
-  }
-
-  render() {
-    if (this.state.error !== undefined) {
-      return onError(this.state.error);
-    }
-    return this.props.children;
-  }
 }
 
 export default function OSCALLoader(props) {

--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import CircularProgress from "@material-ui/core/CircularProgress";
-import { ErrorBoundary } from "./ErrorBoundary";
+import ErrorBoundary from "./ErrorBoundary";
 import OSCALSsp from "./OSCALSsp";
 import OSCALCatalog from "./OSCALCatalog";
 import OSCALComponentDefinition from "./OSCALComponentDefinition";

--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -123,7 +123,6 @@ class ErrorBoundary extends React.Component {
 }
 
 export default function OSCALLoader(props) {
-  const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [isResolutionComplete, setIsResolutionComplete] = useState(false);
   const [isRestMode, setIsRestMode] = useState(
@@ -140,22 +139,12 @@ export default function OSCALLoader(props) {
           if (!response.ok) throw new Error(response.status);
           else return response.json();
         })
-        .then(
-          (result) => {
-            if (!unmounted.current) {
-              setOscalData(result);
-              setIsLoaded(true);
-              setError(null);
-            }
-          },
-          // Note: it's important to handle errors here
-          // instead of a catch() block so that we don't swallow
-          // exceptions from actual bugs in components.
-          (e) => {
-            setError(e);
+        .then((result) => {
+          if (!unmounted.current) {
+            setOscalData(result);
             setIsLoaded(true);
           }
-        );
+        });
     } else {
       setIsLoaded(true);
     }
@@ -223,18 +212,12 @@ export default function OSCALLoader(props) {
         isRestMode={isRestMode}
         onChangeRestMode={handleChangeRestMode}
         isResolutionComplete={isResolutionComplete}
-        onError={(e) => {
-          setError(e);
-          onError(e);
-        }}
       />
     );
   }
 
   let result;
-  if (error) {
-    result = onError(error);
-  } else if (!isLoaded) {
+  if (!isLoaded) {
     result = <CircularProgress />;
   } else if (oscalUrl) {
     result = props.renderer(
@@ -269,7 +252,6 @@ export function OSCALCatalogLoader(props) {
     <OSCALCatalog
       catalog={oscalData[oscalObjectType.jsonRootName]}
       parentUrl={oscalUrl}
-      onError={onError}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(data, update, editedField, newValue) => {
         restPatch(
@@ -300,7 +282,6 @@ export function OSCALSSPLoader(props) {
       system-security-plan={oscalData[oscalObjectType.jsonRootName]}
       isEditable={isRestMode}
       parentUrl={oscalUrl}
-      onError={onError}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(data, update, editedField, newValue) => {
         restPatch(
@@ -330,7 +311,6 @@ export function OSCALComponentLoader(props) {
     <OSCALComponentDefinition
       componentDefinition={oscalData[oscalObjectType.jsonRootName]}
       parentUrl={oscalUrl}
-      onError={onError}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(data, update, editedField, newValue) => {
         restPatch(


### PR DESCRIPTION
Fix for [#240 ](https://github.com/EasyDynamics/oscal-react-library/issues/240)

Should work for Catalogs, SSPs, and Components.