### PR TITLE
Add unit tests for Component UUID edit on save

### DIFF
--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -3,16 +3,26 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import OSCALControlImplementation from "./OSCALControlImplementation";
 import getByTextIncludingChildern from "./oscal-utils/TestUtils";
-import { controlImplTestData, exampleControl } from "../test-data/ControlsData";
+import {
+  controlImplTestData,
+  controlImplWithDecSmtTestData,
+  exampleControl,
+  exampleControlWithDecSmt,
+} from "../test-data/ControlsData";
 import {
   exampleComponents,
   componentsTestData,
+  componentsDecimalTestData,
 } from "../test-data/ComponentsData";
-import { profileModifyTestData } from "../test-data/ModificationsData";
+import {
+  profileModifyTestData,
+  profileModifyDecSmtTestData,
+} from "../test-data/ModificationsData";
 import { sspRestData } from "../test-data/SystemData";
 import testOSCALControlParamLegend from "../common-tests/ControlParamLegend.test";
 
 const controlsTestData = [exampleControl];
+const controlsDecTestData = [exampleControlWithDecSmt];
 
 const emptyProfileModifyTestData = {};
 
@@ -42,6 +52,22 @@ export default function testOSCALControlImplementationImplReq(
     renderer();
     const result = getByTextIncludingChildern(
       "Does something with control 1 / component 1 / parameter 1 value and control 1 / component 1 / parameter 2 value"
+    );
+    expect(result).toBeVisible();
+  });
+
+  test(`${parentElementName}WithDecimalStatements displays component parameters in control prose`, () => {
+    render(
+      <OSCALControlImplementation
+        controlImplementation={controlImplWithDecSmtTestData}
+        components={componentsDecimalTestData}
+        controls={controlsDecTestData}
+        modifications={profileModifyDecSmtTestData}
+        partialRestData={sspRestData}
+      />
+    );
+    const result = getByTextIncludingChildern(
+      "Does something with control 1.1 / component 1.1 / parameter 1 value and control 1.1 / component 1.1 / parameter 2 value"
     );
     expect(result).toBeVisible();
   });

--- a/src/components/OSCALControlProse.test.js
+++ b/src/components/OSCALControlProse.test.js
@@ -4,15 +4,22 @@ import {
   OSCALReplacedProseWithParameterLabel,
   OSCALReplacedProseWithByComponentParameterValue,
 } from "./OSCALControlProse";
-import { exampleModificationSetParameters } from "../test-data/ModificationsData";
+import {
+  exampleModificationSetParameters,
+  exampleModificationSetParametersDecimal,
+} from "../test-data/ModificationsData";
 import {
   controlImplTestData,
+  controlImplWithDecSmtTestData,
   controlProseTestData,
+  controlProseDecimalTestData,
   exampleParams,
+  exampleDecimalParams,
 } from "../test-data/ControlsData";
 import { sspRestData } from "../test-data/SystemData";
 
 const labelTestData = "label-1";
