### PR TITLE
Ensure pipeline fails if tests fail

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,6 +46,10 @@ jobs:
         node: [14, 16]
     name: Build and test (on NodeJS ${{ matrix.node }})
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        # setting the shell to bash will enable fail-fast behavior
+        shell: bash
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Currently, the pipeline will succeed even if the tests fail. This is
because in 0ef14fd we added some additional commands and the tests
executed in the middle of them. By default, the OS's default shell will
be used. When we specify `bash`, the full command shown in the [docs][1]
will be used instead. That will include the `-e` and `pipefail` options.
That will ensure that even commands used in the middle of a `run` will
result in the pipeline failing if there's an issue.

We probably should add this to the root level `defaults` but this is a
quicker fix and I can work on adding it elsewhere later.

[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
