### PR TITLE
Fix issues when loading NIST 800-53 r5 profiles

### DIFF
--- a/src/components/OSCALProfile.js
+++ b/src/components/OSCALProfile.js
@@ -80,8 +80,8 @@ export default function OSCALProfile(props) {
           <OSCALControl
             control={control}
             includeControlIds={includeControlIds}
-            modificationAlters={props.profile.modify.alters}
-            modificationSetParameters={props.profile.modify["set-parameters"]}
+            modificationAlters={props.profile.modify?.alters}
+            modificationSetParameters={props.profile.modify?.["set-parameters"]}
             restData={{
               profile: {
                 uuid: props.profile.uuid,

--- a/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/src/components/oscal-utils/OSCALProfileResolver.js
@@ -1,4 +1,4 @@
-import resolveLinkHref from "./OSCALLinkUtils";
+import resolveLinkHref, { fixJsonUrls } from "./OSCALLinkUtils";
 
 const OSCAL_MEDIA_TYPE_REGEX = /^application\/oscal.*\+json$/;
 /**
@@ -52,6 +52,7 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
   if (itemUrl.includes("/content/fedramp.gov/")) {
     itemUrl = itemUrl.replace("/content/fedramp.gov/", "/fedramp.gov/");
   }
+  itemUrl = fixJsonUrls(itemUrl);
   // Add our current itemUrl to the list of pending processes
   pendingProcesses.push(itemUrl);
   fetch(itemUrl)


### PR DESCRIPTION
When attempting to load the NIST 800-53 rev5 profiles from https://github.com/usnistgov/oscal-content/tree/main/nist.gov/SP800-53/rev5/json, there are two issues that I noticed:
1. The profile still references a `.xml` catalog but in a way that we don't automatically fixup
2. Our application assumes that `profile.modify` will be defined and it is not required in the spec

This (hopefully) fixes both of these issues so that we can load the r5 profiles.