+const labelTestDataDecimal = "label-1.1";
 
 function proseParamLabelsRenderer() {
   render(
@@ -40,6 +47,72 @@ function testOSCALControlProseParamLabels(parentElementName, renderer) {
 
 testOSCALControlProseParamLabels("OSCALControlProse", proseParamLabelsRenderer);
 
+function renderOSCALControlProseEditing(renderer, rollName) {
+  renderer();
+  screen
+    .getByRole("button", {
+      name: rollName,
+    })
+    .click();
+}
+
+function testDefaultDescription(controlName, componentName, parameterValue) {
+  const descriptionTextField = screen.getByLabelText("Description");
+  const paramValueTextField = screen.getByLabelText(parameterValue);
+  expect(descriptionTextField.value).toBe(
+    `${
+      componentName.charAt(0).toUpperCase() +
+      componentName.slice(1).toLowerCase()
+    } description of implementing control 1`
+  );
+
+  expect(paramValueTextField.value).toBe(
+    `${controlName} / ${componentName} / parameter 1 value`
+  );
+}
+
+function EditDescription(
+  controlName,
+  componentName,
+  parameterValue,
+  statementValue
+) {
+  const descriptionTextField = screen.getByLabelText("Description");
+  const paramValueTextField = screen.getByLabelText(parameterValue);
+  fireEvent.change(descriptionTextField, {
+    target: { value: "Test Description" },
+  });
+  screen
+    .getByRole("button", {
+      name: statementValue,
+    })
+    .click();
+  expect(descriptionTextField.value).toBe("Test Description");
+
+  screen.getByLabelText(parameterValue);
+  expect(paramValueTextField.value).toBe(
+    `${controlName} / ${componentName} / parameter 1 value`
+  );
+}
+
+function EditControllerName(parameterValue, statementValue) {
+  const descriptionTextField = screen.getByLabelText("Description");
+  const paramValueTextField = screen.getByLabelText(parameterValue);
+  fireEvent.change(descriptionTextField, {
+    target: { value: "Test Description" },
+  });
+  fireEvent.change(paramValueTextField, {
+    target: { value: "Test Control Name" },
+  });
+  screen
+    .getByRole("button", {
+      name: statementValue,
+    })
+    .click();
+  expect(descriptionTextField.value).toBe("Test Description");
+  expect(paramValueTextField.value).toBe("Test Control Name");
+}
+
 function proseParamValuesEditingRenderer() {
   render(
     <OSCALReplacedProseWithByComponentParameterValue
@@ -59,66 +132,75 @@ function proseParamValuesEditingRenderer() {
 }
 
 function testOSCALControlProseEditing(parentElementName, renderer) {
-  beforeEach(() => {
-    renderer();
-    screen
-      .getByRole("button", {
-        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
-      })
-      .click();
-  });
+  const controlName = "control 1";
+  const componentName = "component 1";
+  const parameterValue = "control-1_prm_1";
+  const statementValue = "save-control-1_smt.a";
+  const rollName = "edit-bycomponent-component-1-statement-control-1_smt.a";
 
   test(`${parentElementName} displays default description and parameter inputs`, async () => {
-    const descriptionTextField = screen.getByLabelText("Description");
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-    expect(descriptionTextField.value).toBe(
-      "Component 1 description of implementing control 1"
-    );
-
-    expect(paramValueTextField.value).toBe(
-      "control 1 / component 1 / parameter 1 value"
-    );
+    renderOSCALControlProseEditing(renderer, rollName);
+    testDefaultDescription(controlName, componentName, parameterValue);
   });
 
   test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
-    const descriptionTextField = screen.getByLabelText("Description");
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-    fireEvent.change(descriptionTextField, {
-      target: { value: "Test Description" },
-    });
-    screen
-      .getByRole("button", {
-        name: "save-control-1_smt.a",
-      })
-      .click();
-    expect(descriptionTextField.value).toBe("Test Description");
-
-    screen.getByLabelText("control-1_prm_1");
-    expect(paramValueTextField.value).toBe(
-      "control 1 / component 1 / parameter 1 value"
-    );
+    renderOSCALControlProseEditing(renderer, rollName);
+    EditDescription(controlName, componentName, parameterValue, statementValue);
   });
 
   test(`${parentElementName} saves changes to controller name and description values`, async () => {
-    const descriptionTextField = screen.getByLabelText("Description");
-    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-    fireEvent.change(descriptionTextField, {
-      target: { value: "Test Description" },
-    });
-    fireEvent.change(paramValueTextField, {
-      target: { value: "Test Control Name" },
-    });
-    screen
-      .getByRole("button", {
-        name: "save-control-1_smt.a",
-      })
-      .click();
-    expect(descriptionTextField.value).toBe("Test Description");
-    expect(paramValueTextField.value).toBe("Test Control Name");
+    renderOSCALControlProseEditing(renderer, rollName);
+    EditControllerName(parameterValue, statementValue);
   });
 }
 
 testOSCALControlProseEditing(
   "OSCALReplacedProseWithByComponentParameterValue",
   proseParamValuesEditingRenderer
+);
+
+function proseDecimalParamValuesEditingRenderer() {
+  render(
+    <OSCALReplacedProseWithByComponentParameterValue
+      label={labelTestDataDecimal}
+      prose={controlProseDecimalTestData}
+      parameters={exampleDecimalParams}
+      implementedRequirement={
+        controlImplWithDecSmtTestData["implemented-requirements"][0]
+      }
+      statementId="control-1.1_smt.a"
+      componentId="component-1.1"
+      modificationSetParameters={exampleModificationSetParametersDecimal}
+      isEditable
+      partialRestData={sspRestData}
+    />
+  );
+}
+
+function testOSCALControlDecimalProseEditing(parentElementName, renderer) {
+  const controlName = "control 1.1";
+  const componentName = "component 1.1";
+  const parameterValue = "control-1.1_prm_1";
+  const statementValue = "save-control-1.1_smt.a";
+  const rollName = "edit-bycomponent-component-1.1-statement-control-1.1_smt.a";
+
+  test(`${parentElementName} displays default description and parameter inputs`, async () => {
+    renderOSCALControlProseEditing(renderer, rollName);
+    testDefaultDescription(controlName, componentName, parameterValue);
+  });
+
+  test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
+    renderOSCALControlProseEditing(renderer, rollName);
+    EditDescription(controlName, componentName, parameterValue, statementValue);
+  });
+
+  test(`${parentElementName} saves changes to controller name and description values`, async () => {
+    renderOSCALControlProseEditing(renderer, rollName);
+    EditControllerName(parameterValue, statementValue);
+  });
+}
+
+testOSCALControlDecimalProseEditing(
+  "OSCALReplacedProseWithByComponentParameterWithDecimalValue",
+  proseDecimalParamValuesEditingRenderer
 );

--- a/src/components/OSCALControlProse.test.js
+++ b/src/components/OSCALControlProse.test.js
@@ -47,72 +47,6 @@ function testOSCALControlProseParamLabels(parentElementName, renderer) {
 
 testOSCALControlProseParamLabels("OSCALControlProse", proseParamLabelsRenderer);
 
-function renderOSCALControlProseEditing(renderer, rollName) {
-  renderer();
-  screen
-    .getByRole("button", {
-      name: rollName,
-    })
-    .click();
-}
-
-function testDefaultDescription(controlName, componentName, parameterValue) {
-  const descriptionTextField = screen.getByLabelText("Description");
-  const paramValueTextField = screen.getByLabelText(parameterValue);
-  expect(descriptionTextField.value).toBe(
-    `${
-      componentName.charAt(0).toUpperCase() +
-      componentName.slice(1).toLowerCase()
-    } description of implementing control 1`
-  );
-
-  expect(paramValueTextField.value).toBe(
-    `${controlName} / ${componentName} / parameter 1 value`
-  );
-}
-
-function EditDescription(
-  controlName,
-  componentName,
-  parameterValue,
-  statementValue
-) {
-  const descriptionTextField = screen.getByLabelText("Description");
-  const paramValueTextField = screen.getByLabelText(parameterValue);
-  fireEvent.change(descriptionTextField, {
-    target: { value: "Test Description" },
-  });
-  screen
-    .getByRole("button", {
-      name: statementValue,
-    })
-    .click();
-  expect(descriptionTextField.value).toBe("Test Description");
-
-  screen.getByLabelText(parameterValue);
-  expect(paramValueTextField.value).toBe(
-    `${controlName} / ${componentName} / parameter 1 value`
-  );
-}
-
-function EditControllerName(parameterValue, statementValue) {
-  const descriptionTextField = screen.getByLabelText("Description");
-  const paramValueTextField = screen.getByLabelText(parameterValue);
-  fireEvent.change(descriptionTextField, {
-    target: { value: "Test Description" },
-  });
-  fireEvent.change(paramValueTextField, {
-    target: { value: "Test Control Name" },
-  });
-  screen
-    .getByRole("button", {
-      name: statementValue,
-    })
-    .click();
-  expect(descriptionTextField.value).toBe("Test Description");
-  expect(paramValueTextField.value).toBe("Test Control Name");
-}
-
 function proseParamValuesEditingRenderer() {
   render(
     <OSCALReplacedProseWithByComponentParameterValue
@@ -132,25 +66,75 @@ function proseParamValuesEditingRenderer() {
 }
 
 function testOSCALControlProseEditing(parentElementName, renderer) {
-  const controlName = "control 1";
-  const componentName = "component 1";
-  const parameterValue = "control-1_prm_1";
-  const statementValue = "save-control-1_smt.a";
-  const rollName = "edit-bycomponent-component-1-statement-control-1_smt.a";
-
   test(`${parentElementName} displays default description and parameter inputs`, async () => {
-    renderOSCALControlProseEditing(renderer, rollName);
-    testDefaultDescription(controlName, componentName, parameterValue);
+    renderer();
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+      })
+      .click();
+
+    const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+    expect(descriptionTextField.value).toBe(
+      "Component 1 description of implementing control 1"
+    );
+
+    expect(paramValueTextField.value).toBe(
+      "control 1 / component 1 / parameter 1 value"
+    );
   });
 
   test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
-    renderOSCALControlProseEditing(renderer, rollName);
-    EditDescription(controlName, componentName, parameterValue, statementValue);
+    renderer();
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+      })
+      .click();
+
+    const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+    fireEvent.change(descriptionTextField, {
+      target: { value: "Test Description" },
+    });
+    screen
+      .getByRole("button", {
+        name: "save-control-1_smt.a",
+      })
+      .click();
+    expect(descriptionTextField.value).toBe("Test Description");
+
+    screen.getByLabelText("control-1_prm_1");
+    expect(paramValueTextField.value).toBe(
+      "control 1 / component 1 / parameter 1 value"
+    );
   });
 
   test(`${parentElementName} saves changes to controller name and description values`, async () => {
-    renderOSCALControlProseEditing(renderer, rollName);
-    EditControllerName(parameterValue, statementValue);
+    renderer();
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1-statement-control-1_smt.a",
+      })
+      .click();
+
+    const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1_prm_1");
+    fireEvent.change(descriptionTextField, {
+      target: { value: "Test Description" },
+    });
+    fireEvent.change(paramValueTextField, {
+      target: { value: "Test Control Name" },
+    });
+    screen
+      .getByRole("button", {
+        name: "save-control-1_smt.a",
+      })
+      .click();
+
+    expect(descriptionTextField.value).toBe("Test Description");
+    expect(paramValueTextField.value).toBe("Test Control Name");
   });
 }
 
