### PR TITLE
Exit Editable Text Field edit state on escape key press

### DIFF
--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -27,6 +27,11 @@ function textFieldWithEditableActions(
               size={props.textFieldSize}
               defaultValue={props.value}
               variant={props.textFieldVariant}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setInEditState(false);
+                }
+              }}
             />
           </Typography>
         </Grid>


### PR DESCRIPTION
As #270 states, we want to improve the usability of the OSCALEditableTextField. Part of the improvements require whenever that component is in an edit state, we want to exit the edit state when the escape key is pressed.

closes #431 