### PR TITLE
Add support for remote URIs in links

### DIFF
--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -8,7 +8,7 @@ import { Typography } from "@material-ui/core";
 import FormatQuoteIcon from "@material-ui/icons/FormatQuote";
 import DescriptionIcon from "@material-ui/icons/Description";
 import StyledTooltip from "./OSCALStyledTooltip";
-import { getAbsoluteUrl } from "./oscal-utils/OSCALBackMatterUtils";
+import { getAbsoluteUrl } from "./oscal-utils/OSCALLinkUtils";
 
 // TODO: Temporary fix for missing media type (https://github.com/GSA/fedramp-automation/issues/103)
 // Uses file extension instead
@@ -98,7 +98,7 @@ export default function OSCALBackMatter(props) {
 
   const getMediaType = (rlink) =>
     rlink["media-type"] ||
-    getURLMediaType(getAbsoluteUrl(rlink, props.parentUrl));
+    getURLMediaType(getAbsoluteUrl(rlink.href, props.parentUrl));
 
   const backMatterDisplay = (resource) => (
     <Grid item xs={3} key={resource.uuid}>
@@ -123,7 +123,7 @@ export default function OSCALBackMatter(props) {
                     key={rlink.href}
                     label={getMediaType(rlink)}
                     component="a"
-                    href={getAbsoluteUrl(rlink, props.parentUrl)}
+                    href={getAbsoluteUrl(rlink.href, props.parentUrl)}
                     variant="outlined"
                     clickable
                   />

--- a/src/components/OSCALDiagram.js
+++ b/src/components/OSCALDiagram.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
-import getUriFromBackMatterByHref from "./oscal-utils/OSCALBackMatterUtils";
+import resolveLinkHref from "./oscal-utils/OSCALLinkUtils";
 
 const useStyles = makeStyles(() => ({
   OSCALDiagramImg: {
@@ -18,7 +18,7 @@ export default function OSCALDiagram(props) {
     throw new Error("no rlink found");
   }
 
-  const diagramUri = getUriFromBackMatterByHref(
+  const diagramUri = resolveLinkHref(
     props.backMatter,
     link.href,
     props.parentUrl,

--- a/src/components/OSCALDiagram.test.js
+++ b/src/components/OSCALDiagram.test.js
@@ -2,27 +2,46 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import OSCALDiagram from "./OSCALDiagram";
 import { backMatterTestData } from "../test-data/BackMatterData";
-import diagramTestData from "../test-data/DiagramData";
+import {
+  localReferenceDiagram,
+  uriReferenceDiagram,
+} from "../test-data/DiagramData";
 
-function diagramRenderer() {
+function diagramRenderer(testData) {
   render(
     <OSCALDiagram
-      diagram={diagramTestData}
+      diagram={testData}
       backMatter={backMatterTestData}
       parentUrl="./"
     />
   );
 }
 
-export default function testOSCALDiagram(parentElementName, renderer) {
+export default function testOSCALDiagram(
+  parentElementName,
+  renderer,
+  testData,
+  expectedSrc
+) {
   test(`${parentElementName} displays diagram`, () => {
-    renderer();
+    renderer(testData);
     const result = screen.getByAltText("Authorization Boundary Diagram");
     expect(result).toBeVisible();
-    expect(result).toHaveAttribute("src", ".//../diagram.png");
+    expect(result).toHaveAttribute("src", expectedSrc);
   });
 }
 
 if (!require.main) {
-  testOSCALDiagram("OSCALDiagram", diagramRenderer);
+  testOSCALDiagram(
+    "OSCALDiagram",
+    diagramRenderer,
+    localReferenceDiagram,
+    ".//../diagram.png"
+  );
+  testOSCALDiagram(
+    "OSCALDiagram",
+    diagramRenderer,
+    uriReferenceDiagram,
+    uriReferenceDiagram.links[0].href
+  );
 }

--- a/src/components/oscal-utils/OSCALBackMatterUtils.js
+++ b/src/components/oscal-utils/OSCALBackMatterUtils.js
@@ -1,24 +1,3 @@
-export function fixJsonUrls(absoluteUrl) {
-  // TODO this is incorrect in the profile (https://github.com/usnistgov/oscal-content/issues/59, https://easydynamics.atlassian.net/browse/EGRC-266)
-  // TODO this workaround must be improved in https://easydynamics.atlassian.net/browse/EGRC-296
-  if (!absoluteUrl.endsWith(".xml")) {
-    return absoluteUrl;
-  }
-  // Replacing all instances of xml with json in the path *should* get us the correct json URL
-  return absoluteUrl.replace(/xml/g, "json");
-}
-
-export function getAbsoluteUrl(rlink, parentUrl) {
-  let absoluteUrl = rlink.href;
-
-  // TODO - this should be improved for other use cases
-  if (!absoluteUrl.startsWith("http")) {
-    absoluteUrl = `${parentUrl}/../${absoluteUrl}`;
-  }
-
-  return absoluteUrl;
-}
-
 /**
  * Gets a resource from the given back matter's resource by the given HREF UUID.
  */
@@ -42,7 +21,6 @@ export function getResourceFromBackMatterByHref(backMatter, href) {
 export default function getUriFromBackMatterByHref(
   backMatter,
   href,
-  parentUrl,
   mediaTypeRegex
 ) {
   const foundResource = getResourceFromBackMatterByHref(backMatter, href);
@@ -59,5 +37,5 @@ export default function getUriFromBackMatterByHref(
     throw new Error("resource not found for href");
   }
 
-  return fixJsonUrls(getAbsoluteUrl(foundLink, parentUrl));
+  return foundLink;
 }

--- a/src/components/oscal-utils/OSCALLinkUtils.js
+++ b/src/components/oscal-utils/OSCALLinkUtils.js
@@ -1,0 +1,33 @@
+import getUriFromBackMatterByHref from "./OSCALBackMatterUtils";
+
+export function fixJsonUrls(absoluteUrl) {
+  // TODO this is incorrect in the profile (https://github.com/usnistgov/oscal-content/issues/59, https://easydynamics.atlassian.net/browse/EGRC-266)
+  // TODO this workaround must be improved in https://easydynamics.atlassian.net/browse/EGRC-296
+  if (!absoluteUrl.endsWith(".xml")) {
+    return absoluteUrl;
+  }
+  // Replacing all instances of xml with json in the path *should* get us the correct json URL
+  return absoluteUrl.replace(/xml/g, "json");
+}
+
+export function getAbsoluteUrl(href, parentUrl) {
+  return href.startsWith("http") ? href : `${parentUrl}/../${href}`;
+}
+
+export default function resolveLinkHref(
+  backMatter,
+  href,
+  parentUrl,
+  mediaTypeRegex
+) {
+  if (!href.startsWith("#")) {
+    return getAbsoluteUrl(href, parentUrl);
+  }
+
+  return fixJsonUrls(
+    getAbsoluteUrl(
+      getUriFromBackMatterByHref(backMatter, href, mediaTypeRegex).href,
+      parentUrl
+    )
+  );
+}

--- a/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/src/components/oscal-utils/OSCALProfileResolver.js
@@ -1,4 +1,4 @@
-import getUriFromBackMatterByHref from "./OSCALBackMatterUtils";
+import resolveLinkHref from "./OSCALLinkUtils";
 
 const OSCAL_MEDIA_TYPE_REGEX = /^application\/oscal.*\+json$/;
 /**
@@ -83,7 +83,7 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
           modifications.alters.push(...result.profile.modify.alters);
 
           result.profile.imports.forEach((profileImport) => {
-            const importUrl = getUriFromBackMatterByHref(
+            const importUrl = resolveLinkHref(
               result.profile["back-matter"],
               profileImport.href,
               null,
@@ -138,7 +138,7 @@ export function OSCALResolveProfile(profile, parentUrl, onSuccess, onError) {
     OSCALResolveProfileOrCatalogUrlControls(
       profile.resolvedControls,
       profile.modifications,
-      getUriFromBackMatterByHref(
+      resolveLinkHref(
         profile["back-matter"],
         imp.href,
         parentUrl,

--- a/src/components/oscal-utils/OSCALSspResolver.js
+++ b/src/components/oscal-utils/OSCALSspResolver.js
@@ -1,5 +1,5 @@
 import OSCALResolveProfileOrCatalogUrlControls from "./OSCALProfileResolver";
-import { fixJsonUrls } from "./OSCALBackMatterUtils";
+import { fixJsonUrls } from "./OSCALLinkUtils";
 /**
  * Loads an SSP's 'import-profile' and adds the resulting controls to the SSP
  *

--- a/src/stories/OSCALDiagram.stories.js
+++ b/src/stories/OSCALDiagram.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import OSCALDiagram from "../components/OSCALDiagram";
 import { backMatterTestData } from "../test-data/BackMatterData";
-import diagramTestData from "../test-data/DiagramData";
+import { localReferenceDiagram } from "../test-data/DiagramData";
 
 export default {
   title: "Components/Diagram",
@@ -15,7 +15,7 @@ function Template(args) {
 export const Default = Template.bind({});
 
 Default.args = {
-  diagram: diagramTestData,
+  diagram: localReferenceDiagram,
   backMatter: backMatterTestData,
   parentUrl: "./",
 };

--- a/src/test-data/DiagramData.js
+++ b/src/test-data/DiagramData.js
@@ -1,9 +1,21 @@
-export default {
+export const localReferenceDiagram = {
   uuid: "bde155b3-6973-4bc7-9aa4-a4f6803968eb",
   description: "A diagram-specific explanation.",
   links: [
     {
       href: "#a2fc103a-9fe6-433d-a83b-44a33db1564b",
+      rel: "diagram",
+    },
+  ],
+  caption: "Authorization Boundary Diagram",
+};
+
+export const uriReferenceDiagram = {
+  uuid: "bde155b3-6973-4bc7-9aa4-a4f6803968eb",
+  description: "A diagram-specific explanation.",
+  links: [
+    {
+      href: "https://raw.githubusercontent.com/EasyDynamics/oscal-react-library/develop/example/public/logo192.png",
       rel: "diagram",
     },
   ],

--- a/src/test-data/SystemData.js
+++ b/src/test-data/SystemData.js
@@ -3,7 +3,7 @@ import {
   systemCharacteristicsDescriptionUrl,
   systemCharacteristicsInformationUrl,
 } from "./Urls";
-import diagramData from "./DiagramData";
+import { localReferenceDiagram } from "./DiagramData";
 import { backMatterTestData } from "./BackMatterData";
 
 const title = "Example Component";
@@ -152,7 +152,7 @@ export const systemCharacteristicsTestData = {
   ],
   "authorization-boundary": {
     description: "The description of the authorization boundary would go here.",
-    diagrams: [diagramData],
+    diagrams: [localReferenceDiagram],
   },
 };
 


### PR DESCRIPTION
While working on the implementation for #273 it was unclear to me
whether the specification permits diagrams to be referenced directly by
URI or not so I split this out into its own pull request.

The specification specifically states:

> The value of the href can be an internet resource, or a local reference
> using a fragment e.g. #fragment that points to a back-matter resource in
> the same document.
>
> If a local reference using a fragment is used, this will be indicated by
> a fragment "#" followed by an identifier which references an identified
> resource in the document's back-matter or another object that is within
> the scope of the containing OSCAL document.
>
> If an internet resource is used, the href value will be an absolute or
> relative URI pointing to the location of the referenced resource. A
> relative URI will be resolved relative to the location of the document
> containing the link.

This, to me, implied that we should be permitting absolute and relative
links via a URI to internet resources.

To implement this, a "wrapper"-ish function has been created for what
used to be a pure Back Matter lookup function. It handles the logic to
determine whether the link is internal (needs to be looked up in Back
Matter) or an internet resource (is a URI).

There are some incidental changes to code and tests due to the changing
of imports and addition of exported `test-data`.