@@ -178,25 +162,75 @@ function proseDecimalParamValuesEditingRenderer() {
 }
 
 function testOSCALControlDecimalProseEditing(parentElementName, renderer) {
-  const controlName = "control 1.1";
-  const componentName = "component 1.1";
-  const parameterValue = "control-1.1_prm_1";
-  const statementValue = "save-control-1.1_smt.a";
-  const rollName = "edit-bycomponent-component-1.1-statement-control-1.1_smt.a";
-
   test(`${parentElementName} displays default description and parameter inputs`, async () => {
-    renderOSCALControlProseEditing(renderer, rollName);
-    testDefaultDescription(controlName, componentName, parameterValue);
+    renderer();
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1.1-statement-control-1.1_smt.a",
+      })
+      .click();
+
+    const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1.1_prm_1");
+    expect(descriptionTextField.value).toBe(
+      "Component 1.1 description of implementing control 1"
+    );
+
+    expect(paramValueTextField.value).toBe(
+      "control 1.1 / component 1.1 / parameter 1 value"
+    );
   });
 
   test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
-    renderOSCALControlProseEditing(renderer, rollName);
-    EditDescription(controlName, componentName, parameterValue, statementValue);
+    renderer();
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1.1-statement-control-1.1_smt.a",
+      })
+      .click();
+
+    const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1.1_prm_1");
+    fireEvent.change(descriptionTextField, {
+      target: { value: "Test Description" },
+    });
+    screen
+      .getByRole("button", {
+        name: "save-control-1.1_smt.a",
+      })
+      .click();
+    expect(descriptionTextField.value).toBe("Test Description");
+
+    screen.getByLabelText("control-1.1_prm_1");
+    expect(paramValueTextField.value).toBe(
+      "control 1.1 / component 1.1 / parameter 1 value"
+    );
   });
 
   test(`${parentElementName} saves changes to controller name and description values`, async () => {
-    renderOSCALControlProseEditing(renderer, rollName);
-    EditControllerName(parameterValue, statementValue);
+    renderer();
+    screen
+      .getByRole("button", {
+        name: "edit-bycomponent-component-1.1-statement-control-1.1_smt.a",
+      })
+      .click();
+
+    const descriptionTextField = screen.getByLabelText("Description");
+    const paramValueTextField = screen.getByLabelText("control-1.1_prm_1");
+    fireEvent.change(descriptionTextField, {
+      target: { value: "Test Description" },
+    });
+    fireEvent.change(paramValueTextField, {
+      target: { value: "Test Control Name" },
+    });
+    screen
+      .getByRole("button", {
+        name: "save-control-1.1_smt.a",
+      })
+      .click();
+
+    expect(descriptionTextField.value).toBe("Test Description");
+    expect(paramValueTextField.value).toBe("Test Control Name");
   });
 }
 

