### PR TITLE
Fix OSCALMarkupLine so that metadata title shows

### DIFF
--- a/src/components/OSCALEditableTextField.js
+++ b/src/components/OSCALEditableTextField.js
@@ -61,7 +61,7 @@ function textFieldWithEditableActions(
   return (
     <>
       <Typography display="inline" variant={props.typographyVariant}>
-        <OSCALMarkupLine text={props.value} />
+        <OSCALMarkupLine>{props.value}</OSCALMarkupLine>
       </Typography>
       <OSCALEditableFieldActions
         editedField={props.editedField}


### PR DESCRIPTION
Originally, OSCALMarkupLine was handling the text as props, and
in a recent PR it was changed to handle it as children. As a result,
the metadata title no longer showed up. This PR makes changes in how
the metadata title text is being passed to OSCALMarkupLine so that
it works according to the new implementation of the component.
