### PR TITLE
Open drawer for better navigation

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -23,7 +23,6 @@ import {
   Routes,
   Link as RouterLink,
   useLocation,
-  useParams,
 } from "react-router-dom";
 import Grid from "@mui/material/Grid";
 import Switch from "@mui/material/Switch";
@@ -64,13 +63,19 @@ function App() {
   );
   const [backendUrl] = useState(process.env.REACT_APP_REST_BASE_URL);
   const [hasDefaultUrl, setHasDefaultUrl] = useState(false);
-  const oscalObjectUuid = useParams()?.id ?? "";
 
   useEffect(() => {
-    if (!oscalObjectUuid) {
+    const currentUrl = window.location.href;
+    // Open the drawer when in REST mode and no uuid is present.
+    // Note: The lowest subdirectory of the url is extracted to see if
+    // it contains a uuid.
+    if (
+      isRestMode &&
+      currentUrl.substring(currentUrl.lastIndexOf("/") + 1) === ""
+    ) {
       setIsDrawerOpen(true);
     }
-  }, [oscalObjectUuid]);
+  }, [isRestMode]);
 
   const appType = React.useMemo(
     () => (isRestMode ? "Editor" : "Viewer"),

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -23,6 +23,7 @@ import {
   Routes,
   Link as RouterLink,
   useLocation,
+  useParams,
 } from "react-router-dom";
 import Grid from "@mui/material/Grid";
 import Switch from "@mui/material/Switch";
@@ -63,6 +64,13 @@ function App() {
   );
   const [backendUrl] = useState(process.env.REACT_APP_REST_BASE_URL);
   const [hasDefaultUrl, setHasDefaultUrl] = useState(false);
+  const oscalObjectUuid = useParams()?.id ?? "";
+
+  useEffect(() => {
+    if (!oscalObjectUuid) {
+      setIsDrawerOpen(true);
+    }
+  }, [oscalObjectUuid]);
 
   const appType = React.useMemo(
     () => (isRestMode ? "Editor" : "Viewer"),
@@ -73,7 +81,10 @@ function App() {
   }, [appType]);
 
   const handleAppNavOpen = (event) => {
-    setAnchorEl(event.currentTarget);
+    if (event) {
+      setAnchorEl(event.currentTarget);
+    }
+
     setIsDrawerOpen(true);
   };
 
@@ -177,6 +188,7 @@ function App() {
       open={isDrawerOpen}
       handleClose={handleAppNavClose}
       backendUrl={backendUrl}
+      handleOpen={handleAppNavOpen}
     />
   ) : (
     <Menu


### PR DESCRIPTION
This will attempt to open the navigation more proactively. A few of the cases I have found include:

- When a `uuid` is not currently set in `url`
- When we switch out of `REST` mode.