--- a/src/test-data/ComponentsData.js
+++ b/src/test-data/ComponentsData.js
@@ -110,6 +110,13 @@ export const componentsTestData = [
   },
 ];
 
+export const componentsDecimalTestData = [
+  {
+    uuid: "component-1.1",
+    title: "Component 1.1 Title",
+  },
+];
+
 export const exampleComponentDefinitionComponent = {
   uuid: "b036a6ac-6cff-4066-92bc-74ddfd9ad6fa",
   type: "software",

--- a/src/test-data/ControlsData.js
+++ b/src/test-data/ControlsData.js
@@ -1,5 +1,7 @@
 export const controlProseTestData =
   "Does something with {{ insert: param, control-1_prm_1 }} and {{ insert: param, control-1_prm_2 }}, and a set value of {{ insert: param, control-1_prm_3 }}";
+export const controlProseDecimalTestData =
+  "Does something with {{ insert: param, control-1.1_prm_1 }} and {{ insert: param, control-1.1_prm_2 }}, and a set value of {{ insert: param, control-1.1_prm_3 }}";
 
 export const controlId = "control-1";
 export const statementId = "statement-1";
@@ -12,6 +14,17 @@ export const exampleParams = [
   {
     id: "control-1_prm_2",
     label: "control 2 label",
+  },
+];
+
+export const exampleDecimalParams = [
+  {
+    id: "control-1.1_prm_1",
+    label: "control 1.1 / parameter 1 label",
+  },
+  {
+    id: "control-1.1_prm_2",
+    label: "control 1.1 / parameter 2 label",
   },
 ];
 

--- a/src/test-data/ControlsData.js
+++ b/src/test-data/ControlsData.js
@@ -51,6 +51,42 @@ export const exampleControl = {
   ],
 };
 
