### PR TITLE
Trim permissions on GitHub Actions

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -34,4 +34,4 @@ jobs:
           npm ci
           npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,6 +10,8 @@ concurrency: gh-pages
 jobs:
   publish:
     name: Publish Storybook to GitHub Pages
+    permissions:
+      contents: write
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint the code base

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
 
 concurrency: package-repo-release
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Create a New Release


### PR DESCRIPTION
Using fewer permissions increases security (since any action we use can
read the token from the `github.token` context). Security is good. I
need to take another look at this before marking it as ready for review.
