### PR TITLE
Fixes for successful patch re-rendering

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -35,7 +35,7 @@
         "@material-ui/styles": "^4.11.4",
         "@testing-library/dom": "^8.11.3",
         "@testing-library/jest-dom": "^5.16.2",
-        "@testing-library/react": "^12.1.2",
+        "@testing-library/react": "^12.1.3",
         "history": "^5.2.0",
         "prop-types": "^15.8.0",
         "react": "^17.0.2",
@@ -61,7 +61,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-prettier": "^8.1.0",
+        "eslint-config-prettier": "^8.4.0",
         "eslint-config-react-app": "^6.0.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jest": "^24.7.0",
@@ -73,7 +73,7 @@
         "microbundle-crl": "^0.13.11",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.5.1",
-        "webpack": "^5.68.0"
+        "webpack": "^5.69.1"
       },
       "engines": {
         "node": ">=10"
@@ -35061,13 +35061,13 @@
         "@storybook/react": "^6.4.19",
         "@testing-library/dom": "^8.11.3",
         "@testing-library/jest-dom": "^5.16.2",
-        "@testing-library/react": "^12.1.2",
+        "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
         "babel-eslint": "^10.1.0",
         "cross-env": "^7.0.3",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-prettier": "^8.1.0",
+        "eslint-config-prettier": "^8.4.0",
         "eslint-config-react-app": "^6.0.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jest": "^24.7.0",
@@ -35086,7 +35086,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^5.0.0",
         "web-vitals": "^2.1.2",
-        "webpack": "^5.68.0"
+        "webpack": "^5.69.1"
       },
       "dependencies": {
         "@ampproject/remapping": {

--- a/src/components/OSCALEditableFieldActions.js
+++ b/src/components/OSCALEditableFieldActions.js
@@ -17,7 +17,6 @@ export default function OSCALEditableFieldActions(props) {
           props.setInEditState(!props.inEditState);
           props.onFieldSave(
             props.patchData,
-            props.update,
             props.editedField,
             props.reference.current.value
           );

--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -41,7 +41,6 @@ function textFieldWithEditableActions(
           onFieldSave={props.onFieldSave}
           patchData={props.patchData}
           reference={reference}
-          update={props.update}
         />
       </Grid>
     </>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -85,7 +85,6 @@ export default function OSCALMetadata(props) {
           size={6}
           textFieldSize="medium"
           typographyVariant="h6"
-          update={props.update}
           value={props.metadata.title}
         />
       </Grid>
@@ -154,7 +153,6 @@ export default function OSCALMetadata(props) {
               size={4}
               textFieldSize="small"
               typographyVariant="body2"
-              update={props.update}
               value={props.metadata.version}
             />
           </Grid>

--- a/src/components/OSCALSsp.js
+++ b/src/components/OSCALSsp.js
@@ -22,23 +22,22 @@ export default function OSCALSsp(props) {
   const [inheritedProfilesAndCatalogs, setInheritedProfilesAndCatalogs] =
     useState({});
   const [isLoaded, setIsLoaded] = useState(false);
-  const [ssp, setSsp] = useState(props["system-security-plan"]);
   const unmounted = useRef(false);
 
   const patchData = {
     "system-security-plan": {
-      uuid: ssp.uuid,
+      uuid: props["system-security-plan"].uuid,
     },
   };
 
   let sspParties;
-  if (ssp.metadata) {
-    sspParties = ssp.metadata.parties;
+  if (props["system-security-plan"].metadata) {
+    sspParties = props["system-security-plan"].metadata.parties;
   }
 
   useEffect(() => {
     OSCALSspResolveProfile(
-      ssp,
+      props["system-security-plan"],
       props.parentUrl,
       (profilesCatalogsTree) => {
         if (!unmounted.current) {
@@ -68,10 +67,14 @@ export default function OSCALSsp(props) {
   } else {
     controlImpl = (
       <OSCALControlImplementation
-        controlImplementation={ssp["control-implementation"]}
-        components={ssp["system-implementation"].components}
-        controls={ssp.resolvedControls}
-        modifications={ssp.modifications}
+        controlImplementation={
+          props["system-security-plan"]["control-implementation"]
+        }
+        components={
+          props["system-security-plan"]["system-implementation"].components
+        }
+        controls={props["system-security-plan"].resolvedControls}
+        modifications={props["system-security-plan"].modifications}
       />
     );
   }
@@ -79,27 +82,30 @@ export default function OSCALSsp(props) {
   return (
     <div className={classes.paper}>
       <OSCALMetadata
-        metadata={ssp.metadata}
+        metadata={props["system-security-plan"].metadata}
         isEditable={props.isEditable}
         onFieldSave={props.onFieldSave}
         patchData={patchData}
-        update={setSsp}
       />
       <OSCALProfileCatalogInheritance
         inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs}
       />
       <OSCALSystemCharacteristics
-        systemCharacteristics={ssp["system-characteristics"]}
-        backMatter={ssp["back-matter"]}
+        systemCharacteristics={
+          props["system-security-plan"]["system-characteristics"]
+        }
+        backMatter={props["system-security-plan"]["back-matter"]}
         parentUrl={props.parentUrl}
       />
       <OSCALSystemImplementation
-        systemImplementation={ssp["system-implementation"]}
+        systemImplementation={
+          props["system-security-plan"]["system-implementation"]
+        }
         parties={sspParties}
       />
       {controlImpl}
       <OSCALBackMatter
-        backMatter={ssp["back-matter"]}
+        backMatter={props["system-security-plan"]["back-matter"]}
         parentUrl={props.parentUrl}
       />
     </div>


### PR DESCRIPTION
Closes #272 

- Moved top-level `restPatch` function to `OSCALLoader.handleRestPatch` to re-use state variables for rendering
- Removed `update` arguments
- Removed `ssp` state variable in `OSCALSsp`

This probably needs further investigation before creating an issue and reviewing but I wanted to get what seems like a fix up somewhere so it's not lost.