+export const exampleControlWithDecSmt = {
+  id: "control-1",
+  title: "Control 1 Title",
+  params: [
+    {
+      id: "control-1.1_prm_1",
+      label: "control 1.1 / parameter 1 label",
+    },
+    {
+      id: "control-1.1_prm_2",
+      label: "control 1.1 / parameter 2 label",
+    },
+  ],
+  parts: [
+    {
+      id: "control-1.1_smt",
+      name: "statement",
+      prose: "Some organizational group:",
+      parts: [
+        {
+          id: "control-1.1_smt.a",
+          name: "item",
+          props: [
+            {
+              name: "label",
+              value: "a.",
+            },
+          ],
+          prose:
+            "Does something with {{ insert: param, control-1.1_prm_1 }} and {{ insert: param, control-1.1_prm_2 }}",
+        },
+      ],
+    },
+  ],
+};
+
 export const controlsData = [
   {
     id: exampleControl.id,
@@ -142,6 +178,40 @@ export const controlImplTestData = {
                 {
                   "param-id": "control-1_prm_2",
                   values: ["control 1 / component 1 / parameter 2 value"],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const controlImplWithDecSmtTestData = {
+  description: "This is the control implementation for the system.",
+  "implemented-requirements": [
+    {
+      uuid: "implemented-requirements-1",
+      "control-id": "control-1",
+      statements: [
+        {
+          "statement-id": "control-1.1_smt.a",
+          uuid: "f3887a91-9ed3-425c-b305-21e4634a1c34",
+          "by-components": [
+            {
+              "component-uuid": "component-1.1",
+              uuid: "a74681b2-fbcb-46eb-90fd-0d55aa74ac7b",
+              description:
+                "Component 1.1 description of implementing control 1",
+              "set-parameters": [
+                {
+                  "param-id": "control-1.1_prm_1",
+                  values: ["control 1.1 / component 1.1 / parameter 1 value"],
+                },
+                {
+                  "param-id": "control-1.1_prm_2",
+                  values: ["control 1.1 / component 1.1 / parameter 2 value"],
                 },
               ],
             },

--- a/src/test-data/ModificationsData.js
+++ b/src/test-data/ModificationsData.js
@@ -28,6 +28,29 @@ export const exampleModificationSetParameters = [
   },
 ];
 
+export const exampleModificationSetParametersDecimal = [
+  {
+    "param-id": "control-1.1_prm_1",
+    constraints: [
+      {
+        description: "some constraint",
+      },
+    ],
+  },
+  {
+    "param-id": "control-1.1_prm_2",
+    constraints: [
+      {
+        description: "another constraint",
+      },
+    ],
+  },
+  {
+    "param-id": "control-1.1_prm_3",
+    values: ["param 3 value"],
+  },
+];
+
 export const exampleModificationAlters = [
   {
     "control-id": "control-1",
@@ -69,6 +92,11 @@ const exampleModificationAltersSmt = [
 
 export const profileModifyTestData = {
   "set-parameters": exampleModificationSetParameters,
+  alters: exampleModificationAltersTopLevel,
+};
+
+export const profileModifyDecSmtTestData = {
+  "set-parameters": exampleModificationSetParametersDecimal,
   alters: exampleModificationAltersTopLevel,
 };
 


### PR DESCRIPTION
This adds unit tests for [PR #538](https://github.com/EasyDynamics/oscal-react-library/pull/538). Test data was created to test for statements including decimal statements.