### PR TITLE
Improve media type detection in back matter resource links

### DIFF
--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -9,7 +9,7 @@ import FormatQuoteIcon from "@mui/icons-material/FormatQuote";
 import DescriptionIcon from "@mui/icons-material/Description";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import StyledTooltip from "./OSCALStyledTooltip";
-import { getAbsoluteUrl } from "./oscal-utils/OSCALLinkUtils";
+import { getAbsoluteUrl, getURLMediaType } from "./oscal-utils/OSCALLinkUtils";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
@@ -20,11 +20,6 @@ export const OSCALBackMatterCard = styled(Card)(
     flex-direction: column;
 `
 );
-
-const getURLMediaType = (url) => {
-  const fileExtension = new URL(url).pathname.split(".").reverse()[0];
-  return fileExtension.length <= 4 ? fileExtension.toUpperCase() : "Unknown";
-};
 
 function TitleDisplay(props) {
   const title = props.resource.title || "No Title";

--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -9,7 +9,10 @@ import FormatQuoteIcon from "@mui/icons-material/FormatQuote";
 import DescriptionIcon from "@mui/icons-material/Description";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import StyledTooltip from "./OSCALStyledTooltip";
-import { getAbsoluteUrl, getURLMediaType } from "./oscal-utils/OSCALLinkUtils";
+import {
+  getAbsoluteUrl,
+  guessExtensionFromHref,
+} from "./oscal-utils/OSCALLinkUtils";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
@@ -88,7 +91,7 @@ export default function OSCALBackMatter(props) {
 
   const getMediaType = (rlink) =>
     rlink["media-type"] ||
-    getURLMediaType(getAbsoluteUrl(rlink.href, props.parentUrl));
+    guessExtensionFromHref(getAbsoluteUrl(rlink.href, props.parentUrl));
 
   const backMatterDisplay = (resource) => (
     <Grid item xs={3} key={resource.uuid}>

--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -21,6 +21,11 @@ export const OSCALBackMatterCard = styled(Card)(
 `
 );
 
