### PR TITLE
Remove underscore replacement workaround

### DIFF
--- a/src/components/oscal-utils/OSCALControlResolver.js
+++ b/src/components/oscal-utils/OSCALControlResolver.js
@@ -46,13 +46,8 @@ export function getStatementByComponent(
   statementId,
   componentId
 ) {
-  // TODO: Remove underscore replacement when OSCAL example content is fixed
-  // https://github.com/EasyDynamics/oscal-react-library/issues/511
-  // Locate matching statement to statementId
   const foundStatement = implReqStatements?.find(
-    (statement) =>
-      statement["statement-id"] === statementId ||
-      statement["statement-id"] === statementId.replace("_", "")
+    (statement) => statement["statement-id"] === statementId
   );
   // Error checking: Exit function when statement or it's by-components are not found
   if (!foundStatement || !foundStatement["by-components"]) {


### PR DESCRIPTION
Now that https://github.com/usnistgov/oscal-content/issues/58 has been resolved, the code removing underscores for the `statement-id` is no longer needed.

Closes #511 