### PR TITLE
Eliminate warnings in OSCAL Viewer

### DIFF
--- a/src/components/OSCALCatalog.js
+++ b/src/components/OSCALCatalog.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import List from "@mui/material/List";
 import ListSubheader from "@mui/material/ListSubheader";
 import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
@@ -7,7 +7,7 @@ import OSCALCatalogGroup from "./OSCALCatalogGroup";
 import OSCALBackMatter from "./OSCALBackMatter";
 
 export default function OSCALCatalog(props) {
-  props.onResolutionComplete();
+  useEffect(props.onResolutionComplete);
 
   const partialRestData = {
     catalog: {

--- a/src/components/OSCALLoaderForm.js
+++ b/src/components/OSCALLoaderForm.js
@@ -20,6 +20,7 @@ const OSCALDocumentForm = styled("form")(
 
 export default function OSCALLoaderForm(props) {
   const [oscalObjects, setOscalObjects] = useState([]);
+  const [selectedUuid, setSelectedUuid] = useState("");
   const unmounted = useRef(false);
 
   const findAllObjects = () => {
@@ -95,7 +96,11 @@ export default function OSCALLoaderForm(props) {
                 labelId="oscal-object-select-label"
                 id="oscal-object-simple-select"
                 label={`Select OSCAL ${props.oscalObjectType.name}`}
-                onChange={props.onUuidChange}
+                value={selectedUuid}
+                onChange={(event) => {
+                  setSelectedUuid(event.target.value);
+                  props.onUuidChange(event);
+                }}
               >
                 {oscalObjects?.map((oscalObject) => (
                   <MenuItem


### PR DESCRIPTION
This removes all warnings in the viewer. The issues in the viwer stemmed from
issues with how we handle state and places where we did not use `useEffect()`.

Hopefully after this pr, future pr's will not allow more warnings into the
viewer.

This will close #446
