### PR TITLE
Update contributing links on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ REACT_APP_REST_BASE_URL=http://localhost:8080/oscal/v1
 
 ## Contributing
 
-For the process of Contributing to the project, please review [CONTRIBUTING.md](/CONTRIBUTING.md)
-and adhere to the [Code of Conduct](/CODE_OF_CONDUCT.md).
+For the process of Contributing to the project, please review
+[CONTRIBUTING.md](https://github.com/EasyDynamics/.github/blob/main/CONTRIBUTING.md)
+and adhere to the
+[Code of Conduct](https://github.com/EasyDynamics/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## Licensing
 


### PR DESCRIPTION
The CODE_OF_CONDUCT.md & CONTRIBUTING.md pages have been moved to a
centralized location in https://github.com/EasyDynamics/.github

Part of closing #563
