### PR TITLE
Update Storybook deployment workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,35 +4,50 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
-concurrency: gh-pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "gh-pages"
+  cancel-in-progress: true
 
 jobs:
-  publish:
-    name: Publish Storybook to GitHub Pages
-    permissions:
-      contents: write
-    runs-on: ubuntu-20.04
+  build:
+    name: Build Storybook site
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v3
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: "npm"
+      - name: Setup pages
+        uses: actions/configure-pages@v1
       - name: Globally update npm
         run: npm install -g npm@latest
       - name: Install dependencies
         run: npm ci
       - name: Build Storybook
         run: npm run build-storybook
-      - name: Deploy to Pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          branch: storybook-docs
-          folder: storybook-static
-          clean: true
-          single-commit: true
-          git-config-name: Easy Dynamics Automation
-          git-config-email: noreply@easydynamics.com
+          path: storybook-static
+          retention-days: "7"
+
+  deploy:
+    environment:
+      name: storybook
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 node_modules/
 dist/
 
+# Storybook files
+storybook-static/
+
 # dependencies
 /node_modules
 /.pnp


### PR DESCRIPTION
This updates the GitHub Pages deployment to use the new deployment
Actions provided by GitHub that are now GA. This is based off the
[starter workflow][1] from GitHub Actions.

Also, we apparently haven't been ignoring the Storybook output directory
so that's now added to the `.gitignore` file.

[1]: https://github.com/actions/starter-workflows/blob/main/pages/static.yml
