### PR TITLE
Safely handle undefined fields in profile resolution

### DIFF
--- a/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/src/components/oscal-utils/OSCALProfileResolver.js
@@ -65,7 +65,7 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
           inheritedOSCALObject.uuid = result.catalog.uuid;
           inheritedOSCALObject.type = "catalog";
           // Dig through catalog controls and add to profile.controls
-          result.catalog.groups.forEach((group) => {
+          result.catalog.groups?.forEach((group) => {
             resolvedControls.push(...group.controls);
           });
           if (result.catalog.controls) {
@@ -79,13 +79,13 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
           inheritedOSCALObject.inherited = [];
 
           modifications["set-parameters"].push(
-            ...(result.profile.modify["set-parameters"] ?? [])
+            ...(result.profile.modify?.["set-parameters"] ?? [])
           );
-          modifications.alters.push(...result.profile.modify.alters);
+          modifications.alters.push(...(result.profile.modify?.alters ?? []));
 
           result.profile.imports.forEach((profileImport) => {
             const importUrl = resolveLinkHref(
-              result.profile["back-matter"],
+              result.profile?.["back-matter"] ?? [],
               profileImport.href,
               null,
               OSCAL_MEDIA_TYPE_REGEX
@@ -95,7 +95,7 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
               modifications,
               importUrl,
               itemUrl,
-              result.profile["back-matter"],
+              result.profilea?.["back-matter"] ?? [],
               inheritedOSCALObject.inherited,
               onSuccess,
               onError,
@@ -140,13 +140,13 @@ export function OSCALResolveProfile(profile, parentUrl, onSuccess, onError) {
       profile.resolvedControls,
       profile.modifications,
       resolveLinkHref(
-        profile["back-matter"],
+        profile?.["back-matter"] ?? [],
         imp.href,
         parentUrl,
         OSCAL_MEDIA_TYPE_REGEX
       ),
       parentUrl,
-      profile["back-matter"],
+      profile?.["back-matter"] ?? [],
       inheritedProfilesAndCatalogs.inherited,
       () => {
         onSuccess(inheritedProfilesAndCatalogs);


### PR DESCRIPTION
Various fields in the OSCAL specification are not required (these are
fields that allow [0, 1] elements). In many cases, we were expecting
those fields to be present. When loading the NIST SP 800-53 rev5
profiles in our viewer, they would fail to render because we required
modify to be present.

This makes some minor changes to profile resolution in order to prevent
similar issues; a more holistic approach to resolution is certainly
still required.
