### PR TITLE
Create Footer

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -256,60 +256,25 @@ function App() {
             <AppBar position="static">
               <Toolbar>
                 <Grid container alignItems="center">
-                  <Grid item md={4} align="left">
-                    <Grid container alignItems="center">
-                      <Grid item align="left">
-                        <OpenNavButton
-                          edge="start"
-                          onClick={handleAppNavOpen}
-                          color="inherit"
-                          aria-label="menu"
-                          size="large"
-                        >
-                          <MenuIcon />
-                        </OpenNavButton>
-                        {navigation}
-                      </Grid>
-                      <Grid item align="left">
-                        <Typography variant="h6">
-                          <Routes>{appBarRoutes}</Routes>
-                        </Typography>
-                      </Grid>
-                    </Grid>
+                  <Grid item md={3} align="left">
+                    <OpenNavButton
+                      edge="start"
+                      onClick={handleAppNavOpen}
+                      color="inherit"
+                      aria-label="menu"
+                      size="large"
+                    >
+                      <MenuIcon />
+                    </OpenNavButton>
+                    {navigation}
                   </Grid>
-                  <Grid item md={4}>
-                    <Grid container alignItems="center" justifyContent="center">
-                      <Grid item align="center">
-                        <Typography
-                          variant="body2"
-                          sx={{ color: "white", fontStyle: "italic" }}
-                        >
-                          Powered by
-                        </Typography>
-                      </Grid>
-                      <Grid item align="center">
-                        <Button
-                          href="https://www.easydynamics.com"
-                          target="_blank"
-                          sx={{ color: "white" }}
-                        >
-                          <LogoImage src={logo} alt="Easy Dynamics Logo" />
-                        </Button>
-                      </Grid>
-                      <Grid item align="center">
-                        <IconButton
-                          href="https://github.com/EasyDynamics/oscal-react-library"
-                          target="_blank"
-                          rel="noreferrer"
-                          size="large"
-                        >
-                          <GitHubIcon htmlColor="white" />
-                        </IconButton>
-                      </Grid>
-                    </Grid>
+                  <Grid item md={6} align="center">
+                    <Typography variant="h6">
+                      <Routes>{appBarRoutes}</Routes>
+                    </Typography>
                   </Grid>
                   {backendUrl && (
-                    <Grid item md={4} align="right">
+                    <Grid item md={3} align="right">
                       <FormControlLabel
                         control={
                           <Switch

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -52,6 +52,14 @@ const LogoImage = styled("img")`
   margin-right: 1em;
 `;
 
+const StyledAppBar = styled(AppBar)`
+  position: fixed;
+  height: 65px;
+  top: 0;
+  left: 0;
+  z-index: 2;
+`;
+
 const StyledFooter = styled("footer")(
   ({ theme }) => `
     position: fixed;
@@ -257,9 +265,9 @@ function App() {
         <CssBaseline />
         <div className="App">
           <div style={{ "min-height": "100vh" }}>
-            <AppBar position="static">
+            <StyledAppBar>
               <Toolbar>
-                <Grid container alignItems="center">
+                <Grid container alignItems="center" justify="center">
                   <Grid item md={3} align="left">
                     <OpenNavButton
                       edge="start"
@@ -294,11 +302,11 @@ function App() {
                   )}
                 </Grid>
               </Toolbar>
-            </AppBar>
+            </StyledAppBar>
             <Container
               maxWidth={false}
               component="main"
-              style={{ "padding-bottom": "50px" }}
+              style={{ "padding-top": "65px", "padding-bottom": "50px" }}
             >
               <Routes>{navRoutes}</Routes>
             </Container>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -52,6 +52,14 @@ const LogoImage = styled("img")`
   margin-right: 1em;
 `;
 
+const StyledFooter = styled("footer")(
+  ({ theme }) => `
+  height: 50px;
+  margin-top: -50px;
+  background-color: ${theme.palette.primary.main};
+`
+);
+
 function App() {
   const [anchorEl, setAnchorEl] = useState(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -244,82 +252,119 @@ function App() {
       <ThemeProvider theme={appTheme}>
         <CssBaseline />
         <div className="App">
-          <AppBar position="static">
-            <Toolbar>
-              <Grid container alignItems="center">
-                <Grid item md={4} align="left">
-                  <Grid container alignItems="center">
-                    <Grid item align="left">
-                      <OpenNavButton
-                        edge="start"
-                        onClick={handleAppNavOpen}
-                        color="inherit"
-                        aria-label="menu"
-                        size="large"
-                      >
-                        <MenuIcon />
-                      </OpenNavButton>
-                      {navigation}
-                    </Grid>
-                    <Grid item align="left">
-                      <Typography variant="h6">
-                        <Routes>{appBarRoutes}</Routes>
-                      </Typography>
+          <div style={{ "min-height": "100vh" }}>
+            <AppBar position="static">
+              <Toolbar>
+                <Grid container alignItems="center">
+                  <Grid item md={4} align="left">
+                    <Grid container alignItems="center">
+                      <Grid item align="left">
+                        <OpenNavButton
+                          edge="start"
+                          onClick={handleAppNavOpen}
+                          color="inherit"
+                          aria-label="menu"
+                          size="large"
+                        >
+                          <MenuIcon />
+                        </OpenNavButton>
+                        {navigation}
+                      </Grid>
+                      <Grid item align="left">
+                        <Typography variant="h6">
+                          <Routes>{appBarRoutes}</Routes>
+                        </Typography>
+                      </Grid>
                     </Grid>
                   </Grid>
+                  <Grid item md={4}>
+                    <Grid container alignItems="center" justifyContent="center">
+                      <Grid item align="center">
+                        <Typography
+                          variant="body2"
+                          sx={{ color: "white", fontStyle: "italic" }}
+                        >
+                          Powered by
+                        </Typography>
+                      </Grid>
+                      <Grid item align="center">
+                        <Button
+                          href="https://www.easydynamics.com"
+                          target="_blank"
+                          sx={{ color: "white" }}
+                        >
+                          <LogoImage src={logo} alt="Easy Dynamics Logo" />
+                        </Button>
+                      </Grid>
+                      <Grid item align="center">
+                        <IconButton
+                          href="https://github.com/EasyDynamics/oscal-react-library"
+                          target="_blank"
+                          rel="noreferrer"
+                          size="large"
+                        >
+                          <GitHubIcon htmlColor="white" />
+                        </IconButton>
+                      </Grid>
+                    </Grid>
+                  </Grid>
+                  {backendUrl && (
+                    <Grid item md={4} align="right">
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            checked={isRestMode}
+                            color="warning"
+                            onChange={onChangeRestMode}
+                            name="isRestMode"
+                          />
+                        }
+                        label="REST Mode"
+                      />
+                    </Grid>
+                  )}
                 </Grid>
-                <Grid item md={4}>
-                  <Grid container alignItems="center" justifyContent="center">
-                    <Grid item align="center">
-                      <Typography
-                        variant="body2"
-                        sx={{ color: "white", fontStyle: "italic" }}
-                      >
-                        Powered by
-                      </Typography>
-                    </Grid>
-                    <Grid item align="center">
-                      <Button
-                        href="https://www.easydynamics.com"
-                        target="_blank"
-                        sx={{ color: "white" }}
-                      >
-                        <LogoImage src={logo} alt="Easy Dynamics Logo" />
-                      </Button>
-                    </Grid>
-                    <Grid item align="center">
-                      <IconButton
-                        href="https://github.com/EasyDynamics/oscal-react-library"
-                        target="_blank"
-                        rel="noreferrer"
-                        size="large"
-                      >
-                        <GitHubIcon htmlColor="white" />
-                      </IconButton>
-                    </Grid>
-                  </Grid>
-                </Grid>
-                {backendUrl && (
-                  <Grid item md={4} align="right">
-                    <FormControlLabel
-                      control={
-                        <Switch
-                          checked={isRestMode}
-                          color="warning"
-                          onChange={onChangeRestMode}
-                          name="isRestMode"
-                        />
-                      }
-                      label="REST Mode"
-                    />
-                  </Grid>
-                )}
+              </Toolbar>
+            </AppBar>
+            <Container
+              maxWidth={false}
+              component="main"
+              style={{ "padding-bottom": "50px" }}
+            >
+              <Routes>{navRoutes}</Routes>
+            </Container>
+          </div>
+          <StyledFooter>
+            <Grid container alignItems="center" justifyContent="center">
+              <Grid item align="center">
+                <Typography
+                  variant="body2"
+                  sx={{ color: "white", fontStyle: "italic" }}
+                >
+                  Powered by
+                </Typography>
               </Grid>
-            </Toolbar>
-          </AppBar>
-          <Container maxWidth={false} component="main">
-            <Routes>{navRoutes}</Routes>
-          </Container>
+              <Grid item align="center">
+                <Button
+                  href="https://www.easydynamics.com"
+                  target="_blank"
+                  sx={{ color: "white" }}
+                >
+                  <LogoImage src={logo} alt="Easy Dynamics Logo" />
+                </Button>
+              </Grid>
+              <Grid item align="center">
+                <IconButton
+                  href="https://github.com/EasyDynamics/oscal-react-library"
+                  target="_blank"
+                  rel="noreferrer"
+                  size="large"
+                >
+                  <GitHubIcon htmlColor="white" />
+                </IconButton>
+              </Grid>
+            </Grid>
+          </StyledFooter>
         </div>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -54,9 +54,13 @@ const LogoImage = styled("img")`
 
 const StyledFooter = styled("footer")(
   ({ theme }) => `
-  height: 50px;
-  margin-top: -50px;
-  background-color: ${theme.palette.primary.main};
+    position: fixed;
+    height: 50px;
+    width: 100vw;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    background-color: ${theme.palette.primary.main};
 `
 );
 

--- a/src/components/OSCALJsonEditor.js
+++ b/src/components/OSCALJsonEditor.js
@@ -42,7 +42,7 @@ export default function OSCALJsonEditor(props) {
       </Grid>
       <Grid sx={{ width: "100%" }} item>
         <Editor
-          height="85vh"
+          height="83vh"
           options={editorOptions}
           onMount={(editor) => {
             editorRef.current = editor;


### PR DESCRIPTION
Here's my idea for a footer within our application.

This moves all info promoting Easy Dynamics ("Powered by Easy Dynamics" and the GitHub icon) to the footer. This first rendition of the footer is a "sticky footer", meaning it sits at the bottom of the viewport when there is no content and when there is content (an example is selected) the footer will display beneath it. While Easy Dynamics is not necessarily  "front and center" like it was at the top `AppBar`, it still will display right away when the application is launched at the bottom of the screen.

Furthermore, I thought it made sense to move `appBarRoutes` to display in the center of the AppBar. This helps avoid having `Object Selector` cover up the title. Although, not sure how I feel about it being centered here. Let me know if anyone has opinions on this. We could honestly just leave it where it was before and have the title also display in `Object Selector` when opened.

Also I want to note, this branch is created off of feature/move-rest-mode-icon as this branch seems most relevant with the placement of the REST mode icon in `AppBar`.