### PR TITLE
Automate release workflows

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -10,29 +10,30 @@ concurrency: package-push
 
 jobs:
   publish:
-    name: Publish OSCAL Viewer Build to GitHub Packages
-    runs-on: ubuntu-20.04
+    name: Publish OSCAL Viewer Build to NPM and GitHub Packages
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - name: Delete previous oscal-react-library version
-        uses: actions/delete-package-versions@v3
-        with:
-          package-name: oscal-react-library
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Setup NodeJS
+      - name: Setup Node.js for NPM publish
         uses: actions/setup-node@v3
         with:
-          node-version: 14
-          registry-url: https://npm.pkg.github.com/
-          cache: npm
-      - name: Update Npm
-        run: npm install -g npm@latest
-      - name: Build and Publish Library
-        run: |
-          npm ci
-          npm publish
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install depdendencies
+        run: npm ci
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Reconfigure Node.js for GitHub Packages publish
+        uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+      - name: Publish to GitHub Packages
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -2,7 +2,8 @@
 name: Publish to GitHub Packages
 on:
   push:
-    branches: [develop]
+    tags:
+      - "v*"
   workflow_dispatch:
 
 concurrency: package-push

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,5 +1,5 @@
 ---
-name: Publish to GitHub Packages
+name: Publish NPM Packages
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: develop
-          token: steps.generate_token.outputs.token
+          token: steps.generate-token.outputs.token
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 ---
 name: Create a New Release
 on:
-  push:
-    branches: [EGRC-492-package]
   workflow_dispatch:
     inputs:
       release-type:
@@ -21,20 +19,38 @@ permissions:
 jobs:
   release:
     name: Create a New Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      # Check out develop branch
+      - name: Login as the automation app
+        # This Action generates a token from the GitHub App and provides it as
+        # an output. It _does_ register that token as a secret so that it will be
+        # filtered from log output automatically
+        id: generate-token
+        uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
           ref: develop
+          token: steps.generate_token.outputs.token
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 14
-          registry-url: https://npm.pkg.github.com/
+          node-version: "lts/*"
           cache: npm
+
+      - name: Set release type to patch
+        if: ${{ github.event.inputs.release-type == 'bug' }}
+        run:
+          echo 'NPM_RELEASE_TYPE=patch' >> $GITHUB_ENV
+      - name: Set release type to minor
+        if: ${{ github.event.inputs.release-type == 'feature' }}
+        run:
+          echo 'NPM_RELEASE_TYPE=minor' >> $GITHUB_ENV
 
       - name: Update Npm
         run: npm install -g npm@latest
@@ -42,24 +58,31 @@ jobs:
       - name: Set Up Git User Info
         run: |
           git config --global user.email "info@easydynamics.com"
-          git config --global user.name "${{ github.actor }}"
+          git config --global user.name "Easy Dynamics Automation"
+
+      # This is needed so that we can handle the situation where other
+      # fixes have been applied to main and since we also need to push to
+      # develop, we can't rewrite history
+      - name: Pull the main branch and merge it into develop
+        run: |
+          git pull origin main --no-rebase
 
       # Increment the version to the next minor release
-      - name: Set Version (Feature)
-        if: ${{ github.event.inputs.release-type  == 'feature' }}
+      # We install to update the example app's lock file to reference
+      # the new version of the library.
+      - name: Bump version 
         run: |
-          npm version minor
+          npm version $NPM_RELEASE_TYPE
           cd example
-          npm version minor
+          npm version $NPM_RELEASE_TYPE
+          npm install
 
-      # Increment the version to the next bug fix
-      # Push the new version to the develop branch
-      - name: Set Version (Bug Fix)
-        #if: ${{ github.event.inputs.release-type == 'bug' }}
+      - name: Push release commit to develop main
         run: |
-          npm version patch
-          cd example
-          npm version patch
+          git add ./{,example/}package{,-lock}.json
+          git commit -m "Release v${{ env.PKG_VERSION }}"
+          git push origin develop
+          git push origin develop:main
 
       # Output the new package version to environment variable
       - name: Get Package Version
@@ -72,27 +95,26 @@ jobs:
           cd example
           npm ci
           npm run build
-          zip -r viewer.zip ./build/
+          zip -r oscal-viewer.zip ./build/
 
       - name: Create a GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name:
-            ${{ env.PKG_VERSION }}
+          generate_release_notes: true
+          tag_name: v${{ env.PKG_VERSION }}
           files:
-            example/viewer.zip
+            example/oscal-viewer.zip
 
       # Commit the new version and push changes to main
-      # And push a new preminor version to develop.
-      # Should only run when triggered for a feature - for bug fixes
-      # this should be done manually since a merge might be needed.
-      - name: Push Changes
-        if: ${{ github.event.inputs.release-type  == 'feature' }}
+      # And push a new prepatch version to develop. We assume prepatch
+      # because we're going into develop and devs can always change this if
+      # needed. But this means we push "x.y.(z+1)-0" instead of "x.(y+1).0-0".
+      # This _does not_ get pushed to main
+      - name: Start work on the next version
         run: |
-          git push origin develop:main
-          git add ./{,example/}package{,-lock}.json
-          git commit -m "Build Viewer for Release ${{ env.PKG_VERSION }}"
-          npm version preminor
+          npm version prepatch
           cd example
-          npm version preminor
+          npm version patch
+          git add ./{,example/}package{,-lock}.json
+          git commit -m "Bump version to v$(npm pkg get version | tr -d '"')"
           git push origin develop


### PR DESCRIPTION
This refactors our release workflow to always pull in main and then push to both `main` and `develop`. `develop` will also get a bump to the _next_ prepatch version. Then, we add support to publish to both GitHub Packages and to NPM.

This is a [new feature](https://github.blog/changelog/2022-05-17-consistently-allow-github-apps-as-exceptions-to-branch-protection-rules/) for branch protection rules.