### PR TITLE
Make prose fields support markdown 

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1390,12 +1390,7 @@
             "chalk": "^3.0.0",
             "css.escape": "^1.5.1",
             "dom-accessibility-api": "^0.5.6",
-            "jest-environment-jsdom-sixteen": "^1.0.3",
-            "jest-watch-select-projects": "^2.0.0",
-            "jsdom": "^16.2.1",
-            "kcd-scripts": "^11.1.0",
             "lodash": "^4.17.15",
-            "pretty-format": "^25.1.0",
             "redent": "^3.0.0"
           }
         },
@@ -1405,42 +1400,13 @@
           "requires": {
             "@babel/runtime": "^7.12.5",
             "@testing-library/dom": "^8.0.0",
-            "@testing-library/jest-dom": "^5.11.6",
-            "@types/react-dom": "<18.0.0",
-            "dotenv-cli": "^4.0.0",
-            "kcd-scripts": "^11.1.0",
-            "npm-run-all": "^4.1.5",
-            "react": "^17.0.1",
-            "react-dom": "^17.0.1",
-            "rimraf": "^3.0.2",
-            "typescript": "^4.1.2"
+            "@types/react-dom": "<18.0.0"
           }
         },
         "@testing-library/user-event": {
           "version": "14.4.3",
           "dev": true,
-          "requires": {
-            "@ph.fritsche/scripts-config": "^2.4.0",
-            "@testing-library/dom": "^8.11.4",
-            "@testing-library/jest-dom": "^5.16.3",
-            "@testing-library/react": "^13.0.0",
-            "@types/jest-in-case": "^1.0.3",
-            "@types/react": "^17.0.42",
-            "eslint-import-resolver-typescript": "^2.7.0",
-            "eslint-plugin-local-rules": "^1.1.0",
-            "is-ci": "^3.0.1",
-            "jest-in-case": "^1.0.2",
-            "jest-serializer-ansi": "^1.0.3",
-            "kcd-scripts": "^12.1.0",
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0",
-            "react17": "npm:react@^17.0.2",
-            "reactDom17": "npm:react-dom@^17.0.2",
-            "reactIs17": "npm:react-is@^17.0.2",
-            "reactTesting17": "npm:@testing-library/react@^12.1.3",
-            "shared-scripts": "^1.5.1",
-            "typescript": "^4.1.2"
-          }
+          "requires": {}
         },
         "history": {
           "version": "5.3.0",
@@ -1506,10 +1472,8 @@
             "postcss-normalize": "^10.0.1",
             "postcss-preset-env": "^7.0.1",
             "prompts": "^2.4.2",
-            "react": "^18.0.0",
             "react-app-polyfill": "^3.0.0",
             "react-dev-utils": "^12.0.1",
-            "react-dom": "^18.0.0",
             "react-refresh": "^0.11.0",
             "resolve": "^1.20.0",
             "resolve-url-loader": "^4.0.0",
@@ -1580,12 +1544,7 @@
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.5.6",
-        "jest-environment-jsdom-sixteen": "^1.0.3",
-        "jest-watch-select-projects": "^2.0.0",
-        "jsdom": "^16.2.1",
-        "kcd-scripts": "^11.1.0",
         "lodash": "^4.17.15",
-        "pretty-format": "^25.1.0",
         "redent": "^3.0.0"
       }
     },
