### PR TITLE
Eliminate all descendant of <p> warnings

### DIFF
--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -447,17 +447,15 @@ export function OSCALReplacedProseWithByComponentParameterValue(props) {
   return (
     <OSCALStatementEditing container spacing={2}>
       <Grid item xs={11}>
-        <Typography className={props.className}>
-          <StyledTooltip
-            title={statementByComponentDescription ?? props.componentId}
-          >
-            <Link underline="hover" href={`#${props.label}`}>
-              {props.label}
-            </Link>
-          </StyledTooltip>
-          {proseDisplay}
-          {props.modificationDisplay}
-        </Typography>
+        <StyledTooltip
+          title={statementByComponentDescription ?? props.componentId}
+        >
+          <Link underline="hover" href={`#${props.label}`}>
+            {props.label}
+          </Link>
+        </StyledTooltip>
+        {proseDisplay}
+        {props.modificationDisplay}
       </Grid>
       <OSCALStatementEditControlsContainer item xs={1}>
         {props.isEditable && !isEditingStatement ? (

--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -15,35 +15,31 @@ function textFieldWithEditableActions(
     return (
       <>
         <Grid item xs={props.size} className={props.className}>
-          <Typography>
-            <TextField
-              label={props.fieldName}
-              fullWidth
-              inputProps={{
-                "data-testid": `textField-${getElementLabel(
-                  props.editedField
-                )}`,
-              }}
-              inputRef={reference}
-              size={props.textFieldSize}
-              defaultValue={props.value}
-              variant={props.textFieldVariant}
-              onKeyDown={(event) => {
-                if (event.key === "Escape") {
-                  setInEditState(false);
-                } else if (event.key === "Enter") {
-                  event.preventDefault();
-                  props.onFieldSave(
-                    props.appendToLastFieldInPath,
-                    props.partialRestData,
-                    props.editedField,
-                    reference.current.value
-                  );
-                  setInEditState(false);
-                }
-              }}
-            />
-          </Typography>
+          <TextField
+            label={props.fieldName}
+            fullWidth
+            inputProps={{
+              "data-testid": `textField-${getElementLabel(props.editedField)}`,
+            }}
+            inputRef={reference}
+            size={props.textFieldSize}
+            defaultValue={props.value}
+            variant={props.textFieldVariant}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                setInEditState(false);
+              } else if (event.key === "Enter") {
+                event.preventDefault();
+                props.onFieldSave(
+                  props.appendToLastFieldInPath,
+                  props.partialRestData,
+                  props.editedField,
+                  reference.current.value
+                );
+                setInEditState(false);
+              }
+            }}
+          />
         </Grid>
         <Grid item>
           <OSCALEditableFieldActions


### PR DESCRIPTION
This will eliminate all descendant of `<p>` related console warnings. To deal
with this issue, there were a couple places where `Typography` tags were
deleted. After running the tests and looking at the viewer, I am fairly certain
it did not break anything. But it would be good to double check that. 

This will close #426
