### PR TITLE
Add missing install command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,11 @@ jobs:
       - name: Bump version 
         run: |
           npm version $NPM_RELEASE_TYPE
+          npm install
           cd example
           npm version $NPM_RELEASE_TYPE
           npm install
+          cd ..
 
       - name: Build OSCAL Viewer
         run: |


### PR DESCRIPTION
The example app uses a script from the root package so we need to make
sure to install the root package's dependencies too.
