### PR TITLE
Make fields with prose statements support markdown

### DIFF
--- a/src/components/OSCALControlGuidance.js
+++ b/src/components/OSCALControlGuidance.js
@@ -6,7 +6,7 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
-
+import OSCALMarkdownProse from "./OSCALMarkdownProse";
 const OSCALControlGuidanceButton = styled(Button)(
   ({ theme }) => `
   color: ${theme.palette.primary.main};
@@ -58,7 +58,7 @@ export default function OSCALControlGuidance(props) {
             ref={descriptionElementRef}
             tabIndex={-1}
           >
-            {props.prose}
+            {<OSCALMarkdownProse text = {props.prose}/>}
           </DialogContentText>
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
There are statements in the controls descriptions and guidance areas where markdown is not supported which can make it hard to read. Convert prose statements in the guidance and descriptions of controls into markdown.