### PR TITLE
Create Usability Tests for OSCALEditableTextField

### DIFF
--- a/src/components/OSCALEditableTextField.test.js
+++ b/src/components/OSCALEditableTextField.test.js
@@ -25,7 +25,7 @@ export default function testOSCALEditableTextField(
   parentElementName,
   renderer
 ) {
-  test(`Tests ${parentElementName} to see if the textfield has the default value "Test Title"`, () => {
+  test(`${parentElementName} verifies default value "Test Title"`, () => {
     renderer();
 
     screen
@@ -41,7 +41,7 @@ export default function testOSCALEditableTextField(
     expect(textField).toBeVisible();
   });
 
-  test(`${parentElementName} tests if textfield value remains same after 'Esc' key pressed`, () => {
+  test(`${parentElementName} verifies textfield remains same (ESC)`, () => {
     renderer();
 
     screen
@@ -62,7 +62,7 @@ export default function testOSCALEditableTextField(
     expect(textField.value).toEqual("Test Title");
   });
 
-  test(`${parentElementName} tests textfield remains the same after pressing Enter without editing`, () => {
+  test(`${parentElementName} verifies textfield without editing (Enter)`, () => {
     renderer();
 
     screen
@@ -87,7 +87,7 @@ export default function testOSCALEditableTextField(
     expect(textFieldAfterEvent.value).toEqual(textField.value);
   });
 
-  test(`${parentElementName} tests textfield changes to a new value after editing`, () => {
+  test(`${parentElementName} verifies value changes to "New Test Title (Enter)`, () => {
     renderer();
 
     screen
@@ -99,7 +99,7 @@ export default function testOSCALEditableTextField(
     const textField = screen.getByTestId(
       "textField-system-security-plan-metadata-title"
     );
-    fireEvent.change(textField, { target: { value: "new Test Title" } });
+    fireEvent.change(textField, { target: { value: "New Test Title" } });
     fireEvent.keyPress(textField, {
       key: "Enter",
       charCode: 13,
@@ -108,6 +108,6 @@ export default function testOSCALEditableTextField(
     const textFieldAfterEvent = screen.getByTestId(
       "textField-system-security-plan-metadata-title"
     );
-    expect(textFieldAfterEvent.value).toEqual("new Test Title");
+    expect(textFieldAfterEvent.value).toEqual("New Test Title");
   });
 }

--- a/src/components/OSCALEditableTextField.test.js
+++ b/src/components/OSCALEditableTextField.test.js
@@ -25,7 +25,7 @@ export default function testOSCALEditableTextField(
   parentElementName,
   renderer
 ) {
-  test(`${parentElementName} displays text field and can be edited`, () => {
+  test(`Tests ${parentElementName} to see if the textfield has the default value "Test Title"`, () => {
     renderer();
 
     screen
@@ -37,10 +37,11 @@ export default function testOSCALEditableTextField(
     const textField = screen.getByTestId(
       "textField-system-security-plan-metadata-title"
     );
+    expect(textField.value).toEqual("Test Title");
     expect(textField).toBeVisible();
   });
 
-  test(`${parentElementName} tests text field is no longer editable after 'Esc' key is pressed`, () => {
+  test(`${parentElementName} tests if text field value remains same after 'Esc' key pressed`, () => {
     renderer();
 
     screen
@@ -53,12 +54,13 @@ export default function testOSCALEditableTextField(
       "textField-system-security-plan-metadata-title"
     );
 
+    textField.click();
     fireEvent.keyDown(textField, {
       key: "Escape",
-      charCode: 27,
+      keyCode: 27,
     });
 
-    expect(textField).not.toBeVisible();
+    expect(textField.value).toEqual("Test Title");
   });
 
   test(`${parentElementName} tests text field is no longer editable after 'Enter' key is pressed`, () => {
@@ -74,11 +76,25 @@ export default function testOSCALEditableTextField(
       "textField-system-security-plan-metadata-title"
     );
 
+    fireEvent.keyPress(
+      screen.getElementById("security-objective-availability"),
+      {
+        key: "Enter",
+        code: "Enter",
+        keyCode: 13,
+        charCode: 13,
+      }
+    );
+
+    const textFieldAfterEvent = screen.getByTestId(
+      "textField-system-security-plan-metadata-title"
+    );
+    expect(textFieldAfterEvent).not.toEqual(textField);
+
     fireEvent.keyDown(textField, {
       key: "Enter",
       charCode: 13,
     });
-
     expect(textField).not.toBeVisible();
   });
 }

--- a/src/components/OSCALEditableTextField.test.js
+++ b/src/components/OSCALEditableTextField.test.js
@@ -77,7 +77,7 @@ export default function testOSCALEditableTextField(
 
     fireEvent.keyPress(textField, {
       key: "Enter",
-      charCode: 13,
+      keyCode: 13,
     });
 
     const textFieldAfterEvent = screen.getByTestId(
@@ -102,7 +102,7 @@ export default function testOSCALEditableTextField(
     fireEvent.change(textField, { target: { value: "New Test Title" } });
     fireEvent.keyPress(textField, {
       key: "Enter",
-      charCode: 13,
+      keyCode: 13,
     });
 
     const textFieldAfterEvent = screen.getByTestId(

--- a/src/components/OSCALEditableTextField.test.js
+++ b/src/components/OSCALEditableTextField.test.js
@@ -25,7 +25,7 @@ export default function testOSCALEditableTextField(
   parentElementName,
   renderer
 ) {
-  test(`${parentElementName} verifies default value "Test Title"`, () => {
+  test(`${parentElementName} displays default value "Test Title"`, () => {
     renderer();
 
     screen
@@ -41,7 +41,7 @@ export default function testOSCALEditableTextField(
     expect(textField).toBeVisible();
   });
 
-  test(`${parentElementName} verifies textfield remains same (ESC)`, () => {
+  test(`${parentElementName} shows textfield remains same (ESC)`, () => {
     renderer();
 
     screen
@@ -62,7 +62,7 @@ export default function testOSCALEditableTextField(
     expect(textField.value).toEqual("Test Title");
   });
 
-  test(`${parentElementName} verifies textfield without editing (Enter)`, () => {
+  test(`${parentElementName} shows textfield without editing (Enter)`, () => {
     renderer();
 
     screen
@@ -87,7 +87,7 @@ export default function testOSCALEditableTextField(
     expect(textFieldAfterEvent.value).toEqual(textField.value);
   });
 
-  test(`${parentElementName} verifies value changes to "New Test Title (Enter)`, () => {
+  test(`${parentElementName} shows value saves changes on edit (Enter)`, () => {
     renderer();
 
     screen

--- a/src/components/OSCALEditableTextField.test.js
+++ b/src/components/OSCALEditableTextField.test.js
@@ -41,7 +41,7 @@ export default function testOSCALEditableTextField(
     expect(textField).toBeVisible();
   });
 
-  test(`${parentElementName} tests if text field value remains same after 'Esc' key pressed`, () => {
+  test(`${parentElementName} tests if textfield value remains same after 'Esc' key pressed`, () => {
     renderer();
 
     screen
@@ -54,7 +54,6 @@ export default function testOSCALEditableTextField(
       "textField-system-security-plan-metadata-title"
     );
 
-    textField.click();
     fireEvent.keyDown(textField, {
       key: "Escape",
       keyCode: 27,
@@ -63,7 +62,7 @@ export default function testOSCALEditableTextField(
     expect(textField.value).toEqual("Test Title");
   });
 
-  test(`${parentElementName} tests text field is no longer editable after 'Enter' key is pressed`, () => {
+  test(`${parentElementName} tests textfield remains the same after pressing Enter without editing`, () => {
     renderer();
 
     screen
@@ -76,20 +75,16 @@ export default function testOSCALEditableTextField(
       "textField-system-security-plan-metadata-title"
     );
 
-    fireEvent.keyPress(
-      screen.getElementById("security-objective-availability"),
-      {
-        key: "Enter",
-        code: "Enter",
-        keyCode: 13,
-        charCode: 13,
-      }
-    );
+    fireEvent.keyPress(textField, {
+      key: "Enter",
+      charCode: 13,
+    });
 
     const textFieldAfterEvent = screen.getByTestId(
       "textField-system-security-plan-metadata-title"
     );
-    expect(textFieldAfterEvent).not.toEqual(textField);
+
+    expect(textFieldAfterEvent.value).toEqual(textField.value);
 
     fireEvent.keyDown(textField, {
       key: "Enter",

--- a/src/components/OSCALEditableTextField.test.js
+++ b/src/components/OSCALEditableTextField.test.js
@@ -85,11 +85,29 @@ export default function testOSCALEditableTextField(
     );
 
     expect(textFieldAfterEvent.value).toEqual(textField.value);
+  });
 
-    fireEvent.keyDown(textField, {
+  test(`${parentElementName} tests textfield changes to a new value after editing`, () => {
+    renderer();
+
+    screen
+      .getByRole("button", {
+        name: "edit-system-security-plan-metadata-title",
+      })
+      .click();
+
+    const textField = screen.getByTestId(
+      "textField-system-security-plan-metadata-title"
+    );
+    fireEvent.change(textField, { target: { value: "new Test Title" } });
+    fireEvent.keyPress(textField, {
       key: "Enter",
       charCode: 13,
     });
-    expect(textField).not.toBeVisible();
+
+    const textFieldAfterEvent = screen.getByTestId(
+      "textField-system-security-plan-metadata-title"
+    );
+    expect(textFieldAfterEvent.value).toEqual("new Test Title");
   });
 }

--- a/src/components/OSCALEditableTextField.test.js
+++ b/src/components/OSCALEditableTextField.test.js
@@ -25,7 +25,7 @@ export default function testOSCALEditableTextField(
   parentElementName,
   renderer
 ) {
-  test(`${parentElementName} displays default value "Test Title"`, () => {
+  test(`${parentElementName} displays default value as "Test Title"`, () => {
     renderer();
 
     screen
@@ -41,7 +41,7 @@ export default function testOSCALEditableTextField(
     expect(textField).toBeVisible();
   });
 
-  test(`${parentElementName} shows textfield remains same (ESC)`, () => {
+  test(`${parentElementName} remains same on ESC`, () => {
     renderer();
 
     screen
@@ -62,7 +62,7 @@ export default function testOSCALEditableTextField(
     expect(textField.value).toEqual("Test Title");
   });
 
-  test(`${parentElementName} shows textfield without editing (Enter)`, () => {
+  test(`${parentElementName} remains same Enter`, () => {
     renderer();
 
     screen
@@ -87,7 +87,7 @@ export default function testOSCALEditableTextField(
     expect(textFieldAfterEvent.value).toEqual(textField.value);
   });
 
-  test(`${parentElementName} shows value saves changes on edit (Enter)`, () => {
+  test(`${parentElementName} changes value on Enter`, () => {
     renderer();
 
     screen

--- a/src/components/OSCALSsp.test.js
+++ b/src/components/OSCALSsp.test.js
@@ -39,4 +39,4 @@ testOSCALEditableFieldActions("OSCALSsp", sspRendererRestMode);
 
 testOSCALDiagram("OSCALSsp", sspRenderer);
 
-testOSCALEditableTextField("OSCALEditableTextField", sspRendererRestMode);
+testOSCALEditableTextField("OSCALSsp", sspRendererRestMode);

--- a/src/components/OSCALSsp.test.js
+++ b/src/components/OSCALSsp.test.js
@@ -29,14 +29,14 @@ function sspRendererRestMode() {
   );
 }
 
-testOSCALSystemCharacteristics("OSCALSystemCharacteristics", sspRenderer);
+testOSCALSystemCharacteristics("OSCALSsp", sspRenderer);
 
-testOSCALSystemImplementation("OSCALSystemImplementation", sspRenderer);
+testOSCALSystemImplementation("OSCALSsp", sspRenderer);
 
-testOSCALMetadata("OSCALSMetadata", sspRenderer);
+testOSCALMetadata("OSCALSsp", sspRenderer);
 
-testOSCALEditableFieldActions("OSCALEditableFieldActions", sspRendererRestMode);
+testOSCALEditableFieldActions("OSCALSsp", sspRendererRestMode);
 
-testOSCALDiagram("OSCALDiagram", sspRenderer);
+testOSCALDiagram("OSCALSsp", sspRenderer);
 
 testOSCALEditableTextField("OSCALEditableTextField", sspRendererRestMode);

--- a/src/components/OSCALSsp.test.js
+++ b/src/components/OSCALSsp.test.js
@@ -9,7 +9,6 @@ import { sspTestData } from "../test-data/SystemData";
 import testOSCALEditableFieldActions from "./OSCALEditableFieldActions.test";
 import testOSCALEditableTextField from "./OSCALEditableTextField.test";
 import testOSCALDiagram from "./OSCALDiagram.test";
-import testOSCALEditableTextField from "./OSCALEditableTextField.test";
 
 test("OSCALSsp loads", () => {
   render(<OSCALSSPLoader />);

--- a/src/components/OSCALSsp.test.js
+++ b/src/components/OSCALSsp.test.js
@@ -7,6 +7,7 @@ import testOSCALSystemImplementation from "./OSCALSystemImplementation.test";
 import testOSCALMetadata from "./OSCALMetadata.test";
 import { sspTestData } from "../test-data/SystemData";
 import testOSCALEditableFieldActions from "./OSCALEditableFieldActions.test";
+import testOSCALEditableTextField from "./OSCALEditableTextField.test";
 import testOSCALDiagram from "./OSCALDiagram.test";
 import testOSCALEditableTextField from "./OSCALEditableTextField.test";
 
@@ -29,14 +30,14 @@ function sspRendererRestMode() {
   );
 }
 
-testOSCALSystemCharacteristics("OSCALSsp", sspRenderer);
+testOSCALSystemCharacteristics("OSCALSystemCharacteristics", sspRenderer);
 
-testOSCALSystemImplementation("OSCALSsp", sspRenderer);
+testOSCALSystemImplementation("OSCALSystemImplementation", sspRenderer);
 
-testOSCALMetadata("OSCALSsp", sspRenderer);
+testOSCALMetadata("OSCALSMetadata", sspRenderer);
 
-testOSCALEditableFieldActions("OSCALSsp", sspRendererRestMode);
+testOSCALEditableFieldActions("OSCALEditableFieldActions", sspRendererRestMode);
 
-testOSCALDiagram("OSCALSsp", sspRenderer);
+testOSCALDiagram("OSCALDiagram", sspRenderer);
 
-testOSCALEditableTextField("OSCALSsp", sspRendererRestMode);
+testOSCALEditableTextField("OSCALEditableTextField", sspRendererRestMode);


### PR DESCRIPTION
I created three unit tests for the OSCALEditableTextField
1) Tests that the textField appears and can be edited
2) Tests that the textField remains the same after 'Esc' key is pressed
3) Tests that the textField value changes after 'Enter' key is pressed

Used the fireEvent to simulate the keypress events and made assertions
for them

Note: First time writing unit tests for react so I expect there to be
errors, happy to talk it out and learn.

Closes #442