### PR TITLE
Add automation to update example `package-lock`

### DIFF
--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -16,6 +16,8 @@ jobs:
   update:
     # If the pull request was closed then nothing needs to be done
     # if: github.event.pull_request.merged == 'true'
+    runs-on: ubuntu-latest
+    name: Synchronize version
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -46,3 +48,5 @@ jobs:
             the `example/package-lock.json` file.
           branch: automation/update-dependencies/${{ github.event.pull_request.number }}
           base: develop
+          committer: noreply@easydynamics.com
+          author: Easy Dynamics Automation <noreply@easydynamics.com>

--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -5,17 +5,15 @@ on:
   # Because we so heavily reference the pull request number within the workflow,
   # it is preferable to use the pull_request_target. This will run after every
   # pull request merged to develop that touches the main package-lock.json
-  # pull_request_target:
-  #   types: [closed]
-  #   branches: [develop]
-  #   paths: ["package-lock.json"]
-  pull_request:
-    branches: [feature/automate-example-app-package-updates]
+  pull_request_target:
+    types: [closed]
+    branches: [develop]
+    paths: ["package-lock.json"]
 
 jobs:
   update:
     # If the pull request was closed then nothing needs to be done
-    # if: github.event.pull_request.merged == 'true'
+    if: ${{ github.event.pull_request.merged == 'true' }}
     runs-on: ubuntu-latest
     name: Synchronize version
     steps:
@@ -28,7 +26,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-          cache: "npm"
       - name: Globally update npm
         run: npm install -g npm@latest
       - name: Install library dependencies
@@ -48,5 +45,5 @@ jobs:
             the `example/package-lock.json` file.
           branch: automation/update-dependencies/${{ github.event.pull_request.number }}
           base: develop
-          committer: noreply@easydynamics.com
+          committer: Easy Dynamics Automation <noreply@easydynamics.com>
           author: Easy Dynamics Automation <noreply@easydynamics.com>

--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -44,6 +44,7 @@ jobs:
             `/package-lock.json` was recently merged. This synchronizes those same updates back into
             the `example/package-lock.json` file.
           branch: automation/update-dependencies/${{ github.event.pull_request.number }}
+          delete-branch: true
           base: develop
           committer: Easy Dynamics Automation <noreply@easydynamics.com>
           author: Easy Dynamics Automation <noreply@easydynamics.com>

--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -40,10 +40,11 @@ jobs:
             Synchronize OSCAL Viewer example app depenencies
           title: Synchronize example app `package-lock.json` (#${{ github.event.pull_request.number }})
           body: |
-            Pull request #${{ github.event.pull_request.number }} which updated some dependencies
+            Pull request #${{ github.event.pull_request.number }} which updated some dependencies in
             `/package-lock.json` was recently merged. This synchronizes those same updates back into
             the `example/package-lock.json` file.
           branch: automation/update-dependencies/${{ github.event.pull_request.number }}
           base: develop
           committer: Easy Dynamics Automation <noreply@easydynamics.com>
           author: Easy Dynamics Automation <noreply@easydynamics.com>
+          path: example/

--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   update:
     # If the pull request was closed then nothing needs to be done
-    if: ${{ github.event.pull_request.merged == 'true' }}
+    if: github.event.pull_request_target.merged == true
     runs-on: ubuntu-latest
     name: Synchronize version
     steps:

--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -5,15 +5,17 @@ on:
   # Because we so heavily reference the pull request number within the workflow,
   # it is preferable to use the pull_request_target. This will run after every
   # pull request merged to develop that touches the main package-lock.json
-  pull_request_target:
-    types: [closed]
-    branches: [develop]
-    paths: ["package-lock.json"]
+  # pull_request_target:
+  #   types: [closed]
+  #   branches: [develop]
+  #   paths: ["package-lock.json"]
+  pull_request:
+    branches: [feature/automate-example-app-package-updates]
 
 jobs:
   update:
     # If the pull request was closed then nothing needs to be done
-    if: github.event.pull_request.merged == 'true'
+    # if: github.event.pull_request.merged == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -48,4 +48,6 @@ jobs:
           base: develop
           committer: Easy Dynamics Automation <noreply@easydynamics.com>
           author: Easy Dynamics Automation <noreply@easydynamics.com>
-          path: example/
+          add-paths: |
+            example/package.json
+            example/package-lock.json

--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -1,0 +1,46 @@
+---
+name: Auto-update example app after Dependabot
+
+on:
+  # Because we so heavily reference the pull request number within the workflow,
+  # it is preferable to use the pull_request_target. This will run after every
+  # pull request merged to develop that touches the main package-lock.json
+  pull_request_target:
+    types: [closed]
+    branches: [develop]
+    paths: ["package-lock.json"]
+
+jobs:
+  update:
+    # If the pull request was closed then nothing needs to be done
+    if: github.event.pull_request.merged == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: develop
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: "npm"
+      - name: Globally update npm
+        run: npm install -g npm@latest
+      - name: Install library dependencies
+        run: npm ci
+      - name: Update example application dependencies
+        run: npm install
+        working-directory: example
+      - name: Commit back changes to example app
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: >-
+            Synchronize OSCAL Viewer example app depenencies
+          title: Synchronize example app `package-lock.json` (#${{ github.event.pull_request.number }})
+          body: |
+            Pull request #${{ github.event.pull_request.number }} which updated some dependencies
+            `/package-lock.json` was recently merged. This synchronizes those same updates back into
+            the `example/package-lock.json` file.
+          branch: automation/update-dependencies/${{ github.event.pull_request.number }}
+          base: develop


### PR DESCRIPTION
Because the example application's `package-lock.json` references the
parent directory for the vast majority of its dependencies, it having
outdated information isn't necessarily an issue; however, it does
falsely trigger quite a few security alerts within GitHub and Dependabot
itself isn't quite talented enough to understand what's going on.

This adds a new GitHub workflow to follow up every pull request that
modifies `package-lock.json` (because people can forget too!) to
synchronize those changes back to the example application.

One of the things I thought about doing here was just pushing to the
PR branch, but dependabot doesn't tolerate that well (it will stop
updating its own PR) and people may not either.
