### PR TITLE
Handle duplicate part ids

### DIFF
--- a/src/components/OSCALControlPart.js
+++ b/src/components/OSCALControlPart.js
@@ -81,25 +81,23 @@ export default function OSCALControlPart(props) {
     <OSCALControlPartWrapper ownerState partName={props.part.name}>
       {replacedProse}
       {props.part.parts &&
-        props.part.parts.map((part, index) => {
-          const partKey = `control-part-${part.id}-${index}`;
-          return (
-            <OSCALControlPart
-              part={part}
-              controlId={props.controlId ?? props.control.id}
-              parameters={props.parameters}
-              implementedRequirement={props.implementedRequirement}
-              componentId={props.componentId}
-              modificationAlters={props.modificationAlters}
-              modificationSetParameters={props.modificationSetParameters}
-              key={partKey}
-              isEditable={props.isEditable}
-              onRestSuccess={props.onRestSuccess}
-              onRestError={props.onRestError}
-              partialRestData={props.partialRestData}
-            />
-          );
-        })}
+        props.part.parts.map((part, index) => (
+          <OSCALControlPart
+            part={part}
+            controlId={props.controlId ?? props.control.id}
+            parameters={props.parameters}
+            implementedRequirement={props.implementedRequirement}
+            componentId={props.componentId}
+            modificationAlters={props.modificationAlters}
+            modificationSetParameters={props.modificationSetParameters}
+            // eslint-disable-next-line
+            key={`control-part-${part.id}-${index}`}
+            isEditable={props.isEditable}
+            onRestSuccess={props.onRestSuccess}
+            onRestError={props.onRestError}
+            partialRestData={props.partialRestData}
+          />
+        ))}
     </OSCALControlPartWrapper>
   );
 }

--- a/src/components/OSCALControlPart.js
+++ b/src/components/OSCALControlPart.js
@@ -81,22 +81,25 @@ export default function OSCALControlPart(props) {
     <OSCALControlPartWrapper ownerState partName={props.part.name}>
       {replacedProse}
       {props.part.parts &&
-        props.part.parts.map((part) => (
-          <OSCALControlPart
-            part={part}
-            controlId={props.controlId ?? props.control.id}
-            parameters={props.parameters}
-            implementedRequirement={props.implementedRequirement}
-            componentId={props.componentId}
-            modificationAlters={props.modificationAlters}
-            modificationSetParameters={props.modificationSetParameters}
-            key={part.id}
-            isEditable={props.isEditable}
-            onRestSuccess={props.onRestSuccess}
-            onRestError={props.onRestError}
-            partialRestData={props.partialRestData}
-          />
-        ))}
+        props.part.parts.map((part, index) => {
+          const partKey = `control-part-${part.id}-${index}`;
+          return (
+            <OSCALControlPart
+              part={part}
+              controlId={props.controlId ?? props.control.id}
+              parameters={props.parameters}
+              implementedRequirement={props.implementedRequirement}
+              componentId={props.componentId}
+              modificationAlters={props.modificationAlters}
+              modificationSetParameters={props.modificationSetParameters}
+              key={partKey}
+              isEditable={props.isEditable}
+              onRestSuccess={props.onRestSuccess}
+              onRestError={props.onRestError}
+              partialRestData={props.partialRestData}
+            />
+          );
+        })}
     </OSCALControlPartWrapper>
   );
 }

--- a/src/components/OSCALControlPart.js
+++ b/src/components/OSCALControlPart.js
@@ -90,6 +90,9 @@ export default function OSCALControlPart(props) {
             componentId={props.componentId}
             modificationAlters={props.modificationAlters}
             modificationSetParameters={props.modificationSetParameters}
+            // The NIST_SP-80053_rev 5 catalog contains parts with duplicate ids.
+            // In order to avoid key duplication, the index of the part as well
+            // as it's id is necessary.
             // eslint-disable-next-line
             key={`control-part-${part.id}-${index}`}
             isEditable={props.isEditable}


### PR DESCRIPTION
The rev5 catalog contained control parts with duplicated ids. Our
strategy for creating keys for these objects was to just use those id's.
This led to duplicated keys warnings in the Viewer.

To deal with that, it was necessary to use the index of each part within
the list to distinguish between parts with the same id. Because using
the index as a key is not usually prefered, extracting the key to a
variable first was necessary.

### Testing
Here are the files used to replicate the error:

- [Profile](https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/main/profiles/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json)
- [Catalog](https://raw.githubusercontent.com/usnistgov/oscal-content/b97d0c0f682d6686c64077678f5e409427972f23/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json)
