### PR TITLE
Give the update bot weekends off

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -3,8 +3,8 @@ name: Update dependencies
 
 on:
   schedule:
-    # Run daily at 12:15 UTC (08:15 EDT/07:15 EST)
-    - cron: "15 12 * * *"
+    # Run daily (Monday-Friday) at 12:15 UTC (08:15 EDT/07:15 EST)
+    - cron: "15 12 * * 1-5"
   workflow_dispatch:
 
 # This workflow needs to leverage a GitHub Personal Access Token (PAT) in order


### PR DESCRIPTION
If we're not working, the bot shouldn't have to work either! :D But more
seriously, no one is around to merge these PRs on weekends anyway (or
it's an extra thing that people may feel inclined to need to interact
with on a weekend). Generally though, this just ends up resulting in the
bot force-pushing over itself (which in itself isn't a problem) and that
sorta mucks up the GitHub notifications where it tries to show
differences between pushes and all that.

So on the whole, it probably just fits better for our workflow to only
have this run on weekdays. We can further consider cutting back how
often this runs at some other point too (do we _really_ need it daily?)
but that feels like a conversation that can go in circles which I don't
really want to do as part of this.

I fully understand the irony of opening _this_ PR on a weekend too :D
