### PR TITLE
Reorder app navigation menu

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -176,9 +176,9 @@ function App() {
             <MenuItem
               onClick={handleAppNavClose}
               component={RouterLink}
-              to="/system-security-plan"
+              to="/profile"
             >
-              {`System Security Plan ${appType}`}
+              {`Profile ${appType}`}
             </MenuItem>
             <MenuItem
               onClick={handleAppNavClose}
@@ -190,9 +190,9 @@ function App() {
             <MenuItem
               onClick={handleAppNavClose}
               component={RouterLink}
-              to="/profile"
+              to="/system-security-plan"
             >
-              {`Profile ${appType}`}
+              {`System Security Plan ${appType}`}
             </MenuItem>
           </Menu>
           <Container maxWidth={false} component="main">


### PR DESCRIPTION
The current ordering is Catalog, SSP, CDef, Profile. Which is an
interesting ordering. Typically, these get listed more inline with the
model of layers of OSCAL, so: Catalog, Profile, CDef, SSP.

This is pretty subjective but hopefully sorta prevents time that people
spend searching through the nav bar (not that we have any concrete way
to get metrics for that).

Other possible options would be an alphabetical sorting (Catalog, CDef,
Profile, SSP), or the inverse of this (SSP, CDef, Profile, Catalog)
which also sorta aligns with what we put the most emphasis around
editing and modeling.
