### PR TITLE
Implemented REST success, existing param handling

### DIFF
--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -139,9 +139,9 @@ export default function OSCALLoader(props) {
     loadOscalData(newOscalUrl);
   };
 
-  const handleReloadClick = () => {
+  const handleReload = (isForced) => {
     // Only reload if we're done loading
-    if (isLoaded && isResolutionComplete) {
+    if (isForced || (isLoaded && isResolutionComplete)) {
       setIsLoaded(false);
       setIsResolutionComplete(false);
       setReloadCount((current) => current + 1);
@@ -183,6 +183,10 @@ export default function OSCALLoader(props) {
     );
   };
 
+  const handleRestSuccess = () => {
+    handleReload(true);
+  };
+
   const onResolutionComplete = () => {
     setIsResolutionComplete(true);
   };
@@ -206,7 +210,7 @@ export default function OSCALLoader(props) {
         oscalUrl={oscalUrl}
         onUrlChange={handleUrlChange}
         onUuidChange={handleUuidChange}
-        onReloadClick={handleReloadClick}
+        onReloadClick={handleReload}
         isRestMode={isRestMode}
         onChangeRestMode={handleChangeRestMode}
         isResolutionComplete={isResolutionComplete}
@@ -255,6 +259,7 @@ export default function OSCALLoader(props) {
               oscalUrl,
               onResolutionComplete,
               handleFieldSave,
+              handleRestSuccess,
               handleRestError
             )}
           </Box>
@@ -267,7 +272,9 @@ export default function OSCALLoader(props) {
           oscalData,
           oscalUrl,
           onResolutionComplete,
-          handleFieldSave
+          handleFieldSave,
+          handleRestSuccess,
+          handleRestError
         )}
       </>
     );
@@ -306,7 +313,9 @@ export function OSCALCatalogLoader(props) {
     oscalData,
     oscalUrl,
     onResolutionComplete,
-    handleFieldSave
+    handleFieldSave,
+    handleRestSuccess,
+    handleRestError
   ) => (
     <OSCALCatalog
       catalog={oscalData[oscalObjectType.jsonRootName]}
@@ -328,6 +337,10 @@ export function OSCALCatalogLoader(props) {
           restUrlPath,
           oscalObjectType
         );
+      }}
+      onRestSuccess={handleRestSuccess}
+      onRestError={(error) => {
+        handleRestError(error);
       }}
     />
   );
@@ -352,6 +365,7 @@ export function OSCALSSPLoader(props) {
     oscalUrl,
     onResolutionComplete,
     handleFieldSave,
+    handleRestSuccess,
     handleRestError
   ) => (
     <OSCALSsp
@@ -375,7 +389,7 @@ export function OSCALSSPLoader(props) {
           oscalObjectType
         );
       }}
-      onRestSuccess={() => {}}
+      onRestSuccess={handleRestSuccess}
       onRestError={(error) => {
         handleRestError(error);
       }}
@@ -401,7 +415,9 @@ export function OSCALComponentLoader(props) {
     oscalData,
     oscalUrl,
     onResolutionComplete,
-    handleFieldSave
+    handleFieldSave,
+    handleRestSuccess,
+    handleRestError
   ) => (
     <OSCALComponentDefinition
       componentDefinition={oscalData[oscalObjectType.jsonRootName]}
@@ -423,6 +439,10 @@ export function OSCALComponentLoader(props) {
           restUrlPath,
           oscalObjectType
         );
+      }}
+      onRestSuccess={handleRestSuccess}
+      onRestError={(error) => {
+        handleRestError(error);
       }}
     />
   );
@@ -446,7 +466,9 @@ export function OSCALProfileLoader(props) {
     oscalData,
     oscalUrl,
     onResolutionComplete,
-    handleFieldSave
+    handleFieldSave,
+    handleRestSuccess,
+    handleRestError
   ) => (
     <OSCALProfile
       profile={oscalData[oscalObjectType.jsonRootName]}
@@ -468,6 +490,10 @@ export function OSCALProfileLoader(props) {
           restUrlPath,
           oscalObjectType
         );
+      }}
+      onRestSuccess={handleRestSuccess}
+      onRestError={(error) => {
+        handleRestError(error);
       }}
     />
   );

--- a/src/components/oscal-utils/OSCALRestUtils.js
+++ b/src/components/oscal-utils/OSCALRestUtils.js
@@ -220,9 +220,23 @@ export function createOrUpdateSspControlImplementationImplementedRequirementStat
   // Set each implementation parameter
   if (implementationSetParameters?.length) {
     statementByComponent["set-parameters"] ??= [];
-    statementByComponent["set-parameters"].push(
-      ...implementationSetParameters.filter((element) => !!element)
-    );
+    implementationSetParameters
+      .filter((element) => !!element)
+      .forEach((implementationSetParameter) => {
+        const foundExistingSetParam = statementByComponent[
+          "set-parameters"
+        ].find(
+          (element) =>
+            element["param-id"] === implementationSetParameter["param-id"]
+        );
+        if (foundExistingSetParam) {
+          foundExistingSetParam.values = implementationSetParameter.values;
+        } else {
+          statementByComponent["set-parameters"].push(
+            implementationSetParameter
+          );
+        }
+      });
   }
 
   const rootUuid = partialRootRestData[oscalObjectTypes.ssp.jsonRootName].uuid;


### PR DESCRIPTION
Creates a `handleRestSuccess` function and sends that to OSCAL root object renderers as the `onRestSuccess` property.  In the case of `OSCALSsp` that is passed down to `OSCALControlProse` and subsequently `OSCALRestUtils` which executes it on success.

For now the `handleRestSuccess` simply reloads the entire page.  In the future we'll likely want to investigate better re-rendering of specific components.

This also resolves an issue where the `set-parameters` were being added to the `implementedRequirements` object rather than replacing an existing one.