### PR TITLE
Support editing metadata for all document types

### DIFF
--- a/src/components/OSCALCatalog.js
+++ b/src/components/OSCALCatalog.js
@@ -10,9 +10,20 @@ export default function OSCALCatalog(props) {
   const classes = useLoaderStyles();
   props.onResolutionComplete();
 
+  const partialRestData = {
+    catalog: {
+      uuid: props.catalog.uuid,
+    },
+  };
+
   return (
     <div className={classes.paper}>
-      <OSCALMetadata metadata={props.catalog.metadata} />
+      <OSCALMetadata
+        metadata={props.catalog.metadata}
+        isEditable={props.isEditable}
+        onFieldSave={props.onFieldSave}
+        patchData={partialRestData}
+      />
       <List
         subheader={
           <ListSubheader

--- a/src/components/OSCALCatalog.js
+++ b/src/components/OSCALCatalog.js
@@ -22,7 +22,7 @@ export default function OSCALCatalog(props) {
         metadata={props.catalog.metadata}
         isEditable={props.isEditable}
         onFieldSave={props.onFieldSave}
-        patchData={partialRestData}
+        partialRestData={partialRestData}
       />
       <List
         subheader={

--- a/src/components/OSCALComponentDefinition.js
+++ b/src/components/OSCALComponentDefinition.js
@@ -14,6 +14,12 @@ export default function OSCALComponentDefinition(props) {
     useState({});
   const classes = useLoaderStyles();
 
+  const partialRestData = {
+    "component-definition": {
+      uuid: props.componentDefinition.uuid,
+    },
+  };
+
   useEffect(() => {
     OSCALComponentResolveSources(
       props.componentDefinition,
@@ -54,7 +60,12 @@ export default function OSCALComponentDefinition(props) {
 
   return (
     <div className={classes.paper}>
-      <OSCALMetadata metadata={props.componentDefinition.metadata} />
+      <OSCALMetadata
+        metadata={props.componentDefinition.metadata}
+        isEditable={props.isEditable}
+        onFieldSave={props.onFieldSave}
+        patchData={partialRestData}
+      />
       <OSCALProfileCatalogInheritance
         inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs}
       />

--- a/src/components/OSCALComponentDefinition.js
+++ b/src/components/OSCALComponentDefinition.js
@@ -68,7 +68,7 @@ export default function OSCALComponentDefinition(props) {
         metadata={props.componentDefinition.metadata}
         isEditable={props.isEditable}
         onFieldSave={props.onFieldSave}
-        patchData={partialRestData}
+        partialRestData={partialRestData}
       />
       <OSCALProfileCatalogInheritance
         inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs}

--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -350,6 +350,7 @@ export function OSCALCatalogLoader(props) {
   ) => (
     <OSCALCatalog
       catalog={oscalData[oscalObjectType.jsonRootName]}
+      isEditable={isRestMode}
       parentUrl={oscalUrl}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(data, editedField, newValue) => {
@@ -425,6 +426,7 @@ export function OSCALComponentLoader(props) {
   ) => (
     <OSCALComponentDefinition
       componentDefinition={oscalData[oscalObjectType.jsonRootName]}
+      isEditable={isRestMode}
       parentUrl={oscalUrl}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(data, editedField, newValue) => {
@@ -461,6 +463,7 @@ export function OSCALProfileLoader(props) {
   ) => (
     <OSCALProfile
       profile={oscalData[oscalObjectType.jsonRootName]}
+      isEditable={isRestMode}
       parentUrl={oscalUrl}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(data, editedField, newValue) => {

--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -119,7 +119,7 @@ export default function OSCALProfile(props) {
         metadata={props.profile.metadata}
         isEditable={props.isEditable}
         onFieldSave={props.onFieldSave}
-        patchData={partialRestData}
+        partialRestData={partialRestData}
       />
       <OSCALProfileCatalogInheritance
         inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs}

--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -26,6 +26,12 @@ export default function OSCALProfile(props) {
   const classes = useLoaderStyles();
   const unmounted = useRef(false);
 
+  const partialRestData = {
+    profile: {
+      uuid: props.profile.uuid,
+    },
+  };
+
   // Resolved profile using oscal-utils. Provides error when failure.
   useEffect(() => {
     OSCALResolveProfile(
@@ -104,7 +110,12 @@ export default function OSCALProfile(props) {
   // Display Metadata and BackMatter components at bottom of Profile
   return (
     <div className={classes.paper}>
-      <OSCALMetadata metadata={props.profile.metadata} />
+      <OSCALMetadata
+        metadata={props.profile.metadata}
+        isEditable={props.isEditable}
+        onFieldSave={props.onFieldSave}
+        patchData={partialRestData}
+      />
       <OSCALProfileCatalogInheritance
         inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs}
       />

--- a/src/stories/OSCALMetadata.stories.js
+++ b/src/stories/OSCALMetadata.stories.js
@@ -18,10 +18,21 @@ export const Default = Template.bind({});
 
 export const WithPartiesAndRoles = Template.bind({});
 
+export const Editable = Template.bind({});
+
 Default.args = {
   metadata: exampleMetadata,
 };
 
 WithPartiesAndRoles.args = {
   metadata: exampleMetadataWithPartiesAndRoles,
+};
+
+function nop() {}
+
+Editable.args = {
+  metadata: exampleMetadata,
+  isEditable: true,
+  onFieldSave: nop,
+  partialRestData: { topLevel: { uuid: "" } },
 };

--- a/src/stories/OSCALMetadata.stories.js
+++ b/src/stories/OSCALMetadata.stories.js
@@ -28,11 +28,9 @@ WithPartiesAndRoles.args = {
   metadata: exampleMetadataWithPartiesAndRoles,
 };
 
-function nop() {}
-
 Editable.args = {
   metadata: exampleMetadata,
   isEditable: true,
-  onFieldSave: nop,
-  partialRestData: { topLevel: { uuid: "" } },
+  onFieldSave: () => {},
+  partialRestData: { "top-level": { uuid: "" } },
 };


### PR DESCRIPTION
This allows editing metadata for each of the existing document types.
Because the metadata is a totally shared (and root) object and because
all the base objects server-side support a `PATCH` operation, this is a
pretty easy change to patch in. All other changes have to be made via
the JSON editor.

This _is not_ yet ready to be merged. It is going to have conflicts
(well, conflicts really are the best case; more likely, this will
silently break) with other open PRs but this gives a starting point for
making the modifications.

Eventually, we can probably patch through a few other editable types
from an SSP to other documents that reuse those components. But again,
this is easy and its available now so I figured why not go for it.
