### PR TITLE
Allow unused variables that start with _

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,8 @@
       "react/destructuring-assignment": [0],
       "react/jsx-props-no-spreading": "off",
       "prettier/prettier": "error",
-      "import/no-extraneous-dependencies": ["error", {"packageDir": ["./", "./example"]}]
+      "import/no-extraneous-dependencies": ["error", {"packageDir": ["./", "./example"]}],
+      "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrorsIgnorePattern": "^_" }]
     },
     "overrides": [
         {


### PR DESCRIPTION
This is a common idiom especially in unpacking where only one of the
values is needed. This allows ignoring the underscore itself `_` as well
as names that start with `_` such as `_ignored` or `_foo`.
