### PR TITLE
Handle Save on Enter Key

### DIFF
--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -31,13 +31,13 @@ function textFieldWithEditableActions(
                 if (event.key === "Escape") {
                   setInEditState(false);
                 } else if (event.key === "Enter") {
+                  event.preventDefault()
                   props.onFieldSave(
                     props.appendToLastFieldInPath,
                     props.partialRestData,
                     props.editedField,
                     reference.current.value
                     );
-                    event.preventDefault()
                     setInEditState(false);
                   }
               }}

--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -4,7 +4,6 @@ import { Grid, TextField } from "@mui/material";
 import OSCALEditableFieldActions, {
   getElementLabel,
 } from "./OSCALEditableFieldActions";
-import { StaticDatePicker } from "@mui/lab";
 
 function textFieldWithEditableActions(
   props,

--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -31,15 +31,15 @@ function textFieldWithEditableActions(
                 if (event.key === "Escape") {
                   setInEditState(false);
                 } else if (event.key === "Enter") {
-                  event.preventDefault()
+                  event.preventDefault();
                   props.onFieldSave(
                     props.appendToLastFieldInPath,
                     props.partialRestData,
                     props.editedField,
                     reference.current.value
-                    );
-                    setInEditState(false);
-                  }
+                  );
+                  setInEditState(false);
+                }
               }}
             />
           </Typography>

--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -36,9 +36,10 @@ function textFieldWithEditableActions(
                     props.partialRestData,
                     props.editedField,
                     reference.current.value
-                  );
-                  setInEditState(false);
-                }
+                    );
+                    event.preventDefault()
+                    setInEditState(false);
+                  }
               }}
             />
           </Typography>

--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -26,23 +26,22 @@ function textFieldWithEditableActions(
               }}
               inputRef={reference}
               size={props.textFieldSize}
-              defaultValue={props.value} 
+              defaultValue={props.value}
               variant={props.textFieldVariant}
               onKeyDown={(event) => {
                 if (event.key === "Escape") {
                   setInEditState(false);
-                }
-                else if(event.key === "Enter"){
+                } else if (event.key === "Enter") {
                   props.onFieldSave(
-                   props.appendToLastFieldInPath,
-                   props.partialRestData,
-                   props.editedField,
-                   reference.current.value
+                    props.appendToLastFieldInPath,
+                    props.partialRestData,
+                    props.editedField,
+                    reference.current.value
                   );
-                   setInEditState(false);
-             
-              }
-            }}/>
+                  setInEditState(false);
+                }
+              }}
+            />
           </Typography>
         </Grid>
         <Grid item>

--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -4,6 +4,7 @@ import { Grid, TextField } from "@mui/material";
 import OSCALEditableFieldActions, {
   getElementLabel,
 } from "./OSCALEditableFieldActions";
+import { StaticDatePicker } from "@mui/lab";
 
 function textFieldWithEditableActions(
   props,
@@ -25,14 +26,23 @@ function textFieldWithEditableActions(
               }}
               inputRef={reference}
               size={props.textFieldSize}
-              defaultValue={props.value}
+              defaultValue={props.value} 
               variant={props.textFieldVariant}
               onKeyDown={(event) => {
                 if (event.key === "Escape") {
                   setInEditState(false);
                 }
-              }}
-            />
+                else if(event.key === "Enter"){
+                  props.onFieldSave(
+                   props.appendToLastFieldInPath,
+                   props.partialRestData,
+                   props.editedField,
+                   reference.current.value
+                  );
+                   setInEditState(false);
+             
+              }
+            }}/>
           </Typography>
         </Grid>
         <Grid item>


### PR DESCRIPTION
Allows user to save the state of the text field when pressing the Enter key to save changes

This closes #424 and #270

Discussion Question:
I noticed that the save button keeps the changes for any text box. I was wondering whether 
we should implement a way to keep track of previous entries for the text box because
the text box can be prone to accidental saves where a user can save the textbox value 
unintentionally and lose the data from the text box due to the save.

This could be a potential problem if a text box needs to be reverted to a previous 
text value.
