### PR TITLE
Test that blank `set-parameters` is handled correctly

### DIFF
--- a/src/components/OSCALControlProse.test.js
+++ b/src/components/OSCALControlProse.test.js
@@ -59,7 +59,7 @@ function proseParamValuesEditingRenderer() {
 }
 
 function testOSCALControlProseEditing(parentElementName, renderer) {
-  test(`${parentElementName} displays description and parameter inputs`, async () => {
+  test(`${parentElementName} displays default description and parameter inputs`, async () => {
     renderer();
     screen
       .getByRole("button", {
@@ -77,6 +77,72 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
       "control 1 / component 1 / parameter 1 value"
     );
   });
+
+  test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
+  renderer();
+  screen
+  .getByRole("button", {
+    name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+  })
+  .click();
+  const descriptionTextField = screen.getByLabelText("Description");
+  fireEvent.change(descriptionTextField, {target: {value: "New Description"}});
+  screen.getByRole("button", {
+    name: "save-control-1_smt.a",
+  })
+  .click();
+  expect (descriptionTextField.value).toBe("New Description");
+  const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+
+  screen.getByLabelText("control-1_prm_1");
+  expect(paramValueTextField.value).toBe(
+    "control 1 / component 1 / parameter 1 value"
+  );  });
+
+
+  test(`${parentElementName} saves changes to controller name and description values`, async () => {
+    renderer();
+    screen.getByRole("button",{
+      name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+  })
+  .click();
+  
+  const descriptionTextField = screen.getByLabelText("Description");
+  const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+  fireEvent.change(descriptionTextField, {target:{value: "Test Description"}});
+  fireEvent.change(paramValueTextField, {target: {value: "Test Control Name"}});
+  screen.getByRole("button", {
+    name: "save-control-1_smt.a",
+  })
+  .click();
+  expect (descriptionTextField.value).toBe("Test Description");
+  expect (paramValueTextField.value).toBe("Test Control Name");
+  });
+
+
+  test(`${parentElementName} displays description when hovering after editing`, async () => {
+    renderer();
+    screen.getByRole("button",{
+      name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+  })
+  .click();
+  
+  const descriptionTextField = screen.getByLabelText("Description");
+  const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+  fireEvent.change(descriptionTextField, {target:{value: "Test Description"}});
+  fireEvent.change(paramValueTextField, {target: {value: "Test Control Name"}});
+  screen.getByRole("button", {
+    name: "save-control-1_smt.a",
+  })
+  .click();
+  //   screen.getByRole("link",{
+  //   name: "Component 1 description of implementing control 1"
+  // });
+  // expect (descriptionLink.ariaLabel).toBe("Test ");
+  const descriptionLink = screen.getByText('Test Description').closest('a');
+expect(descriptionLink).toHaveValue("Test Description")
+  });
+
 }
 
 testOSCALControlProseEditing(

--- a/src/components/OSCALControlProse.test.js
+++ b/src/components/OSCALControlProse.test.js
@@ -79,70 +79,83 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
   });
 
   test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
-  renderer();
-  screen
-  .getByRole("button", {
-    name: "edit-bycomponent-component-1-statement-control-1_smt.a",
-  })
-  .click();
-  const descriptionTextField = screen.getByLabelText("Description");
-  fireEvent.change(descriptionTextField, {target: {value: "New Description"}});
-  screen.getByRole("button", {
-    name: "save-control-1_smt.a",
-  })
-  .click();
-  expect (descriptionTextField.value).toBe("New Description");
-  const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+    renderer();
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+      })
+      .click();
+    const descriptionTextField = screen.getByLabelText("Description");
+    fireEvent.change(descriptionTextField, {
+      target: { value: "New Description" },
+    });
+    screen
+      .getByRole("button", {
+        name: "save-control-1_smt.a",
+      })
+      .click();
+    expect(descriptionTextField.value).toBe("New Description");
+    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
 
