### PR TITLE
Make Citations, titles and, descriptions appear in markdown in backmatter

### DIFF
--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -10,7 +10,7 @@ import DescriptionIcon from "@mui/icons-material/Description";
 import StyledTooltip from "./OSCALStyledTooltip";
 import { getAbsoluteUrl } from "./oscal-utils/OSCALLinkUtils";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
-import { OSCALMarkupLine } from "./OSCALMarkupProse";
+import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
 export const OSCALBackMatterCard = styled(Card)(
   ({ theme }) => `
@@ -49,7 +49,7 @@ function DescriptionDisplay(props) {
   }
   return (
     <StyledTooltip
-      title={<OSCALMarkupLine text={props.resource.description} />}
+      title={<OSCALMarkupMultiLine text={props.resource.description} />}
     >
       <DescriptionIcon
         color="primary"

--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -10,6 +10,7 @@ import DescriptionIcon from "@mui/icons-material/Description";
 import StyledTooltip from "./OSCALStyledTooltip";
 import { getAbsoluteUrl } from "./oscal-utils/OSCALLinkUtils";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
+import { OSCALMarkupLine } from "./OSCALMarkupProse";
 
 export const OSCALBackMatterCard = styled(Card)(
   ({ theme }) => `
@@ -31,7 +32,7 @@ function TitleDisplay(props) {
   const color = props.resource.title ? "initial" : "error";
   return (
     <Typography color={color} variant="subtitle1">
-      {title}
+      <OSCALMarkupLine text={title} />
     </Typography>
   );
 }
@@ -47,7 +48,9 @@ function DescriptionDisplay(props) {
     );
   }
   return (
-    <StyledTooltip title={props.resource.description}>
+    <StyledTooltip
+      title={<OSCALMarkupLine text={props.resource.description} />}
+    >
       <DescriptionIcon
         color="primary"
         fontSize="small"
@@ -68,7 +71,9 @@ function CitationDisplay(props) {
     );
   }
   return (
-    <StyledTooltip title={props.resource.citation.text}>
+    <StyledTooltip
+      title={<OSCALMarkupLine text={props.resource.citation.text} />}
+    >
       <FormatQuoteIcon
         color="primary"
         fontSize="small"

--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -33,7 +33,7 @@ function TitleDisplay(props) {
   const color = props.resource.title ? "initial" : "error";
   return (
     <Typography color={color} variant="subtitle1">
-      <OSCALMarkupLine text={title} />
+      <OSCALMarkupLine>{title}</OSCALMarkupLine>
     </Typography>
   );
 }
@@ -50,7 +50,11 @@ function DescriptionDisplay(props) {
   }
   return (
     <StyledTooltip
-      title={<OSCALMarkupMultiLine text={props.resource.description} />}
+      title={
+        <OSCALMarkupMultiLine>
+          {props.resource.description}
+        </OSCALMarkupMultiLine>
+      }
     >
       <DescriptionIcon
         color="primary"
@@ -73,7 +77,7 @@ function CitationDisplay(props) {
   }
   return (
     <StyledTooltip
-      title={<OSCALMarkupLine text={props.resource.citation.text} />}
+      title={<OSCALMarkupLine>{props.resource.citation.text}</OSCALMarkupLine>}
     >
       <FormatQuoteIcon
         color="primary"


### PR DESCRIPTION
The Backmatter has markup language shown in prose in the screenshots below. Wrap them in a `OSCALMarkupProse` component so that it is easier for users to read.
<img src = "https://user-images.githubusercontent.com/106985986/183956830-aa5ad573-456b-4aa3-8ead-201248b6ce01.png"><br/><img src="https://user-images.githubusercontent.com/106985986/183957500-d053710d-1a3b-4182-9cd2-9fc62e421af5.png">
