### PR TITLE
Add aria label to OSCALEditableTextField

### DIFF
--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -17,6 +17,7 @@ function textFieldWithEditableActions(
         <Grid item xs={props.size} className={props.className}>
           <Typography>
             <TextField
+              aria-label="Text"
               fullWidth
               inputProps={{
                 "data-testid": `textField-${getElementLabel(

--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -17,7 +17,7 @@ function textFieldWithEditableActions(
         <Grid item xs={props.size} className={props.className}>
           <Typography>
             <TextField
-              aria-label="Text"
+              label={props.fieldName}
               fullWidth
               inputProps={{
                 "data-testid": `textField-${getElementLabel(

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -68,6 +68,7 @@ export default function OSCALMetadata(props) {
       <Grid item xs={12}>
         <OSCALMetadataTitle container direction="row" alignItems="center">
           <OSCALEditableTextField
+            fieldName="Title"
             canEdit={props.isEditable}
             editedField={
               props.isEditable
@@ -135,6 +136,7 @@ export default function OSCALMetadata(props) {
                   </OSCALMetadataLabel>
                 </OSCALMetadataKey>
                 <OSCALEditableTextField
+                  fieldName="Version"
                   canEdit={props.isEditable}
                   editedField={
                     props.isEditable


### PR DESCRIPTION
To increase user accessability it is important to have aria lables
