### PR TITLE
Dump events for Dependency PR workflow

### DIFF
--- a/.github/workflows/dependency-pr.yml
+++ b/.github/workflows/dependency-pr.yml
@@ -11,6 +11,13 @@ on:
     paths: ["package-lock.json"]
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    name: Debug -- Dump Event
+    steps:
+      - name: Dump GitHub event
+        run: |
+          echo "${{ toJSON(github.event) }}"
   update:
     # If the pull request was closed then nothing needs to be done
     if: github.event.pull_request_target.merged == true


### PR DESCRIPTION
This is just a debug step but we need to merge it because to be included
in the `pull_request_target` workflow, it has to be included on the
default branch. This doesn't fix anything. It does give us more output
to maybe understand how to fix something.