-  screen.getByLabelText("control-1_prm_1");
-  expect(paramValueTextField.value).toBe(
-    "control 1 / component 1 / parameter 1 value"
-  );  });
-
+    screen.getByLabelText("control-1_prm_1");
+    expect(paramValueTextField.value).toBe(
+      "control 1 / component 1 / parameter 1 value"
+    );
+  });
 
   test(`${parentElementName} saves changes to controller name and description values`, async () => {
     renderer();
-    screen.getByRole("button",{
-      name: "edit-bycomponent-component-1-statement-control-1_smt.a",
-  })
-  .click();
-  
-  const descriptionTextField = screen.getByLabelText("Description");
-  const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-  fireEvent.change(descriptionTextField, {target:{value: "Test Description"}});
-  fireEvent.change(paramValueTextField, {target: {value: "Test Control Name"}});
-  screen.getByRole("button", {
-    name: "save-control-1_smt.a",
-  })
-  .click();
-  expect (descriptionTextField.value).toBe("Test Description");
-  expect (paramValueTextField.value).toBe("Test Control Name");
-  });
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+      })
+      .click();
 
+    const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+    fireEvent.change(descriptionTextField, {
+      target: { value: "Test Description" },
+    });
+    fireEvent.change(paramValueTextField, {
+      target: { value: "Test Control Name" },
+    });
+    screen
+      .getByRole("button", {
+        name: "save-control-1_smt.a",
+      })
+      .click();
+    expect(descriptionTextField.value).toBe("Test Description");
+    expect(paramValueTextField.value).toBe("Test Control Name");
+  });
 
   test(`${parentElementName} displays description when hovering after editing`, async () => {
     renderer();
-    screen.getByRole("button",{
-      name: "edit-bycomponent-component-1-statement-control-1_smt.a",
-  })
-  .click();
-  
-  const descriptionTextField = screen.getByLabelText("Description");
-  const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-  fireEvent.change(descriptionTextField, {target:{value: "Test Description"}});
-  fireEvent.change(paramValueTextField, {target: {value: "Test Control Name"}});
-  screen.getByRole("button", {
-    name: "save-control-1_smt.a",
-  })
-  .click();
-  //   screen.getByRole("link",{
-  //   name: "Component 1 description of implementing control 1"
-  // });
-  // expect (descriptionLink.ariaLabel).toBe("Test ");
-  const descriptionLink = screen.getByText('Test Description').closest('a');
-expect(descriptionLink).toHaveValue("Test Description")
-  });
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+      })
+      .click();
 
