### PR TITLE
Disable Dependabot PRs for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,6 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: daily
-    reviewers:
-      - "EasyDynamics/easygrc-reviewers"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -4,7 +4,7 @@ name: Update dependencies
 on:
   schedule:
     # Run daily at 12:15 UTC (08:15 EDT/07:15 EST)
-    - cron: 15 12 * * *
+    - cron: "15 12 * * *"
   workflow_dispatch:
 
 # This workflow needs to leverage a GitHub Personal Access Token (PAT) in order


### PR DESCRIPTION
This will not impact PRs for GitHub Actions nor for security alerts.
This can be done because the fix from #359 actually worked.