+const getURLMediaType = (url) => {
+  const fileExtension = new URL(url).pathname.split(".").reverse()[0];
+  return fileExtension.length <= 4 ? fileExtension.toUpperCase() : "Unknown";
+};
+
 function TitleDisplay(props) {
   const title = props.resource.title || "No Title";
   const color = props.resource.title ? "initial" : "error";
@@ -87,7 +92,8 @@ export default function OSCALBackMatter(props) {
   }
 
   const getMediaType = (rlink) =>
-    rlink["media-type"] || getAbsoluteUrl(rlink.href, props.parentUrl);
+    rlink["media-type"] ||
+    getURLMediaType(getAbsoluteUrl(rlink.href, props.parentUrl));
 
   const backMatterDisplay = (resource) => (
     <Grid item xs={3} key={resource.uuid}>

--- a/src/components/OSCALBackMatter.js
+++ b/src/components/OSCALBackMatter.js
@@ -21,13 +21,6 @@ export const OSCALBackMatterCard = styled(Card)(
 `
 );
 
-// TODO: Remove workaround for missing media type
-// https://github.com/EasyDynamics/oscal-react-library/issues/512
-const getURLMediaType = (url) => {
-  const lastUrlPath = url.split("//").pop().split("/").pop();
-  return lastUrlPath.match(/\.[A-Za-z]{3,4}($|\?)/) || "Unknown";
-};
-
 function TitleDisplay(props) {
   const title = props.resource.title || "No Title";
   const color = props.resource.title ? "initial" : "error";
@@ -94,8 +87,7 @@ export default function OSCALBackMatter(props) {
   }
 
   const getMediaType = (rlink) =>
-    rlink["media-type"] ||
-    getURLMediaType(getAbsoluteUrl(rlink.href, props.parentUrl));
+    rlink["media-type"] || getAbsoluteUrl(rlink.href, props.parentUrl);
 
   const backMatterDisplay = (resource) => (
     <Grid item xs={3} key={resource.uuid}>

--- a/src/components/OSCALBackMatter.test.js
+++ b/src/components/OSCALBackMatter.test.js
@@ -8,7 +8,11 @@ import {
   parentUrlTestData,
   revFourCatalog,
 } from "../test-data/Urls";
-import { backMatterTestData } from "../test-data/BackMatterData";
+import {
+  backMatterTestData,
+  exampleBackMatterWithoutMediaTypeAndUnknownExtension,
+  exampleBackMatterWithoutMediaType,
+} from "../test-data/BackMatterData";
 
 function backMatterRenderer() {
   render(
@@ -66,6 +70,32 @@ export default function testOSCALBackMatter(parentElementName, renderer) {
     });
 
     within(button).getByTestId("OpenInNewIcon");
+  });
+
+  test(`${parentElementName} renders valid media type extension`, async () => {
+    render(
+      <OSCALBackMatter
+        backMatter={exampleBackMatterWithoutMediaType}
+        parentUrl={parentUrlTestData}
+      />
+    );
+    const button = screen.getByRole("button", {
+      name: "PNG",
+    });
+    expect(button.getAttribute("href"));
+  });
+
+  test(`${parentElementName} renders "Unknown" media type extension`, async () => {
+    render(
+      <OSCALBackMatter
+        backMatter={exampleBackMatterWithoutMediaTypeAndUnknownExtension}
+        parentUrl={parentUrlTestData}
+      />
+    );
+    const button = screen.getByRole("button", {
+      name: "Unknown",
+    });
+    expect(button.getAttribute("href"));
   });
 }
 

--- a/src/components/OSCALBackMatter.test.js
+++ b/src/components/OSCALBackMatter.test.js
@@ -13,7 +13,6 @@ import {
   exampleBackMatterWithoutMediaTypeAndUnknownExtension,
   exampleBackMatterWithoutMediaType,
 } from "../test-data/BackMatterData";
-import { getURLMediaTypeWithUrl } from "./oscal-utils/TestUtils";
 
 function backMatterRenderer() {
   render(
@@ -102,11 +101,4 @@ export default function testOSCALBackMatter(parentElementName, renderer) {
 
 if (!require.main) {
   testOSCALBackMatter("OSCALBackMatter", backMatterRenderer);
-  expect(getURLMediaTypeWithUrl(`${backMatterTestUrl}/../diagram.png`, "PNG"));
-  expect(
-    getURLMediaTypeWithUrl(
-      `${backMatterTestUrl}/../unknown/unknown-filetype`,
-      "Unknown"
-    )
-  );
 }

--- a/src/components/OSCALBackMatter.test.js
+++ b/src/components/OSCALBackMatter.test.js
@@ -13,6 +13,7 @@ import {
   exampleBackMatterWithoutMediaTypeAndUnknownExtension,
   exampleBackMatterWithoutMediaType,
 } from "../test-data/BackMatterData";
+import { getURLMediaTypeWithUrl } from "./oscal-utils/TestUtils";
 
 function backMatterRenderer() {
   render(
@@ -101,4 +102,11 @@ export default function testOSCALBackMatter(parentElementName, renderer) {
 
 if (!require.main) {
   testOSCALBackMatter("OSCALBackMatter", backMatterRenderer);
+  expect(getURLMediaTypeWithUrl(`${backMatterTestUrl}/../diagram.png`, "PNG"));
+  expect(
+    getURLMediaTypeWithUrl(
+      `${backMatterTestUrl}/../unknown/unknown-filetype`,
+      "Unknown"
+    )
+  );
 }

--- a/src/components/oscal-utils/OSCALLinkUtils.js
+++ b/src/components/oscal-utils/OSCALLinkUtils.js
@@ -43,7 +43,6 @@ function getFileExtension(url) {
   try {
     return new URL(url).pathname.split("/").pop().split(".").pop();
   } catch {
-    console.warn(`Unable to detect extension for: ${url}`);
     return "";
   }
 }
@@ -57,12 +56,8 @@ function getFileExtension(url) {
  */
 export function guessExtensionFromHref(url) {
   const fallbackFileExtension = "Unknown";
-  // TODO: Use an HTTP HEAD request to attempt to get a `Content-Type` header
-  // for the underlying document. The request(s) should likely properly handle
-  // redirects in order to handle DOI URLs etc. This would require refactoring
-  // the length check in the return as well. In fact, doing so may replace the
-  // need for an extension-based check at all. But in implementing that we
-  // should remember that a HEAD is more expensive than splitting strings.
+  // TODO: Use an HTTP HEAD request to attempt to get a `Content-Type` header for the underlying
+  // document. (https://github.com/EasyDynamics/oscal-react-library/issues/580)
   const detectedExtension = getFileExtension(url).toUpperCase();
   const extensionLength = detectedExtension.length;
   // This is purely a guess based on typical file types. When the length is less

--- a/src/components/oscal-utils/OSCALLinkUtils.js
+++ b/src/components/oscal-utils/OSCALLinkUtils.js
@@ -33,15 +33,43 @@ export default function resolveLinkHref(
   );
 }
 
-export function getURLMediaType(url) {
-  let fileExtension = "";
+/**
+ * A helper function for guessExtensionFromHref
+ *
+ * @param url A given href.
+ * @returns A string providing a valid or blank extension type.
+ */
+function getFileExtension(url) {
   try {
-    fileExtension = new URL(url).pathname.split(".").pop();
-    if (fileExtension === "/") {
-      fileExtension = "href";
-    }
+    return new URL(url).pathname.split("/").pop().split(".").pop();
   } catch {
-    fileExtension = "Unknown";
+    console.warn(`Unable to detect extension for: ${url}`);
+    return "";
   }
-  return fileExtension.length <= 4 ? fileExtension.toUpperCase() : "Unknown";
+}
+
+/**
+ * Guesses an extension type based on a provided href, and provides
+ * "Unkown" when an invalid.
+ *
+ * @param url A given href.
+ * @returns A string providing a valid or "Unknown" extension type.
+ */
+export function guessExtensionFromHref(url) {
+  const fallbackFileExtension = "Unknown";
+  // TODO: Use an HTTP HEAD request to attempt to get a `Content-Type` header
+  // for the underlying document. The request(s) should likely properly handle
+  // redirects in order to handle DOI URLs etc. This would require refactoring
+  // the length check in the return as well. In fact, doing so may replace the
+  // need for an extension-based check at all. But in implementing that we
+  // should remember that a HEAD is more expensive than splitting strings.
+  const detectedExtension = getFileExtension(url).toUpperCase();
+  const extensionLength = detectedExtension.length;
+  // This is purely a guess based on typical file types. When the length is less
+  // than 2 or more than 4, it's likely not the file extension we've aquired,
+  // but an unexpected part of the filename.
+  if (extensionLength > 4 || extensionLength < 2) {
+    return fallbackFileExtension;
+  }
+  return detectedExtension;
 }

--- a/src/components/oscal-utils/OSCALLinkUtils.js
+++ b/src/components/oscal-utils/OSCALLinkUtils.js
@@ -32,3 +32,8 @@ export default function resolveLinkHref(
     )
   );
 }
+
+export function getURLMediaType(url) {
+  const fileExtension = new URL(url).pathname.split(".").pop();
+  return fileExtension.length <= 4 ? fileExtension.toUpperCase() : "Unknown";
+}

--- a/src/components/oscal-utils/OSCALLinkUtils.js
+++ b/src/components/oscal-utils/OSCALLinkUtils.js
@@ -34,6 +34,14 @@ export default function resolveLinkHref(
 }
 
 export function getURLMediaType(url) {
-  const fileExtension = new URL(url).pathname.split(".").pop();
+  let fileExtension = "";
+  try {
+    fileExtension = new URL(url).pathname.split(".").pop();
+    if (fileExtension === "/") {
+      fileExtension = "href";
+    }
+  } catch {
+    fileExtension = "Unknown";
+  }
   return fileExtension.length <= 4 ? fileExtension.toUpperCase() : "Unknown";
 }

--- a/src/components/oscal-utils/OSCALLinkUtils.test.js
+++ b/src/components/oscal-utils/OSCALLinkUtils.test.js
@@ -1,0 +1,67 @@
+import { getURLMediaType } from "./OSCALLinkUtils";
+
+describe("getURLMediaType", () => {
+  it("gets favicon", async () => {
+    expect(getURLMediaType("https://easydynamics.com/favicon.ico")).toEqual(
+      "ICO"
+    );
+  });
+
+  it("gets png", async () => {
+    expect(getURLMediaType(`https://easydynamics.com/diagram.png`)).toEqual(
+      "PNG"
+    );
+  });
+
+  it("gets unknown", async () => {
+    expect(
+      getURLMediaType(`https://easydynamics.com/unknown/unknown-filetype`)
+    ).toEqual("Unknown");
+  });
+
+  it("gets OSCAL React Library README.md", async () => {
+    expect(
+      getURLMediaType(
+        "https://raw.githubusercontent.com/EasyDynamics/oscal-react-library/develop/README.md"
+      )
+    ).toEqual("MD");
+  });
+
+  it("gets OSCAL React Library PR#574", async () => {
+    expect(
+      getURLMediaType(
+        "https://github.com/EasyDynamics/oscal-react-library/pull/574/files"
+      )
+    ).toEqual("Unknown");
+  });
+
+  it("gets NIST SP.800-97 Publication", async () => {
+    expect(getURLMediaType(`"https://doi.org/10.6028/NIST.SP.800-97"`)).toEqual(
+      "Unknown"
+    );
+  });
+
+  it("gets US government configuration baseline", async () => {
+    expect(
+      getURLMediaType(
+        "https://csrc.nist.gov/projects/united-states-government-configuration-baseline"
+      )
+    ).toEqual("Unknown");
+  });
+
+  it("gets Easy Dynamics SSP JSON Example", async () => {
+    expect(
+      getURLMediaType(
+        "https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/main/system-security-plans/ssp-example.json"
+      )
+    ).toEqual("JSON");
+  });
+
+  it("gets href", async () => {
+    expect(getURLMediaType("https://github.com/")).toEqual("HREF");
+  });
+
+  it("gets bad link", async () => {
+    expect(getURLMediaType("githubuserconte.nt")).toEqual("Unknown");
+  });
+});

