### PR TITLE
Use a GitHub App instead of a PAT in workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -56,7 +56,7 @@ jobs:
         # an output. It _does_ register that token as a secret so that it will be
         # filtered from log output automatically
         id: generate-token
-        uses: tibdex/github-app-token@c95b1c441a4dacd6d24f231b9697a5f9a04c607e
+        uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -51,6 +51,16 @@ jobs:
           npm install
           cd ..
 
+      - name: Login as the automation app
+        # This Action generates a token from the GitHub App and provides it as
+        # an output. It _does_ register that token as a secret so that it will be
+        # filtered from log output automatically
+        id: generate-token
+        uses: tibdex/github-app-token@c95b1c441a4dacd6d24f231b9697a5f9a04c607e
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create update pull request
         uses: peter-evans/create-pull-request@v4
         with:
@@ -64,4 +74,4 @@ jobs:
           base: develop
           committer: Easy Dynamics Automation <noreply@easydynamics.com>
           author: Easy Dynamics Automation <noreply@easydynamics.com>
-          token: "${{ secrets.DEPENDENCY_PR_TOKEN }}"
+          token: "${{ steps.generate-token.outputs.token }}"


### PR DESCRIPTION
A GitHub App is easier for multiple users across the enterprise to
manage _and_ grants access to specific repositories and more finely
scoped permissions than what is possible with a PAT associated with a
user in the organization. We also get to choose a cool name for the app.
This app is named "Easy Dynamics OSCAL Automation" which we can rename
at any time. It currently only has access to this repository; however,
we can trivially grant it access to others.
