### PR TITLE
Edit element name of Component

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -101,7 +101,7 @@ function App() {
     },
     {
       pathName: "component-definition",
-      elementName: "Component Definition",
+      elementName: "Component",
       loaderElement: OSCALComponentLoader,
     },
     {


### PR DESCRIPTION
`Cypress` tests expect the title of a `Component` to be just `Component` and not
`Component Definition`