--- a/src/components/oscal-utils/OSCALLinkUtils.test.js
+++ b/src/components/oscal-utils/OSCALLinkUtils.test.js
@@ -1,27 +1,29 @@
-import { getURLMediaType } from "./OSCALLinkUtils";
+import { guessExtensionFromHref } from "./OSCALLinkUtils";
 
-describe("getURLMediaType", () => {
+describe("guessExtensionFromHref", () => {
   it("gets favicon", async () => {
-    expect(getURLMediaType("https://easydynamics.com/favicon.ico")).toEqual(
-      "ICO"
-    );
+    expect(
+      guessExtensionFromHref("https://easydynamics.com/favicon.ico")
+    ).toEqual("ICO");
   });
 
   it("gets png", async () => {
-    expect(getURLMediaType(`https://easydynamics.com/diagram.png`)).toEqual(
-      "PNG"
-    );
+    expect(
+      guessExtensionFromHref(`https://easydynamics.com/diagram.png`)
+    ).toEqual("PNG");
   });
 
   it("gets unknown", async () => {
     expect(
-      getURLMediaType(`https://easydynamics.com/unknown/unknown-filetype`)
+      guessExtensionFromHref(
+        `https://easydynamics.com/unknown/unknown-filetype`
+      )
     ).toEqual("Unknown");
   });
 
   it("gets OSCAL React Library README.md", async () => {
     expect(
-      getURLMediaType(
+      guessExtensionFromHref(
         "https://raw.githubusercontent.com/EasyDynamics/oscal-react-library/develop/README.md"
       )
     ).toEqual("MD");
@@ -29,21 +31,21 @@ describe("getURLMediaType", () => {
 
   it("gets OSCAL React Library PR#574", async () => {
     expect(
-      getURLMediaType(
+      guessExtensionFromHref(
         "https://github.com/EasyDynamics/oscal-react-library/pull/574/files"
       )
     ).toEqual("Unknown");
   });
 
   it("gets NIST SP.800-97 Publication", async () => {
-    expect(getURLMediaType(`"https://doi.org/10.6028/NIST.SP.800-97"`)).toEqual(
-      "Unknown"
-    );
+    expect(
+      guessExtensionFromHref(`"https://doi.org/10.6028/NIST.SP.800-97"`)
+    ).toEqual("Unknown");
   });
 
   it("gets US government configuration baseline", async () => {
     expect(
-      getURLMediaType(
+      guessExtensionFromHref(
         "https://csrc.nist.gov/projects/united-states-government-configuration-baseline"
       )
     ).toEqual("Unknown");
@@ -51,17 +53,23 @@ describe("getURLMediaType", () => {
 
   it("gets Easy Dynamics SSP JSON Example", async () => {
     expect(
-      getURLMediaType(
+      guessExtensionFromHref(
         "https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/main/system-security-plans/ssp-example.json"
       )
     ).toEqual("JSON");
   });
 
-  it("gets href", async () => {
-    expect(getURLMediaType("https://github.com/")).toEqual("HREF");
+  it("gets github.com", async () => {
+    expect(guessExtensionFromHref("https://github.com/")).toEqual("Unknown");
   });
 
-  it("gets bad link", async () => {
-    expect(getURLMediaType("githubuserconte.nt")).toEqual("Unknown");
+  it("gets bad github content link", async () => {
+    expect(guessExtensionFromHref("githubuserconte.nt")).toEqual("Unknown");
+  });
+
+  it("gets bad diagram link", async () => {
+    expect(
+      guessExtensionFromHref("https://easydynamics.com/diagram.png/")
+    ).toEqual("Unknown");
   });
 });

--- a/src/components/oscal-utils/TestUtils.js
+++ b/src/components/oscal-utils/TestUtils.js
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
+import { getURLMediaType } from "./OSCALLinkUtils";
 
-function getByTextIncludingChildren(textMatch) {
+export default function getByTextIncludingChildren(textMatch) {
   return screen.getByText((content, node) => {
     const hasText = (testNode) =>
       testNode.textContent === textMatch ||
@@ -13,4 +14,6 @@ function getByTextIncludingChildren(textMatch) {
   });
 }
 
-export default getByTextIncludingChildren;
+export function getURLMediaTypeWithUrl(url, name) {
+  return getURLMediaType(url).match(name);
+}

--- a/src/components/oscal-utils/TestUtils.js
+++ b/src/components/oscal-utils/TestUtils.js
@@ -1,7 +1,6 @@
 import { screen } from "@testing-library/react";
-import { getURLMediaType } from "./OSCALLinkUtils";
 
-export default function getByTextIncludingChildren(textMatch) {
+function getByTextIncludingChildren(textMatch) {
   return screen.getByText((content, node) => {
     const hasText = (testNode) =>
       testNode.textContent === textMatch ||
@@ -14,6 +13,4 @@ export default function getByTextIncludingChildren(textMatch) {
   });
 }
 
-export function getURLMediaTypeWithUrl(url, name) {
-  return getURLMediaType(url).match(name);
-}
+export default getByTextIncludingChildren;

--- a/src/test-data/BackMatterData.js
+++ b/src/test-data/BackMatterData.js
@@ -130,3 +130,35 @@ export const exampleBackMatterWithMediaType = {
     },
   ],
 };
+
+export const exampleBackMatterWithoutMediaType = {
+  resources: [
+    {
+      uuid,
+      title,
+      citation,
+      description,
+      rlinks: [
+        {
+          href: diagram,
+        },
+      ],
+    },
+  ],
+};
+
+export const exampleBackMatterWithoutMediaTypeAndUnknownExtension = {
+  resources: [
+    {
+      uuid,
+      title,
+      citation,
+      description,
+      rlinks: [
+        {
+          href: "unknown/unknown-filetype",
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
Since the `media-type` property is optional, we still need a clean and testable way to give users some indication of the type of file they are attempting to access. While the preferred method remains to display the `media-type` attribute of the `rlink`, we fall back to using any file type-looking string at the end of the URL. Failing that, we fall back to displaying “Unknown”. In the future, we may consider using alternative means to determine the media type.

This resolves the TODO comment and converts a regular expression to more imperative code that hopefully will be easier to maintain and to extend in the future.

### Testing

Ensure https://raw.githubusercontent.com/GSA/fedramp-automation/master/dist/content/baselines/rev4/json/FedRAMP_rev4_MODERATE-baseline_profile.json successfully loads and displays `OSCALBackMatter` links as simply file extensions or a valid rlink `media-type`.

Closes #512