### PR TITLE
Handle errors during URL fetching

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -10,7 +10,10 @@ export function BasicError(props) {
   const message = props.error.message?.trim();
   return (
     <Alert severity="error">
-      Yikes! Something went wrong loading the OSCAL data. ({message})
+      <details>
+        <summary>Yikes! Something went wrong loading the OSCAL data.</summary>
+        {message}
+      </details>
     </Alert>
   );
 }

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -6,10 +6,11 @@ import Alert from "@material-ui/lab/Alert";
  * message using a Material UI Alert.
  */
 export function BasicError(props) {
+  // Cleanup the message to prevent potential weird spacing around the parenthesis
+  const message = props.error.message?.trim();
   return (
     <Alert severity="error">
-      Yikes! Something went wrong loading the OSCAL data. Sorry, we&apos;ll look
-      into it. ({props.error.message})
+      Yikes! Something went wrong loading the OSCAL data. ({message})
     </Alert>
   );
 }

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,31 +1,57 @@
 import React from "react";
 import Alert from "@material-ui/lab/Alert";
 
-function defaultFormatter(error) {
+/**
+ * A basic FallbackComponent for the {@link ErrorBoundary}. Displays a "yikes"
+ * message using a Material UI Alert.
+ */
+export function BasicError(props) {
   return (
     <Alert severity="error">
       Yikes! Something went wrong loading the OSCAL data. Sorry, we&apos;ll look
-      into it. ({error.message})
+      into it. ({props.error.message})
     </Alert>
   );
 }
 
-class ErrorBoundary extends React.Component {
+/**
+ * Creates a React Error Boundary to ensure that errors are handled and that the
+ * application does not get unmounted.
+ *
+ * The following `props` are accepted (in addition to standard component props):
+ *
+ *  - `FallbackComponent`: The component to used to display the error. A single
+ *    prop will be passed, `error`, containing the error object that was caught.
+ *    This defaults to {@link BasicError}.
+ *  - `onError(error)`: A function to be executed when a function is caught, the
+ *    error passed in is the error that was caught.
+ *
+ * Providing a `key` will cause the boundary to be reset and remounted when the
+ * key changes, as with any React component. This may be useful for allowing the
+ * component to be redrawn.
+ */
+export default class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
-    this.errorFormatter = props.errorFormatter ?? defaultFormatter;
-    this.state = { error: undefined };
+    this.state = {
+      error: undefined,
+    };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
   }
 
   componentDidCatch(error) {
-    this.setState({ error });
+    this.props.onError?.(error);
   }
 
   render() {
     if (this.state.error !== undefined) {
-      return this.errorFormatter(this.state.error);
+      return React.createElement(this.props.FallbackComponent ?? BasicError, {
+        error: this.state.error,
+      });
     }
     return this.props.children || null;
   }
 }
-export default ErrorBoundary;


### PR DESCRIPTION
Because `OSCALLoader` itself is the top-level component that has an
`<ErrorBoundary>` as a child, we cannot rely on the `<ErrorBoundary>` to
catch errors further in the stack. Additionally, Error Boundaries do a
poor job of catching asynchronous errors. Instead, we track error state
(which we did prior to https://github.com/EasyDynamics/oscal-react-library/pull/267, though, this implementation is a little
cleaner as we don't try to pass the `onError` further down the call
stack since we _can_ use the `<ErrorBoundary>` for that.

Since we've refactored the logic to handle the error into its own
(reused) function, it's now also trivial to set the `loaded` and
`isResolutionComplete` variables, which means we can also re-enable the
"Reload" button even after an error.

Resolves https://github.com/EasyDynamics/oscal-react-library/issues/283
Resolves https://github.com/EasyDynamics/oscal-react-library/issues/163