@@ -1594,41 +1553,12 @@
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
-        "@testing-library/jest-dom": "^5.11.6",
-        "@types/react-dom": "<18.0.0",
-        "dotenv-cli": "^4.0.0",
-        "kcd-scripts": "^11.1.0",
-        "npm-run-all": "^4.1.5",
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1",
-        "rimraf": "^3.0.2",
-        "typescript": "^4.1.2"
+        "@types/react-dom": "<18.0.0"
       }
     },
     "@testing-library/user-event": {
       "version": "file:../node_modules/@testing-library/user-event",
-      "requires": {
-        "@ph.fritsche/scripts-config": "^2.4.0",
-        "@testing-library/dom": "^8.11.4",
-        "@testing-library/jest-dom": "^5.16.3",
-        "@testing-library/react": "^13.0.0",
-        "@types/jest-in-case": "^1.0.3",
-        "@types/react": "^17.0.42",
-        "eslint-import-resolver-typescript": "^2.7.0",
-        "eslint-plugin-local-rules": "^1.1.0",
-        "is-ci": "^3.0.1",
-        "jest-in-case": "^1.0.2",
-        "jest-serializer-ansi": "^1.0.3",
-        "kcd-scripts": "^12.1.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "react17": "npm:react@^17.0.2",
-        "reactDom17": "npm:react-dom@^17.0.2",
-        "reactIs17": "npm:react-is@^17.0.2",
-        "reactTesting17": "npm:@testing-library/react@^12.1.3",
-        "shared-scripts": "^1.5.1",
-        "typescript": "^4.1.2"
-      }
+      "requires": {}
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1894,10 +1824,8 @@
         "postcss-normalize": "^10.0.1",
         "postcss-preset-env": "^7.0.1",
         "prompts": "^2.4.2",
-        "react": "^18.0.0",
         "react-app-polyfill": "^3.0.0",
         "react-dev-utils": "^12.0.1",
-        "react-dom": "^18.0.0",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
         "resolve-url-loader": "^4.0.0",

--- a/src/components/OSCALComponentDefinitionControlImplementation.test.js
+++ b/src/components/OSCALComponentDefinitionControlImplementation.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import OSCALComponentDefinitionControlImplementation from "./OSCALComponentDefinitionControlImplementation";
-import getByTextIncludingChildern from "./oscal-utils/TestUtils";
+import getByTextIncludingChildren from "./oscal-utils/TestUtils";
 import { controlsData } from "../test-data/ControlsData";
 import {
   componentDefinitionControlImplementationTestData,
@@ -43,12 +43,12 @@ test("OSCALComponentDefinitionControlImplementation displays component parameter
       controls={controlsData}
     />
   );
-  const nonplaceholder1 = getByTextIncludingChildern(/Does something with/i);
-  const placeholderText1 = getByTextIncludingChildern(
+  const nonplaceholder1 = getByTextIncludingChildren(/Does something with/i);
+  const placeholderText1 = getByTextIncludingChildren(
     /< control 1 \/ parameter 1 label >/i
   );
-  const nonplaceholder2 = getByTextIncludingChildern(/and/i);
-  const placeholderText2 = getByTextIncludingChildern(
+  const nonplaceholder2 = getByTextIncludingChildren(/and/i);
+  const placeholderText2 = getByTextIncludingChildren(
     /< control 1 \/ parameter 2 label >/i
   );
 

--- a/src/components/OSCALComponentDefinitionControlImplementation.test.js
+++ b/src/components/OSCALComponentDefinitionControlImplementation.test.js
@@ -43,10 +43,19 @@ test("OSCALComponentDefinitionControlImplementation displays component parameter
       controls={controlsData}
     />
   );
-  const resultByProse = getByTextIncludingChildern(
-    "Does something with < control 1 / parameter 1 label > and < control 1 / parameter 2 label >"
+  const nonplaceholder1 = getByTextIncludingChildern(/Does something with/i);
+  const placeholderText1 = getByTextIncludingChildern(
+    /< control 1 \/ parameter 1 label >/i
   );
-  expect(resultByProse).toBeVisible();
+  const nonplaceholder2 = getByTextIncludingChildern(/and/i);
+  const placeholderText2 = getByTextIncludingChildern(
+    /< control 1 \/ parameter 2 label >/i
+  );
+
+  expect(nonplaceholder1).toBeVisible();
+  expect(placeholderText1).toBeVisible();
+  expect(nonplaceholder2).toBeVisible();
+  expect(placeholderText2).toBeVisible();
 });
 
 testOSCALControlParamLegend(

--- a/src/components/OSCALControlGuidance.js
+++ b/src/components/OSCALControlGuidance.js
@@ -59,7 +59,7 @@ export default function OSCALControlGuidance(props) {
             ref={descriptionElementRef}
             tabIndex={-1}
           >
-            <OSCALMarkupLine text={props.prose} />
+            <OSCALMarkupLine>{props.prose}</OSCALMarkupLine>
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/components/OSCALControlGuidance.js
+++ b/src/components/OSCALControlGuidance.js
@@ -59,7 +59,7 @@ export default function OSCALControlGuidance(props) {
             ref={descriptionElementRef}
             tabIndex={-1}
           >
-           <OSCALMarkupLine text =  {props.prose}/>
+            <OSCALMarkupLine text={props.prose} />
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/components/OSCALControlGuidance.js
+++ b/src/components/OSCALControlGuidance.js
@@ -6,6 +6,7 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
+import { OSCALMarkupLine } from "./OSCALMarkupProse";
 
 const OSCALControlGuidanceButton = styled(Button)(
   ({ theme }) => `
@@ -58,7 +59,7 @@ export default function OSCALControlGuidance(props) {
             ref={descriptionElementRef}
             tabIndex={-1}
           >
-            {props.prose}
+           <OSCALMarkupLine text =  {props.prose}/>
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import OSCALControlImplementation from "./OSCALControlImplementation";
-import getByTextIncludingChildern from "./oscal-utils/TestUtils";
+import getByTextIncludingChildren from "./oscal-utils/TestUtils";
 import { controlImplTestData, exampleControl } from "../test-data/ControlsData";
 import {
   exampleComponents,
@@ -40,12 +40,12 @@ export default function testOSCALControlImplementationImplReq(
 
   test(`${parentElementName} displays component parameters in control prose`, () => {
     renderer();
-    const nonplaceholder1 = getByTextIncludingChildern(/does something with/i);
-    const placeholderText1 = getByTextIncludingChildern(
+    const nonplaceholder1 = getByTextIncludingChildren(/does something with/i);
+    const placeholderText1 = getByTextIncludingChildren(
       /control 1 \/ component 1 \/ parameter 1 value/i
     );
-    const nonplaceholder2 = getByTextIncludingChildern(/and/i);
-    const placeholderText2 = getByTextIncludingChildern(
+    const nonplaceholder2 = getByTextIncludingChildren(/and/i);
+    const placeholderText2 = getByTextIncludingChildren(
       /control 1 \/ component 1 \/ parameter 2 value/i
     );
 

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -3,26 +3,16 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import OSCALControlImplementation from "./OSCALControlImplementation";
 import getByTextIncludingChildern from "./oscal-utils/TestUtils";
-import {
-  controlImplTestData,
-  controlImplWithDecSmtTestData,
-  exampleControl,
-  exampleControlWithDecSmt,
-} from "../test-data/ControlsData";
+import { controlImplTestData, exampleControl } from "../test-data/ControlsData";
 import {
   exampleComponents,
   componentsTestData,
-  componentsDecimalTestData,
 } from "../test-data/ComponentsData";
-import {
-  profileModifyTestData,
-  profileModifyDecSmtTestData,
-} from "../test-data/ModificationsData";
+import { profileModifyTestData } from "../test-data/ModificationsData";
 import { sspRestData } from "../test-data/SystemData";
 import testOSCALControlParamLegend from "../common-tests/ControlParamLegend.test";
 
 const controlsTestData = [exampleControl];
-const controlsDecTestData = [exampleControlWithDecSmt];
 
 const emptyProfileModifyTestData = {};
 
@@ -50,26 +40,19 @@ export default function testOSCALControlImplementationImplReq(
 
   test(`${parentElementName} displays component parameters in control prose`, () => {
     renderer();
-    const result = getByTextIncludingChildern(
-      "Does something with control 1 / component 1 / parameter 1 value and control 1 / component 1 / parameter 2 value"
+    const nonplaceholder1 = getByTextIncludingChildern(/does something with/i);
+    const placeholderText1 = getByTextIncludingChildern(
+      /control 1 \/ component 1 \/ parameter 1 value/i
     );
-    expect(result).toBeVisible();
-  });
+    const nonplaceholder2 = getByTextIncludingChildern(/and/i);
+    const placeholderText2 = getByTextIncludingChildern(
+      /control 1 \/ component 1 \/ parameter 2 value/i
+    );
 
-  test(`${parentElementName}WithDecimalStatements displays component parameters in control prose`, () => {
-    render(
-      <OSCALControlImplementation
-        controlImplementation={controlImplWithDecSmtTestData}
-        components={componentsDecimalTestData}
-        controls={controlsDecTestData}
-        modifications={profileModifyDecSmtTestData}
-        partialRestData={sspRestData}
-      />
-    );
-    const result = getByTextIncludingChildern(
-      "Does something with control 1.1 / component 1.1 / parameter 1 value and control 1.1 / component 1.1 / parameter 2 value"
-    );
-    expect(result).toBeVisible();
+    expect(nonplaceholder1).toBeVisible();
+    expect(placeholderText1).toBeVisible();
+    expect(nonplaceholder2).toBeVisible();
+    expect(placeholderText2).toBeVisible();
   });
 
   test(`${parentElementName} displays component implementation description`, async () => {

--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -11,7 +11,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import StyledTooltip from "./OSCALStyledTooltip";
 import { getStatementByComponent } from "./oscal-utils/OSCALControlResolver";
 import * as restUtils from "./oscal-utils/OSCALRestUtils";
-import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
+import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
 const OSCALStatementEditing = styled(Grid)`
   ${(props) =>
@@ -169,7 +169,7 @@ function getTextSegment(text, key) {
   }
   return (
     <Typography component="span" key={key}>
-      {text}
+      <OSCALMarkupLine text={text} />
     </Typography>
   );
 }
@@ -229,7 +229,7 @@ function getParameterLabelSegment(
     );
     paramSegment = styledParamLabel(
       `param-label-key-${key}`,
-      parameterLabelText
+      <OSCALMarkupLine text={parameterLabelText} />
     );
   }
 
@@ -336,7 +336,7 @@ export function OSCALReplacedProseWithParameterLabel(props) {
             index
           );
         })
-    : props.prose;
+    : getTextSegment(props.prose, 0);
 
   if (!props.isImplemented) {
     return (

--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -169,7 +169,7 @@ function getTextSegment(text, key) {
   }
   return (
     <Typography component="span" key={key}>
-      <OSCALMarkupLine text={text} />
+      <OSCALMarkupLine>{text}</OSCALMarkupLine>
     </Typography>
   );
 }
@@ -229,7 +229,7 @@ function getParameterLabelSegment(
     );
     paramSegment = styledParamLabel(
       `param-label-key-${key}`,
-      <OSCALMarkupLine text={parameterLabelText} />
+      <OSCALMarkupLine>{parameterLabelText}</OSCALMarkupLine>
     );
   }
 


### PR DESCRIPTION
There are statements in the controls descriptions and guidance areas where markdown is not supported which can make it hard to read. Convert prose statements in the guidance and descriptions of controls into markdown.
This is came from issue https://github.com/EasyDynamics/oscal-react-library/pull/546

This commit holds the remade version to resolve merging conflicts