### PR TITLE
Support Friendly URLs

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -111,12 +111,14 @@ function App() {
     },
   ];
 
+  const routePaths = ["", ":id"];
+
   const appBarRoutes = (
     <Route path="/">
       <Route index element={`OSCAL Catalog ${appType}`} />
       {oscalObjectTypes.map((oscalObjectType) => (
         <Route path={oscalObjectType.pathName} key={oscalObjectType.pathName}>
-          {["", ":id"].map((path) => (
+          {routePaths.map((path) => (
             <Route
               path={path}
               key={path}
@@ -147,7 +149,7 @@ function App() {
       />
       {oscalObjectTypes.map((oscalObjectType) => (
         <Route path={oscalObjectType.pathName} key={oscalObjectType.pathName}>
-          {["", ":id"].map((path) => (
+          {routePaths.map((path) => (
             <Route
               path={path}
               key={path}

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -5,7 +5,7 @@ import {
   ThemeProvider,
   StyledEngineProvider,
 } from "@mui/material/styles";
-import React, { useEffect, useState } from "react";
+import React, { createElement, useEffect, useState } from "react";
 import Typography from "@mui/material/Typography";
 import Container from "@mui/material/Container";
 import AppBar from "@mui/material/AppBar";
@@ -19,7 +19,6 @@ import MenuItem from "@mui/material/MenuItem";
 import CssBaseline from "@mui/material/CssBaseline";
 import ReactGA from "react-ga";
 import {
-  Navigate,
   Route,
   Routes,
   Link as RouterLink,
@@ -89,6 +88,85 @@ function App() {
     }
   }, [location]);
 
+  const oscalObjectTypes = [
+    {
+      pathName: "catalog",
+      elementName: "Catalog",
+      loaderElement: OSCALCatalogLoader,
+    },
+    {
+      pathName: "profile",
+      elementName: "Profile",
+      loaderElement: OSCALProfileLoader,
+    },
+    {
+      pathName: "component-definition",
+      elementName: "Component Definition",
+      loaderElement: OSCALComponentLoader,
+    },
+    {
+      pathName: "system-security-plan",
+      elementName: "System Security Plan",
+      loaderElement: OSCALSSPLoader,
+    },
+  ];
+
+  const appBarRoutes = (
+    <Route path="/">
+      <Route index element={`OSCAL Catalog ${appType}`} />
+      {oscalObjectTypes.map((oscalObjectType) => (
+        <Route path={oscalObjectType.pathName} key={oscalObjectType.pathName}>
+          <Route
+            path=""
+            element={`OSCAL ${oscalObjectType.elementName} ${appType}`}
+          />
+          <Route
+            path=":id"
+            element={`OSCAL ${oscalObjectType.elementName} ${appType}`}
+          />
+        </Route>
+      ))}
+    </Route>
+  );
+
+  const oscalObjectLoaderProps = {
+    renderForm: true,
+    isRestMode,
+    setIsRestMode,
+    backendUrl,
+  };
+
+  const navRoutes = (
+    <Route path="/">
+      {/* Default index will open up the Catalog */}
+      <Route
+        index
+        element={createElement(
+          oscalObjectTypes[0].loaderElement,
+          oscalObjectLoaderProps
+        )}
+      />
+      {oscalObjectTypes.map((oscalObjectType) => (
+        <Route path={oscalObjectType.pathName} key={oscalObjectType.pathName}>
+          <Route
+            path=""
+            element={createElement(
+              oscalObjectType.loaderElement,
+              oscalObjectLoaderProps
+            )}
+          />
+          <Route
+            path=":id"
+            element={createElement(
+              oscalObjectType.loaderElement,
+              oscalObjectLoaderProps
+            )}
+          />
+        </Route>
+      ))}
+    </Route>
+  );
+
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={appTheme}>
@@ -106,35 +184,7 @@ function App() {
                 <MenuIcon />
               </OpenNavButton>
               <Typography variant="h6" sx={{ flexGrow: 1 }}>
-                <Routes>
-                  {/*
-                   * Because we immediately redirect users, `/` won't be visible for
-                   * long; however, having this entry means that we avoid a console
-                   * warning and at least presents something if the redirect or
-                   * rendering fails for any reason.
-                   */}
-                  <Route exact path="/" element={`OSCAL ${appType}`} />
-                  <Route
-                    exact
-                    path="/catalog"
-                    element={`OSCAL Catalog ${appType}`}
-                  />
-                  <Route
-                    exact
-                    path="/system-security-plan"
-                    element={`OSCAL System Security Plan ${appType}`}
-                  />
-                  <Route
-                    exact
-                    path="/component-definition"
-                    element={`OSCAL Component ${appType}`}
-                  />
-                  <Route
-                    exact
-                    path="/profile"
-                    element={`OSCAL Profile ${appType}`}
-                  />
-                </Routes>
+                <Routes>{appBarRoutes}</Routes>
               </Typography>
               <Typography
                 variant="body2"
@@ -196,60 +246,7 @@ function App() {
             </MenuItem>
           </Menu>
           <Container maxWidth={false} component="main">
-            <Routes>
-              <Route
-                exact
-                path="/"
-                element={<Navigate replace to="/catalog" />}
-              />
-              <Route
-                path="/catalog"
-                element={
-                  <OSCALCatalogLoader
-                    renderForm
-                    isRestMode={isRestMode}
-                    setIsRestMode={setIsRestMode}
-                    backendUrl={backendUrl}
-                  />
-                }
-              />
-              <Route
-                exact
-                path="/system-security-plan"
-                element={
-                  <OSCALSSPLoader
-                    renderForm
-                    isRestMode={isRestMode}
-                    setIsRestMode={setIsRestMode}
-                    backendUrl={backendUrl}
-                  />
-                }
-              />
-              <Route
-                exact
-                path="/component-definition"
-                element={
-                  <OSCALComponentLoader
-                    renderForm
-                    isRestMode={isRestMode}
-                    setIsRestMode={setIsRestMode}
-                    backendUrl={backendUrl}
-                  />
-                }
-              />
-              <Route
-                exact
-                path="/profile"
-                element={
-                  <OSCALProfileLoader
-                    renderForm
-                    isRestMode={isRestMode}
-                    setIsRestMode={setIsRestMode}
-                    backendUrl={backendUrl}
-                  />
-                }
-              />
-            </Routes>
+            <Routes>{navRoutes} </Routes>
           </Container>
         </div>
       </ThemeProvider>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -116,14 +116,13 @@ function App() {
       <Route index element={`OSCAL Catalog ${appType}`} />
       {oscalObjectTypes.map((oscalObjectType) => (
         <Route path={oscalObjectType.pathName} key={oscalObjectType.pathName}>
-          <Route
-            path=""
-            element={`OSCAL ${oscalObjectType.elementName} ${appType}`}
-          />
-          <Route
-            path=":id"
-            element={`OSCAL ${oscalObjectType.elementName} ${appType}`}
-          />
+          {["", ":id"].map((path) => (
+            <Route
+              path={path}
+              key={path}
+              element={`OSCAL ${oscalObjectType.elementName} ${appType}`}
+            />
+          ))}
         </Route>
       ))}
     </Route>
@@ -148,20 +147,16 @@ function App() {
       />
       {oscalObjectTypes.map((oscalObjectType) => (
         <Route path={oscalObjectType.pathName} key={oscalObjectType.pathName}>
-          <Route
-            path=""
-            element={createElement(
-              oscalObjectType.loaderElement,
-              oscalObjectLoaderProps
-            )}
-          />
-          <Route
-            path=":id"
-            element={createElement(
-              oscalObjectType.loaderElement,
-              oscalObjectLoaderProps
-            )}
-          />
+          {["", ":id"].map((path) => (
+            <Route
+              path={path}
+              key={path}
+              element={createElement(
+                oscalObjectType.loaderElement,
+                oscalObjectLoaderProps
+              )}
+            />
+          ))}
         </Route>
       ))}
     </Route>
@@ -246,7 +241,7 @@ function App() {
             </MenuItem>
           </Menu>
           <Container maxWidth={false} component="main">
-            <Routes>{navRoutes} </Routes>
+            <Routes>{navRoutes}</Routes>
           </Container>
         </div>
       </ThemeProvider>

--- a/src/components/OSCALLoader.js
+++ b/src/components/OSCALLoader.js
@@ -4,6 +4,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Split from "react-split";
 import { Box, Fab } from "@mui/material";
 import CodeIcon from "@mui/icons-material/Code";
+import { useParams } from "react-router-dom";
 import * as restUtils from "./oscal-utils/OSCALRestUtils";
 import ErrorBoundary, { BasicError } from "./ErrorBoundary";
 import OSCALSsp from "./OSCALSsp";
@@ -132,8 +133,8 @@ export default function OSCALLoader(props) {
     setOscalUrl(event.target.value);
   };
 
-  const handleUuidChange = (event) => {
-    const newOscalUrl = `${props.backendUrl}/${props.oscalObjectType.restPath}/${event.target.value}`;
+  const handleUuidChange = (objectUuid) => {
+    const newOscalUrl = `${props.backendUrl}/${props.oscalObjectType.restPath}/${objectUuid}`;
     setOscalUrl(newOscalUrl);
     setIsLoaded(false);
     setIsResolutionComplete(false);
@@ -197,6 +198,10 @@ export default function OSCALLoader(props) {
   // similar to componentDidMount()
   useEffect(() => {
     loadOscalData(oscalUrl);
+
+    if (props.oscalObjectUuid) {
+      handleUuidChange(props.oscalObjectUuid);
+    }
 
     return () => {
       unmounted.current = true;
@@ -307,6 +312,7 @@ export function getRequestedUrl() {
 }
 
 export function OSCALCatalogLoader(props) {
+  const { id } = useParams();
   const oscalObjectType = restUtils.oscalObjectTypes.catalog;
   const renderer = (
     isRestMode,
@@ -347,6 +353,7 @@ export function OSCALCatalogLoader(props) {
   return (
     <OSCALLoader
       oscalObjectType={oscalObjectType}
+      oscalObjectUuid={id}
       oscalUrl={getRequestedUrl() || oscalObjectType.defaultUrl}
       renderer={renderer}
       renderForm={props.renderForm}
@@ -358,6 +365,7 @@ export function OSCALCatalogLoader(props) {
 }
 
 export function OSCALSSPLoader(props) {
+  const { id } = useParams();
   const oscalObjectType = restUtils.oscalObjectTypes.ssp;
   const renderer = (
     isRestMode,
@@ -395,9 +403,11 @@ export function OSCALSSPLoader(props) {
       }}
     />
   );
+
   return (
     <OSCALLoader
       oscalObjectType={oscalObjectType}
+      oscalObjectUuid={id}
       oscalUrl={getRequestedUrl() || oscalObjectType.defaultUrl}
       renderer={renderer}
       renderForm={props.renderForm}
@@ -409,6 +419,7 @@ export function OSCALSSPLoader(props) {
 }
 
 export function OSCALComponentLoader(props) {
+  const { id } = useParams();
   const oscalObjectType = restUtils.oscalObjectTypes.component;
   const renderer = (
     isRestMode,
@@ -449,6 +460,7 @@ export function OSCALComponentLoader(props) {
   return (
     <OSCALLoader
       oscalObjectType={oscalObjectType}
+      oscalObjectUuid={id}
       oscalUrl={getRequestedUrl() || oscalObjectType.defaultUrl}
       renderer={renderer}
       renderForm={props.renderForm}
@@ -460,6 +472,7 @@ export function OSCALComponentLoader(props) {
 }
 
 export function OSCALProfileLoader(props) {
+  const { id } = useParams();
   const oscalObjectType = restUtils.oscalObjectTypes.profile;
   const renderer = (
     isRestMode,
@@ -500,6 +513,7 @@ export function OSCALProfileLoader(props) {
   return (
     <OSCALLoader
       oscalObjectType={oscalObjectType}
+      oscalObjectUuid={id}
       oscalUrl={getRequestedUrl() || oscalObjectType.defaultUrl}
       renderer={renderer}
       renderForm={props.renderForm}

--- a/src/components/OSCALLoaderForm.js
+++ b/src/components/OSCALLoaderForm.js
@@ -58,7 +58,7 @@ export default function OSCALLoaderForm(props) {
     setSelectedUuid(
       oscalObjects
         .map((item) => item[props.oscalObjectType.jsonRootName].uuid)
-        .filter((uuid) => uuid === requestedId)?.[0] ?? ""
+        .find((uuid) => uuid === requestedId) ?? ""
     );
   }, [oscalObjects, requestedId]);
 

--- a/src/components/OSCALLoaderForm.js
+++ b/src/components/OSCALLoaderForm.js
@@ -10,6 +10,7 @@ import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import Switch from "@mui/material/Switch";
 import FormControlLabel from "@mui/material/FormControlLabel";
+import { useNavigate, useParams } from "react-router-dom";
 
 const OSCALDocumentForm = styled("form")(
   ({ theme }) => `
@@ -21,7 +22,9 @@ const OSCALDocumentForm = styled("form")(
 export default function OSCALLoaderForm(props) {
   const [oscalObjects, setOscalObjects] = useState([]);
   const [selectedUuid, setSelectedUuid] = useState("");
+  const requestedId = useParams()?.id;
   const unmounted = useRef(false);
+  const navigate = useNavigate();
 
   const findAllObjects = () => {
     fetch(`${props.backendUrl}/${props.oscalObjectType.restPath}`)
@@ -50,6 +53,14 @@ export default function OSCALLoaderForm(props) {
       unmounted.current = true;
     };
   }, []);
+
+  useEffect(() => {
+    setSelectedUuid(
+      oscalObjects
+        .map((item) => item[props.oscalObjectType.jsonRootName].uuid)
+        .filter((uuid) => uuid === requestedId)?.[0] ?? ""
+    );
+  }, [oscalObjects, requestedId]);
 
   return (
     <OSCALDocumentForm
@@ -99,7 +110,11 @@ export default function OSCALLoaderForm(props) {
                 value={selectedUuid}
                 onChange={(event) => {
                   setSelectedUuid(event.target.value);
-                  props.onUuidChange(event);
+                  props.onUuidChange(event.target.value);
+                  navigate(
+                    `/${props.oscalObjectType.jsonRootName}/${event.target.value}`,
+                    { replace: true }
+                  );
                 }}
               >
                 {oscalObjects?.map((oscalObject) => (


### PR DESCRIPTION
Rather than loading by OscalURL's in the editor, we now load based on
the OSCALObjects uuid. This allows for a lot more coherent way of
routing throughout the editor. It also allows you to load an element by
placing the uuid in the url.

This may render some portions of the `OSCALLoader` redundant. As I still do not
feel completely confident on what everything in the `OSCALLoader` does, please
pay extra attention in case I missed something. 

Testing still needs to be added to this, but the functionality should 
be working. It makes more sense to deal with this testing in https://github.com/EasyDynamics/oscal-editor-deployment/issues/98

Closes #336
