### PR TITLE
Fix URL generated for Implemented Requirements API

### DIFF
--- a/src/components/oscal-utils/OSCALRestUtils.js
+++ b/src/components/oscal-utils/OSCALRestUtils.js
@@ -232,7 +232,7 @@ export function createOrUpdateSspControlImplementationImplementedRequirementStat
   performRequest(
     { "implemented-requirement": partialRestImplementedRequirement },
     restMethods.PUT,
-    requestUrl,
+    buildRequestUrl(null, requestUrl, null),
     onPreRestRequest,
     onSuccess,
     onError


### PR DESCRIPTION
We were failing to take into consideration the REST URL base so all
calls were relative to `/` which doesn't work. This makes sure the base
is at least considered. There may be a cleaner way to do this that
doesn't require passing `null` around as much but this at least re-uses
the function.

The primary situation this bug is noticeable is running the Editor app
and the server on different hosts/ports (for example, running the server
directly instead of in the Docker container) and running a local dev
version of the editor. So it's a niche case but one that comes up in
development situations.