+    const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+    fireEvent.change(descriptionTextField, {
+      target: { value: "Test Description" },
+    });
+    fireEvent.change(paramValueTextField, {
+      target: { value: "Test Control Name" },
+    });
+    screen
+      .getByRole("button", {
+        name: "save-control-1_smt.a",
+      })
+      .click();
+    //   screen.getByRole("link",{
+    //   name: "Component 1 description of implementing control 1"
+    // });
+    // expect (descriptionLink.ariaLabel).toBe("Test ");
+    const descriptionLink = screen.getByText("Test Description").closest("a");
+    expect(descriptionLink).toHaveValue("Test Description");
+  });
 }
 
 testOSCALControlProseEditing(

--- a/src/components/OSCALControlProse.test.js
+++ b/src/components/OSCALControlProse.test.js
@@ -59,33 +59,30 @@ function proseParamValuesEditingRenderer() {
 }
 
 function testOSCALControlProseEditing(parentElementName, renderer) {
-  test(`${parentElementName} displays default description and parameter inputs`, async () => {
+  beforeEach(() => {
     renderer();
     screen
       .getByRole("button", {
         name: "edit-bycomponent-component-1-statement-control-1_smt.a",
       })
       .click();
+  });
 
+  test(`${parentElementName} displays default description and parameter inputs`, async () => {
     const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
     expect(descriptionTextField.value).toBe(
       "Component 1 description of implementing control 1"
     );
 
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
     expect(paramValueTextField.value).toBe(
       "control 1 / component 1 / parameter 1 value"
     );
   });
 
   test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
-    renderer();
-    screen
-      .getByRole("button", {
-        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
-      })
-      .click();
     const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
     fireEvent.change(descriptionTextField, {
       target: { value: "New Description" },
     });
@@ -95,7 +92,6 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
       })
       .click();
     expect(descriptionTextField.value).toBe("New Description");
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
 
     screen.getByLabelText("control-1_prm_1");
     expect(paramValueTextField.value).toBe(
@@ -104,13 +100,6 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
   });
 
   test(`${parentElementName} saves changes to controller name and description values`, async () => {
-    renderer();
-    screen
-      .getByRole("button", {
-        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
-      })
-      .click();
-
     const descriptionTextField = screen.getByLabelText("Description");
     const paramValueTextField = screen.getByLabelText("control-1_prm_1");
     fireEvent.change(descriptionTextField, {
@@ -126,35 +115,6 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
       .click();
     expect(descriptionTextField.value).toBe("Test Description");
     expect(paramValueTextField.value).toBe("Test Control Name");
-  });
-
-  test(`${parentElementName} displays description when hovering after editing`, async () => {
-    renderer();
-    screen
-      .getByRole("button", {
-        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
-      })
-      .click();
-
-    const descriptionTextField = screen.getByLabelText("Description");
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-    fireEvent.change(descriptionTextField, {
-      target: { value: "Test Description" },
-    });
-    fireEvent.change(paramValueTextField, {
-      target: { value: "Test Control Name" },
-    });
-    screen
-      .getByRole("button", {
-        name: "save-control-1_smt.a",
-      })
-      .click();
-    //   screen.getByRole("link",{
-    //   name: "Component 1 description of implementing control 1"
-    // });
-    // expect (descriptionLink.ariaLabel).toBe("Test ");
-    const descriptionLink = screen.getByText("Test Description").closest("a");
-    expect(descriptionLink).toHaveValue("Test Description");
   });
 }
 

--- a/src/components/OSCALControlProse.test.js
+++ b/src/components/OSCALControlProse.test.js
@@ -68,9 +68,26 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
       .click();
   });
 
+  renderer();
+  screen
+    .getByRole("button", {
+      name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+    })
+    .click();
+  const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+  const descriptionTextField = screen.getByLabelText("Description");
+  const changeDescription = () =>
+    fireEvent.change(descriptionTextField, {
+      target: { value: "Test Description" },
+    });
+  const saveChanges = () =>
+    screen
+      .getByRole("button", {
+        name: "save-control-1_smt.a",
+      })
+      .click();
+
   test(`${parentElementName} displays default description and parameter inputs`, async () => {
-    const descriptionTextField = screen.getByLabelText("Description");
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
     expect(descriptionTextField.value).toBe(
       "Component 1 description of implementing control 1"
     );
@@ -81,17 +98,9 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
   });
 
   test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
-    const descriptionTextField = screen.getByLabelText("Description");
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-    fireEvent.change(descriptionTextField, {
-      target: { value: "New Description" },
-    });
-    screen
-      .getByRole("button", {
-        name: "save-control-1_smt.a",
-      })
-      .click();
-    expect(descriptionTextField.value).toBe("New Description");
+    changeDescription();
+    saveChanges();
+    expect(descriptionTextField.value).toBe("Test Description");
 
     screen.getByLabelText("control-1_prm_1");
     expect(paramValueTextField.value).toBe(
@@ -100,19 +109,11 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
   });
 
   test(`${parentElementName} saves changes to controller name and description values`, async () => {
-    const descriptionTextField = screen.getByLabelText("Description");
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-    fireEvent.change(descriptionTextField, {
-      target: { value: "Test Description" },
-    });
+    changeDescription();
     fireEvent.change(paramValueTextField, {
       target: { value: "Test Control Name" },
     });
-    screen
-      .getByRole("button", {
-        name: "save-control-1_smt.a",
-      })
-      .click();
+    saveChanges();
     expect(descriptionTextField.value).toBe("Test Description");
     expect(paramValueTextField.value).toBe("Test Control Name");
   });


### PR DESCRIPTION
This is testing the changes made by https://github.com/EasyDynamics/oscal-react-library/pull/525. Specifically, it adds tests to check that if the description is changed, the placeholder values for the blank parameters are displayed, and that if the description and parameters are changed, the new values will be displayed instead of the placeholders.