### PR TITLE
Remove GitHub Super-Linter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,31 +26,18 @@ jobs:
       - name: Install dependencies
         run:
           npm ci && cd example && npm ci && cd ..
-      - name: Lint Code Base
-        # super-linter@v4.4.0 moves to using eslint for JSON files which in
-        # our configuration results in JSON parsing failures. Temporarily,
-        # pinning to @v4.3.0 (using jsonlint) allows validation to succeed
-        uses: github/super-linter@v4
-        env:
-          DEFAULT_BRANCH: develop
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Our linter configuration files will be specified relative to the
-          # root of the workspace (/) rather than within the default directory
-          # (.github/linters)
-          LINTER_RULES_PATH: /
-          JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.json
-          MARKDOWN_CONFIG_FILE: .markdownlint.yaml
-          # A specific subset of linters are enabled
-          VALIDATE_HTML: true
-          VALIDATE_JAVASCRIPT_ES: true
-          VALIDATE_MARKDOWN: true
-          VALIDATE_JSON: true
-          VALIDATE_YAML: true
-          # Ideally, we should validate only changed files; we don't want to
-          # have a PR fail because rules changed outside the PR itself.
-          VALIDATE_ALL_CODEBASE: false
-          # The possum is fun but it does add a little noise to the workflow
-          SUPPRESS_POSSUM: true
+      - name: Install lint dependencies
+        run: |
+          npm install -g markdownlint-cli
+          pip install yamllint
+      - name: Lint code base
+        run: |
+          # Run built-in JavaScript/JSON linting
+          npm run lint
+          # Lint markdown files
+          markdownlint '**/*.md' --ignore node_modules --ignore example/node_modules
+          # Lint YAML files
+          yamllint --format github --config-file .yaml-lint.yml .
   build_and_test:
     strategy:
       matrix:

--- a/.yaml-lint.yml
+++ b/.yaml-lint.yml
@@ -1,0 +1,3 @@
+---
+ignore: |
+  node_modules/

--- a/example/package.json
+++ b/example/package.json
@@ -31,7 +31,10 @@
     "@testing-library/user-event": "file:../node_modules/@testing-library/user-event"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
We've run into issues in the past with the super linter. It evaluates
file one-by-one rather how developers run tests. When run against the
entire codebase it's extremely slow; this causes issues because it means
that configuration changes that may break linting aren't caught (since
rarely do code files get modified at the same time as linting
configuration files). We've had issues with breaking changes in tools
used for linting (such as migrating from jsonlint to eslint).

We lint JSON and JavaScript with `npm run lint`. The only thing we
meaningfully lint outside that is Markdown and YAML. Both of these are
pretty easy to just use the actual tools that Super-Linter is running
anyway.

We might be able to integrate markdownlint into our `npm lint` workflow
but we can't for yamllint (since it's a Python package) so there's not
much value in that as far as I can see.