### PR TITLE
Pin react-refresh to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10051,15 +10051,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/@storybook/react/node_modules/react-refresh": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@storybook/react/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -11125,9 +11116,9 @@
       "dev": true
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.8",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.8.tgz",
-      "integrity": "sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
+      "integrity": "sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -12349,13 +12340,13 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -17320,9 +17311,9 @@
       }
     },
     "node_modules/es5-shim": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.6.tgz",
-      "integrity": "sha512-Ay5QQE78I2WKUoZVZjL0AIuiIjsmXwZGkyCTH9+n6J1anPbb0ymDA27ASa2Lt0rhOpAlEKy2W0d17gJ1XOQ5eQ==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.7.tgz",
+      "integrity": "sha512-jg21/dmlrNQI7JyyA2w7n+yifSxBng0ZralnSfVZjoCawgNTCnS+yBCyVM9DL5itm7SUnDGgv7hcq2XCZX4iRQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -19195,9 +19186,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
       "funding": [
         {
           "type": "individual",
@@ -29323,10 +29314,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
-      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
-      "peer": true,
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30405,14 +30395,6 @@
       "dependencies": {
         "lodash": "^4.17.20",
         "renderkid": "^3.0.0"
-      }
-    },
-    "node_modules/react-scripts/node_modules/react-refresh": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-scripts/node_modules/renderkid": {
@@ -43915,7 +43897,7 @@
         "global": "^4.4.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2",
-        "react-refresh": "^0.11.0",
+        "react-refresh": "0.11.0",
         "read-pkg-up": "^7.0.1",
         "regenerator-runtime": "^0.13.7",
         "ts-dedent": "^2.0.0",
@@ -44287,12 +44269,6 @@
           "requires": {
             "minimist": "^1.2.6"
           }
-        },
-        "react-refresh": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-          "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -45179,9 +45155,9 @@
       "dev": true
     },
     "@types/http-proxy": {
-      "version": "1.17.8",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.8.tgz",
-      "integrity": "sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
+      "integrity": "sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==",
       "requires": {
         "@types/node": "*"
       }
@@ -46211,13 +46187,13 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -50068,9 +50044,9 @@
       }
     },
     "es5-shim": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.6.tgz",
-      "integrity": "sha512-Ay5QQE78I2WKUoZVZjL0AIuiIjsmXwZGkyCTH9+n6J1anPbb0ymDA27ASa2Lt0rhOpAlEKy2W0d17gJ1XOQ5eQ==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.7.tgz",
+      "integrity": "sha512-jg21/dmlrNQI7JyyA2w7n+yifSxBng0ZralnSfVZjoCawgNTCnS+yBCyVM9DL5itm7SUnDGgv7hcq2XCZX4iRQ==",
       "dev": true
     },
     "es6-promisify": {
@@ -51483,9 +51459,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -59233,10 +59209,9 @@
       }
     },
     "react-refresh": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
-      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
-      "peer": true
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
       "version": "6.3.0",
@@ -59295,7 +59270,7 @@
         "prompts": "^2.4.2",
         "react-app-polyfill": "^3.0.0",
         "react-dev-utils": "^12.0.1",
-        "react-refresh": "^0.11.0",
+        "react-refresh": "0.11.0",
         "resolve": "^1.20.0",
         "resolve-url-loader": "^4.0.0",
         "sass-loader": "^12.3.0",
@@ -59882,11 +59857,6 @@
             "lodash": "^4.17.20",
             "renderkid": "^3.0.0"
           }
-        },
-        "react-refresh": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-          "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
         },
         "renderkid": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,9 @@
     "prettier": "^2.6.2",
     "webpack": "^5.72.0"
   },
+  "overrides": {
+    "react-refresh": "0.11.0"
+  },
   "files": [
     "dist"
   ]


### PR DESCRIPTION
When there are conflicting versions of `react-refresh`, `npm run start`
seems to lose its mind (well, not that command directly but something
way deep down in `react-scripts` that's responsible for actually running
the dev server).

For now, let's pin it to 0.11.0 so that people can actually develop and
work. And we can evaluate removing this. The conflicting version that
seems to be coming up at the moment is 0.13.0. We probably could have
picked that version too but this is what most the app was resolving and
so that feels safer.
