### PR TITLE
Persist rest mode toggle across page loads

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -62,6 +62,10 @@ function App() {
   const classes = useStyles();
 
   const [anchorEl, setAnchorEl] = useState(null);
+  const [isRestMode, setIsRestMode] = useState(
+    !!process.env.REACT_APP_REST_BASE_URL
+  );
+  const [backendUrl] = useState(process.env.REACT_APP_REST_BASE_URL);
 
   const handleAppNavOpen = (event) => {
     setAnchorEl(event.currentTarget);
@@ -190,22 +194,50 @@ function App() {
             />
             <Route
               path="/catalog"
-              element={<OSCALCatalogLoader renderForm />}
+              element={
+                <OSCALCatalogLoader
+                  renderForm
+                  isRestMode={isRestMode}
+                  setIsRestMode={setIsRestMode}
+                  backendUrl={backendUrl}
+                />
+              }
             />
             <Route
               exact
               path="/system-security-plan"
-              element={<OSCALSSPLoader renderForm />}
+              element={
+                <OSCALSSPLoader
+                  renderForm
+                  isRestMode={isRestMode}
+                  setIsRestMode={setIsRestMode}
+                  backendUrl={backendUrl}
+                />
+              }
             />
             <Route
               exact
               path="/component-definition"
-              element={<OSCALComponentLoader renderForm />}
+              element={
+                <OSCALComponentLoader
+                  renderForm
+                  isRestMode={isRestMode}
+                  setIsRestMode={setIsRestMode}
+                  backendUrl={backendUrl}
+                />
+              }
             />
             <Route
               exact
               path="/profile"
-              element={<OSCALProfileLoader renderForm />}
+              element={
+                <OSCALProfileLoader
+                  renderForm
+                  isRestMode={isRestMode}
+                  setIsRestMode={setIsRestMode}
+                  backendUrl={backendUrl}
+                />
+              }
             />
           </Routes>
         </Container>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -63,7 +63,7 @@ function App() {
 
   const [anchorEl, setAnchorEl] = useState(null);
   const [isRestMode, setIsRestMode] = useState(
-    // We want to ensure that throughout the app is is always a boolean
+    // We want to ensure that throughout the app this is always a boolean
     // so that it can be decoupled from the _actual_ API URL (which may
     // be different).
     !!process.env.REACT_APP_REST_BASE_URL

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -63,6 +63,9 @@ function App() {
 
   const [anchorEl, setAnchorEl] = useState(null);
   const [isRestMode, setIsRestMode] = useState(
+    // We want to ensure that throughout the app is is always a boolean
+    // so that it can be decoupled from the _actual_ API URL (which may
+    // be different).
     !!process.env.REACT_APP_REST_BASE_URL
   );
   const [backendUrl] = useState(process.env.REACT_APP_REST_BASE_URL);

--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -89,9 +89,7 @@ export default function OSCALLoader(props) {
   const classes = useStyles();
   const [isLoaded, setIsLoaded] = useState(false);
   const [isResolutionComplete, setIsResolutionComplete] = useState(false);
-  const [isRestMode, setIsRestMode] = useState(
-    process.env.REACT_APP_REST_BASE_URL
-  );
+  const { isRestMode, setIsRestMode } = props;
   const [oscalData, setOscalData] = useState([]);
   const [oscalUrl, setOscalUrl] = useState(isRestMode ? null : props.oscalUrl);
   const [editorIsVisible, setEditorIsVisble] = useState(true);
@@ -180,7 +178,8 @@ export default function OSCALLoader(props) {
     jsonRootName,
     restPath
   ) => {
-    const url = `${process.env.REACT_APP_REST_BASE_URL}/${restPath}/${partialPatchData[jsonRootName].uuid}`;
+    const url = `${props.backendUrl}/${restPath}/${partialPatchData[jsonRootName].uuid}`;
+
     populatePartialPatchData(partialPatchData, editedFieldJsonPath, newValue);
     handleRestRequest("PATCH", url, partialPatchData);
   };
@@ -194,7 +193,7 @@ export default function OSCALLoader(props) {
   };
 
   const handleUuidChange = (event) => {
-    const newOscalUrl = `${process.env.REACT_APP_REST_BASE_URL}/${props.oscalObjectType.restPath}/${event.target.value}`;
+    const newOscalUrl = `${props.backendUrl}/${props.oscalObjectType.restPath}/${event.target.value}`;
     setOscalUrl(newOscalUrl);
     setIsLoaded(false);
     setIsResolutionComplete(false);
@@ -253,6 +252,7 @@ export default function OSCALLoader(props) {
         onChangeRestMode={handleChangeRestMode}
         isResolutionComplete={isResolutionComplete}
         onError={handleFetchError}
+        backendUrl={props.backendUrl}
       />
     );
   }
@@ -369,6 +369,9 @@ export function OSCALCatalogLoader(props) {
       oscalUrl={getRequestedUrl() || oscalObjectType.defaultUrl}
       renderer={renderer}
       renderForm={props.renderForm}
+      backendUrl={props.backendUrl}
+      isRestMode={props.isRestMode}
+      setIsRestMode={props.setIsRestMode}
     />
   );
 }
@@ -404,6 +407,9 @@ export function OSCALSSPLoader(props) {
       oscalUrl={getRequestedUrl() || oscalObjectType.defaultUrl}
       renderer={renderer}
       renderForm={props.renderForm}
+      backendUrl={props.backendUrl}
+      isRestMode={props.isRestMode}
+      setIsRestMode={props.setIsRestMode}
     />
   );
 }
@@ -438,6 +444,9 @@ export function OSCALComponentLoader(props) {
       oscalUrl={getRequestedUrl() || oscalObjectType.defaultUrl}
       renderer={renderer}
       renderForm={props.renderForm}
+      backendUrl={props.backendUrl}
+      isRestMode={props.isRestMode}
+      setIsRestMode={props.setIsRestMode}
     />
   );
 }
@@ -471,6 +480,9 @@ export function OSCALProfileLoader(props) {
       oscalUrl={getRequestedUrl() || oscalObjectType.defaultUrl}
       renderer={renderer}
       renderForm={props.renderForm}
+      backendUrl={props.backendUrl}
+      isRestMode={props.isRestMode}
+      setIsRestMode={props.setIsRestMode}
     />
   );
 }

--- a/src/components/OSCALLoaderForm.js
+++ b/src/components/OSCALLoaderForm.js
@@ -24,9 +24,7 @@ export default function OSCALLoaderForm(props) {
   const unmounted = useRef(false);
 
   const findAllObjects = () => {
-    fetch(
-      `${process.env.REACT_APP_REST_BASE_URL}/${props.oscalObjectType.restPath}`
-    )
+    fetch(`${props.backendUrl}/${props.oscalObjectType.restPath}`)
       .then((response) => {
         if (!response.ok) throw new Error(response.status);
         else return response.json();
@@ -118,7 +116,7 @@ export default function OSCALLoaderForm(props) {
             </FormControl>
           </Grid>
         )}
-        {process.env.REACT_APP_REST_BASE_URL && (
+        {!!props.backendUrl && (
           <Grid item xs={2} md={1}>
             <FormControlLabel
               control={

--- a/src/components/OSCALLoaderForm.js
+++ b/src/components/OSCALLoaderForm.js
@@ -116,7 +116,7 @@ export default function OSCALLoaderForm(props) {
             </FormControl>
           </Grid>
         )}
-        {!!props.backendUrl && (
+        {props.backendUrl && (
           <Grid item xs={2} md={1}>
             <FormControlLabel
               control={


### PR DESCRIPTION
This makes the configuration of "rest mode" an app-level configuration
that is a parameter to the library components. This matches with how the
Google Analytics is set; additionally, it means that the environment
variable should be set when building the app and that this isn't a
decision made when compiling the library (so it doesn't have to be set
in the CI pipeline!).
