### PR TITLE
Remove profile URL workaround

### DIFF
--- a/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/src/components/oscal-utils/OSCALProfileResolver.js
@@ -47,15 +47,6 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
     itemUrl = `${parentUrl}/../${origItemUrl}`;
   }
 
-  // TODO: This is only necessary because of a source issue with OSCAL Content.
-  // Once the issue has been resolved, this can be removed.
-  // https://github.com/EasyDynamics/oscal-react-library/issues/502
-  if (itemUrl.includes("/content/nist.gov/")) {
-    itemUrl = itemUrl.replace("/content/nist.gov/", "/nist.gov/");
-  }
-  if (itemUrl.includes("/content/fedramp.gov/")) {
-    itemUrl = itemUrl.replace("/content/fedramp.gov/", "/fedramp.gov/");
-  }
   itemUrl = fixJsonUrls(itemUrl);
   // Add our current itemUrl to the list of pending processes
   pendingProcesses.push(itemUrl);


### PR DESCRIPTION
https://github.com/usnistgov/oscal-content/issues/59 has been resolved, so this bit of code that fixes content URLs is no longer needed.

This can be tested by loading https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_MODERATE-baseline_profile.json into the profile viewer

Closes #502 