### PR TITLE
Auto-assign reviewers only on ready-for-review PRs

### DIFF
--- a/.github/workflows/triage-pr.yml
+++ b/.github/workflows/triage-pr.yml
@@ -45,7 +45,8 @@ jobs:
             const query = `query($owner:String!, $name:String!, $number:Int!) {
               repository(owner:$owner, name:$name) {
                 pullRequest(number:$number) {
-                  reviewDecision
+                  reviewDecision,
+                  isDraft
                 }
               }
             }`;
@@ -59,12 +60,13 @@ jobs:
             const decision = result.repository.pullRequest.reviewDecision;
             console.log(`Review Decision: ${decision}`);
             core.setOutput("review-decision", decision);
+            core.setOutput("is-draft", result.repository.pullRequest.isDraft);
       - name: Generate token from App
         # Only authenticate as the application if a review is still required. If the review
         # criteria have been met then there's not much point in requesting another review and
         # it will just generate unnecessary noise. Additionally, we really want to use the
         # app's elevated permissions as infrequently as possible.
-        if: steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
+        if: steps.pr-reviews.outputs.is-draft == false && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
         id: generate_token
         uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe
         with:
@@ -72,7 +74,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Assign reviewers
         uses: actions/github-script@v6
-        if: ${{ github.event.pull_request.draft == false && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED' }}
+        if: steps.pr-reviews.outputs.is-draft == false && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |

--- a/.github/workflows/triage-pr.yml
+++ b/.github/workflows/triage-pr.yml
@@ -67,7 +67,7 @@ jobs:
         # criteria have been met then there's not much point in requesting another review and
         # it will just generate unnecessary noise. Additionally, we really want to use the
         # app's elevated permissions as infrequently as possible.
-        if: steps.pr-reviews.outputs.is-draft == false && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
+        if: steps.pr-reviews.outputs.is-draft == 'false' && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
         id: generate_token
         uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe
         with:
@@ -75,7 +75,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Assign reviewers
         uses: actions/github-script@v6
-        if: steps.pr-reviews.outputs.is-draft == false && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
+        if: steps.pr-reviews.outputs.is-draft == 'false' && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |

--- a/.github/workflows/triage-pr.yml
+++ b/.github/workflows/triage-pr.yml
@@ -72,7 +72,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Assign reviewers
         uses: actions/github-script@v6
-        if: steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
+        if: ${{ github.event.pull_request.draft == false && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED' }}
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |

--- a/.github/workflows/triage-pr.yml
+++ b/.github/workflows/triage-pr.yml
@@ -7,6 +7,7 @@ on:
     types:
       - opened
       - reopened
+      - ready_for_review
 
 env:
   DEFAULT_REVIEW_TEAM: "easygrc-reviewers"


### PR DESCRIPTION
This updates the triage-pr workflow to ensure that reviewers will only be
assigned to prs that are not a draft.
