### PR TITLE
Display Parties Contact Information

### DIFF
--- a/src/components/OSCALComponentDefinition.test.js
+++ b/src/components/OSCALComponentDefinition.test.js
@@ -3,7 +3,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { OSCALComponentLoader } from "./OSCALLoader";
 import OSCALComponentDefinition from "./OSCALComponentDefinition";
-import testOSCALMetadata from "./OSCALMetadata.test";
 import testOSCALResponsibleRoles from "./OSCALResponsibleRoles.test";
 import { componentDefinitionTestData } from "../test-data/ComponentsData";
 
@@ -34,8 +33,6 @@ function testOSCALComponentDefinitionComponent(parentElementName, renderer) {
     ).toBeInTheDocument();
   });
 }
-
-testOSCALMetadata("OSCALComponentDefinition", componentDefinitionRenderer);
 
 testOSCALComponentDefinitionComponent(
   "OSCALComponentDefinition",

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -1,30 +1,29 @@
-import React from "react";
-import { styled } from "@mui/material/styles";
-import Grid from "@mui/material/Grid";
-import Paper from "@mui/material/Paper";
-import Typography from "@mui/material/Typography";
+import BusinessIcon from "@mui/icons-material/Business";
+import ContactPageIcon from "@mui/icons-material/ContactPage";
+import EmailIcon from "@mui/icons-material/Email";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import HomeIcon from "@mui/icons-material/Home";
+import MapIcon from "@mui/icons-material/Map";
+import PhoneIcon from "@mui/icons-material/Phone";
+import SmartphoneIcon from "@mui/icons-material/Smartphone";
+import Avatar from "@mui/material/Avatar";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardHeader from "@mui/material/CardHeader";
+import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
-import ContactPageIcon from "@mui/icons-material/ContactPage";
 import DialogTitle from "@mui/material/DialogTitle";
+import Grid from "@mui/material/Grid";
 import Link from "@mui/material/Link";
-import ListSubheader from "@mui/material/ListSubheader";
-import Card from "@mui/material/Card";
-import MapIcon from "@mui/icons-material/Map";
-import EmailIcon from "@mui/icons-material/Email";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import CardContent from "@mui/material/CardContent";
-import Avatar from "@mui/material/Avatar";
-import GroupIcon from "@mui/icons-material/Group";
-import PhoneIcon from "@mui/icons-material/Phone";
-import CardActions from "@mui/material/CardActions";
-import Button from "@mui/material/Button";
-import HomeIcon from "@mui/icons-material/Home";
-import BusinessIcon from "@mui/icons-material/Business";
-import SmartphoneIcon from "@mui/icons-material/Smartphone";
-import Dialog from "@mui/material/Dialog";
-import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import ListSubheader from "@mui/material/ListSubheader";
+import Paper from "@mui/material/Paper";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
 import OSCALEditableTextField from "./OSCALEditableTextField";
 
 export const OSCALMetadataPartiesHeader = styled(ListSubheader)(
@@ -43,7 +42,7 @@ const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
   color: theme.palette.text.secondary,
 }));
 
-const OSCALMetadataTitle = styled(Grid)`
+const OSCALMetadataTitle = styled("div")`
   height: 56px;
 `;
 
@@ -55,11 +54,16 @@ const OSCALMetadataAdditional = styled(Paper)(
   ({ theme }) => `padding: ${theme.spacing(1)};`
 );
 
-const OSCALMetadataPartiesCard = styled(Paper)(({ theme }) => ({
+const OSCALMetadataPartiesCardHolder = styled(Grid)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
   position: "relative",
   overflow: "auto",
-  maxHeight: "18em",
+  maxHeight: "26em",
+  paddingBottom: "1em",
+  paddingRight: ".5em",
+  paddingTop: ".5em",
+  display: "flex",
+  direction: "row",
 }));
 
 // Returns a string with a locality-sensitive representation of this date
@@ -147,16 +151,6 @@ function OSCALMetadataPartyContactTypeHeader(props) {
 }
 
 export function OSCALMetadataPartyDialog(props) {
-  const [open, setOpen] = React.useState(false);
-
-  const handleOpen = () => {
-    setOpen(true);
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-  };
-
   const PartyInfoTypes = {
     address: "address",
     telephone: "telephone",
@@ -188,95 +182,102 @@ export function OSCALMetadataPartyDialog(props) {
   };
 
   return (
-    <CardActions>
-      <Button size="small" variant="outlined" onClick={handleOpen}>
-        <ContactPageIcon />
-        Contact
-      </Button>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        scroll="paper"
-        aria-labelledby="scroll-dialog-title"
-        aria-describedby="scroll-dialog-description"
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle id="scroll-dialog-title">{props.party.name}</DialogTitle>
-        <DialogContent>{props.partyRolesText}</DialogContent>
-        <DialogContent>
-          <Grid container spacing={1}>
-            <Grid item xs={4}>
-              <OSCALMetadataPartyContactTypeHeader
-                icon={<MapIcon fontSize="small" />}
-                title="Address"
-              />
-              <List>
-                {getPartyInfoList(
-                  props.party.addresses,
-                  PartyInfoTypes.address,
-                  "No address information provided"
-                )}
-              </List>
-            </Grid>
-            <Grid item xs={4}>
-              <OSCALMetadataPartyContactTypeHeader
-                icon={<PhoneIcon fontSize="small" />}
-                title="Phone"
-              />
-              <List>
-                {getPartyInfoList(
-                  props.party["telephone-numbers"],
-                  PartyInfoTypes.telephone,
-                  "No telephone information provided"
-                )}
-              </List>
-            </Grid>
-            <Grid item xs={4}>
-              <OSCALMetadataPartyContactTypeHeader
-                icon={<EmailIcon fontSize="small" />}
-                title="Email"
-              />
-              <List>
-                {getPartyInfoList(
-                  props.party["email-addresses"],
-                  PartyInfoTypes.email,
-                  "No email information provided"
-                )}
-              </List>
-            </Grid>
+    <Dialog
+      open={props.open}
+      onClose={props.handleClose}
+      scroll="paper"
+      aria-labelledby="scroll-dialog-title"
+      aria-describedby="scroll-dialog-description"
+      maxWidth="md"
+      fullWidth
+    >
+      <DialogTitle id="scroll-dialog-title">
+        {props.party.name}
+        <Typography variant="body2">{props.partyRolesText}</Typography>
+      </DialogTitle>
+      <DialogContent>
+        <Grid container spacing={1}>
+          <Grid item xs={4}>
+            <OSCALMetadataPartyContactTypeHeader
+              icon={<MapIcon fontSize="small" />}
+              title="Address"
+            />
+            <List>
+              {getPartyInfoList(
+                props.party.addresses,
+                PartyInfoTypes.address,
+                "No address information provided"
+              )}
+            </List>
           </Grid>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose} color="primary">
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </CardActions>
+          <Grid item xs={4}>
+            <OSCALMetadataPartyContactTypeHeader
+              icon={<PhoneIcon fontSize="small" />}
+              title="Phone"
+            />
+            <List>
+              {getPartyInfoList(
+                props.party["telephone-numbers"],
+                PartyInfoTypes.telephone,
+                "No telephone information provided"
+              )}
+            </List>
+          </Grid>
+          <Grid item xs={4}>
+            <OSCALMetadataPartyContactTypeHeader
+              icon={<EmailIcon fontSize="small" />}
+              title="Email"
+            />
+            <List>
+              {getPartyInfoList(
+                props.party["email-addresses"],
+                PartyInfoTypes.email,
+                "No email information provided"
+              )}
+            </List>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.handleClose} color="primary">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 
 export function OSCALMetadataParty(props) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
   return (
     <Card>
-      <CardContent>
-        <Grid container spacing={2}>
-          <Grid item>
-            <Avatar>
-              {props.party.type === "organization" ? <GroupIcon /> : null}
-            </Avatar>
-          </Grid>
-          <Grid item>
-            <Typography>{props.party.name}</Typography>
-            <Typography variant="subtitle2">{props.partyRolesText}</Typography>
-            <OSCALMetadataPartyDialog
-              party={props.party}
-              partyRolesText={props.partyRolesText}
-            />
-          </Grid>
-        </Grid>
-      </CardContent>
+      <CardHeader
+        avatar={<Avatar>{props.party.name?.substring(0, 1)}</Avatar>}
+        title={props.party.name}
+        subheader={props.partyRolesText}
+      />
+      <CardActions>
+        <Button size="small" variant="outlined" onClick={handleOpen}>
+          <ContactPageIcon />
+          Contact
+        </Button>
+        <OSCALMetadataPartyDialog
+          open={open}
+          handleOpen={handleOpen}
+          handleClose={handleClose}
+          party={props.party}
+          partyRolesText={props.partyRolesText}
+        />
+      </CardActions>
     </Card>
   );
 }
@@ -333,21 +334,25 @@ export default function OSCALMetadata(props) {
           />
         </OSCALMetadataTitle>
       </Grid>
-      <Grid item xs={12}>
-        <Grid container spacing={3}>
-          <Grid item xs={8}>
-            <OSCALMetadataPartiesCard>
-              <OSCALMetadataPartiesHeader>Parties</OSCALMetadataPartiesHeader>
-              {props.metadata.parties?.map((party) => (
+      <Grid container spacing={1}>
+        <Grid component={Paper} item xs={8}>
+          <Grid item xs={12}>
+            <OSCALMetadataPartiesHeader>Parties</OSCALMetadataPartiesHeader>
+          </Grid>
+          <OSCALMetadataPartiesCardHolder container spacing={1} wrap="wrap">
+            {props.metadata.parties?.map((party) => (
+              <Grid item xs={12} md={4} key={party.uuid}>
                 <OSCALMetadataParty
                   key={party.uuid}
                   party={party}
                   partyRolesText={getPartyRolesText(party)}
                 />
-              ))}
-            </OSCALMetadataPartiesCard>
-          </Grid>
-          <Grid item xs={4}>
+              </Grid>
+            ))}
+          </OSCALMetadataPartiesCardHolder>
+        </Grid>
+        <Grid item md={3} xs={12}>
+          <Grid item xs={12}>
             <OSCALMetadataAdditional>
               <Grid container direction="row" alignItems="center">
                 <OSCALMetadataKey item>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -101,12 +101,10 @@ function getAddressIcon(contactType) {
 function TextWithIcon(props) {
   const { icon, text } = props;
   return (
-    <Grid container spacing={1}>
-      <Grid item>{icon}</Grid>
-      <Grid item>
-        <Typography>{text}</Typography>
-      </Grid>
-    </Grid>
+    <Stack direction="row" gap={1} alignItems="start">
+      {icon}
+      <Typography>{text}</Typography>
+    </Stack>
   );
 }
 
@@ -144,10 +142,12 @@ export function OSCALMetadataPartyTelephone(props) {
 
 function OSCALMetadataPartyContactTypeHeader(props) {
   return (
-    <OSCALMetadataPartiesInfoHeader variant="h6" component="h3">
+    <Stack direction="row" alignItems="center" gap={1}>
       {props.icon}
-      {props.title}
-    </OSCALMetadataPartiesInfoHeader>
+      <OSCALMetadataPartiesInfoHeader variant="h6" component="h3">
+        {props.title}
+      </OSCALMetadataPartiesInfoHeader>
+    </Stack>
   );
 }
 

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -21,6 +21,7 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListSubheader from "@mui/material/ListSubheader";
 import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
@@ -192,10 +193,15 @@ export function OSCALMetadataPartyDialog(props) {
       fullWidth
     >
       <DialogTitle id="scroll-dialog-title">
-        {props.party.name}
-        <Typography variant="body2">{props.partyRolesText}</Typography>
+        <Stack direction="row" alignItems="center" gap={1}>
+          {props.avatar}
+          <Stack direction="column">
+            {props.party.name}
+            <Typography variant="body2">{props.partyRolesText}</Typography>
+          </Stack>
+        </Stack>
       </DialogTitle>
-      <DialogContent>
+      <DialogContent dividers>
         <Grid container spacing={1}>
           <Grid item xs={4}>
             <OSCALMetadataPartyContactTypeHeader
@@ -258,10 +264,41 @@ export function OSCALMetadataParty(props) {
     setOpen(false);
   };
 
+  const avatarColor = (name) => {
+    // This implementation hashes the given string to create a
+    // color string. This is based of the example algorithm given
+    // in the MUI documentation and adapted to our use case.
+    let hash = 0;
+    for (let i = 0; i < name.length; i += 1) {
+      // eslint-disable-next-line no-bitwise
+      hash = name.charCodeAt(i) + ((hash << 5) - hash);
+    }
+
+    let color = "#";
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-bitwise
+      const value = (hash >> (i * 8)) & 0xff;
+      color += `00${value.toString(16)}`.slice(-2);
+    }
+    return color;
+  };
+  const avatarValue = (name) =>
+    name
+      ?.split(" ")
+      .map((str) => str.substring(0, 1))
+      .join("")
+      .substring(0, 2);
+
+  const avatar = (
+    <Avatar sx={{ bgcolor: avatarColor(props.party.name) }}>
+      {avatarValue(props.party.name)}
+    </Avatar>
+  );
+
   return (
     <Card>
       <CardHeader
-        avatar={<Avatar>{props.party.name?.substring(0, 1)}</Avatar>}
+        avatar={avatar}
         title={props.party.name}
         subheader={props.partyRolesText}
       />
@@ -276,6 +313,7 @@ export function OSCALMetadataParty(props) {
           handleClose={handleClose}
           party={props.party}
           partyRolesText={props.partyRolesText}
+          avatar={avatar}
         />
       </CardActions>
     </Card>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -136,6 +136,12 @@ export function OSCALMetadataPartyDialog(props) {
     setOpen(false);
   };
 
+  const PartyInfoTypes = {
+    address: "address",
+    telephone: "telephone",
+    email: "email",
+  };
+
   const TYPE_MAPPING = (infoProps) => ({
     address: <OSCALMetadataPartyAddress address={infoProps} />,
     telephone: <OSCALMetadataPartyTelephone telephone={infoProps} />,
@@ -185,7 +191,7 @@ export function OSCALMetadataPartyDialog(props) {
               <List>
                 {getPartyInfoList(
                   props.party.addresses,
-                  "address",
+                  PartyInfoTypes.address,
                   "No address information provided"
                 )}
               </List>
@@ -199,7 +205,7 @@ export function OSCALMetadataPartyDialog(props) {
               <List>
                 {getPartyInfoList(
                   props.party["telephone-numbers"],
-                  "telephone",
+                  PartyInfoTypes.telephone,
                   "No telephone information provided"
                 )}
               </List>
@@ -212,7 +218,7 @@ export function OSCALMetadataPartyDialog(props) {
               <List>
                 {getPartyInfoList(
                   props.party["email-addresses"],
-                  "email",
+                  PartyInfoTypes.email,
                   "No email information provided"
                 )}
               </List>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -3,13 +3,26 @@ import { styled } from "@mui/material/styles";
 import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
 import Link from "@mui/material/Link";
 import ListSubheader from "@mui/material/ListSubheader";
 import Card from "@mui/material/Card";
+import MapIcon from "@mui/icons-material/Map";
+import AlternateEmailIcon from "@mui/icons-material/AlternateEmail";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
 import CardContent from "@mui/material/CardContent";
 import Avatar from "@mui/material/Avatar";
-import Container from "@mui/material/Container";
 import GroupIcon from "@mui/icons-material/Group";
+import PhoneIcon from "@mui/icons-material/Phone";
+import CardActions from "@mui/material/CardActions";
+import Button from "@mui/material/Button";
+import HomeIcon from "@mui/icons-material/Home";
+import BusinessIcon from "@mui/icons-material/Business";
+import SmartphoneIcon from "@mui/icons-material/Smartphone";
+import Dialog from "@mui/material/Dialog";
 import OSCALEditableTextField from "./OSCALEditableTextField";
 
 export const OSCALMetadataPartiesHeader = styled(ListSubheader)(
@@ -17,14 +30,11 @@ export const OSCALMetadataPartiesHeader = styled(ListSubheader)(
   background-color: ${theme.palette.background.paper};
 `
 );
-const OSCALMetadataLabel = styled(Typography)`
-  text-align: right;
-  color: #0000008a;
-`;
 
-const OSCALMetadataPartyInformation = styled(Container)`
-  color: #0000008a;
-`;
+const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
+  textAlign: "right",
+  color: theme.palette.text.secondary,
+}));
 
 const OSCALMetadataTitle = styled(Grid)`
   height: 56px;
@@ -49,16 +59,18 @@ const OSCALMetadataPartiesCard = styled(Paper)(({ theme }) => ({
 const formatDate = (isoDate) => new Date(isoDate).toLocaleString();
 
 export function OSCALMetadataPartyAddress(props) {
-  // TODO: Show an icon for the address type (home, work)
   const { address } = props;
   return (
-    <address>
-      <Typography>
-        {`${address["addr-lines"]?.join(", ")} ${address.city} ${
-          address["postal-code"]
-        } ${address.country}`}
-      </Typography>
-    </address>
+    <>
+      {address.type === "home" ? <HomeIcon /> : <BusinessIcon />}
+      <address>
+        <Typography>
+          {`${address["addr-lines"]?.join(", ")} ${address.city} ${
+            address["postal-code"]
+          } ${address.country}`}
+        </Typography>
+      </address>
+    </>
   );
 }
 
@@ -71,13 +83,108 @@ export function OSCALMetadataPartyEmail(props) {
 }
 
 export function OSCALMetadataPartyTelephone(props) {
-  // TODO: Show an icon for the telephone type (home, work, mobile)
+  const { telephone } = props;
+  let icon = null;
+
+  switch (telephone.type) {
+    case "home":
+      icon = <HomeIcon />;
+      break;
+    case "mobile":
+      icon = <SmartphoneIcon />;
+      break;
+    case "office":
+      icon = <BusinessIcon />;
+      break;
+    default:
+      break;
+  }
+
   return (
     <Typography>
-      <Link href={`tel:${props.telephone.number}`}>
-        {props.telephone.number}
-      </Link>
+      {icon}
+      <Link href={`tel:${telephone.number}`}>{telephone.number}</Link>
     </Typography>
+  );
+}
+
+export function OSCALMetadataPartyDialog(props) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <CardActions>
+      <Button size="small" onClick={handleOpen}>
+        Contact
+      </Button>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        scroll="paper"
+        aria-labelledby="scroll-dialog-title"
+        aria-describedby="scroll-dialog-description"
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle id="scroll-dialog-title">{props.party.name}</DialogTitle>
+        <DialogContent>
+          <Grid container spacing={1}>
+            <Grid item xs={4}>
+              <Typography>
+                <MapIcon />
+                Addresses
+              </Typography>
+              <List>
+                {props.party.addresses?.map((address) => (
+                  <ListItem key={`${address.type}`}>
+                    <OSCALMetadataPartyAddress address={address} />
+                  </ListItem>
+                ))}
+              </List>
+            </Grid>
+
+            <Grid item xs={4}>
+              <Typography>
+                <PhoneIcon />
+                Phone
+              </Typography>
+              <List>
+                {props.party["telephone-numbers"]?.map((telephone) => (
+                  <ListItem key={`${telephone.type}-${telephone.number}`}>
+                    <OSCALMetadataPartyTelephone telephone={telephone} />
+                  </ListItem>
+                ))}
+              </List>
+            </Grid>
+            <Grid item xs={4}>
+              <Typography>
+                <AlternateEmailIcon />
+                Email
+              </Typography>
+              <List>
+                {props.party["email-addresses"]?.map((email) => (
+                  <ListItem key={email}>
+                    <OSCALMetadataPartyEmail email={email} />
+                  </ListItem>
+                ))}
+              </List>
+            </Grid>
+          </Grid>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary">
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </CardActions>
   );
 }
 
@@ -98,24 +205,8 @@ export function OSCALMetadataParty(props) {
             </Typography>
           </Grid>
         </Grid>
-        <OSCALMetadataPartyInformation>
-          {props.party["telephone-numbers"]?.map((telephone) => (
-            <OSCALMetadataPartyTelephone
-              key={`${telephone.type}-${telephone.number}`}
-              telephone={telephone}
-            />
-          ))}
-          {props.party["email-addresses"]?.map((email) => (
-            <OSCALMetadataPartyEmail key={email} email={email} />
-          ))}
-          {props.party.addresses?.map((address) => (
-            <OSCALMetadataPartyAddress
-              key={`${address.type}`}
-              address={address}
-            />
-          ))}
-        </OSCALMetadataPartyInformation>
       </CardContent>
+      <OSCALMetadataPartyDialog party={props.party} />
     </Card>
   );
 }

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -11,7 +11,7 @@ import Link from "@mui/material/Link";
 import ListSubheader from "@mui/material/ListSubheader";
 import Card from "@mui/material/Card";
 import MapIcon from "@mui/icons-material/Map";
-import AlternateEmailIcon from "@mui/icons-material/AlternateEmail";
+import EmailIcon from "@mui/icons-material/Email";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import CardContent from "@mui/material/CardContent";
@@ -32,6 +32,11 @@ export const OSCALMetadataPartiesHeader = styled(ListSubheader)(
   background-color: ${theme.palette.background.paper};
 `
 );
+
+const OSCALMetadataPartiesInfoHeader = styled(Typography)`
+  display: flex;
+  align-items: center;
+`;
 
 const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
   textAlign: "right",
@@ -126,6 +131,15 @@ export function OSCALMetadataPartyTelephone(props) {
   );
 }
 
+function OSCALMetadataPartyContactTypeHeader(props) {
+  return (
+    <OSCALMetadataPartiesInfoHeader variant="h6" component="h3">
+      {props.icon}
+      {props.title}
+    </OSCALMetadataPartiesInfoHeader>
+  );
+}
+
 export function OSCALMetadataPartyDialog(props) {
   const [open, setOpen] = React.useState(false);
 
@@ -187,10 +201,10 @@ export function OSCALMetadataPartyDialog(props) {
         <DialogContent>
           <Grid container spacing={1}>
             <Grid item xs={4}>
-              <Typography variant="h6" component="h3">
-                <MapIcon />
-                Addresses
-              </Typography>
+              <OSCALMetadataPartyContactTypeHeader
+                icon={<MapIcon fontSize="small" />}
+                title="Address"
+              />
               <List>
                 {getPartyInfoList(
                   props.party.addresses,
@@ -199,12 +213,11 @@ export function OSCALMetadataPartyDialog(props) {
                 )}
               </List>
             </Grid>
-
             <Grid item xs={4}>
-              <Typography variant="h6" component="h3">
-                <PhoneIcon />
-                Phone
-              </Typography>
+              <OSCALMetadataPartyContactTypeHeader
+                icon={<PhoneIcon fontSize="small" />}
+                title="Phone"
+              />
               <List>
                 {getPartyInfoList(
                   props.party["telephone-numbers"],
@@ -214,10 +227,10 @@ export function OSCALMetadataPartyDialog(props) {
               </List>
             </Grid>
             <Grid item xs={4}>
-              <Typography variant="h6" component="h3">
-                <AlternateEmailIcon />
-                Email
-              </Typography>
+              <OSCALMetadataPartyContactTypeHeader
+                icon={<EmailIcon fontSize="small" />}
+                title="Email"
+              />
               <List>
                 {getPartyInfoList(
                   props.party["email-addresses"],

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -89,17 +89,21 @@ function getAddressIcon(contactType) {
 
 export function OSCALMetadataPartyAddress(props) {
   const { address } = props;
+  const addrString = [
+    ...address["addr-lines"],
+    `${address.city}, ${address.state} ${address["postal-code"]}`,
+    address.country,
+  ]
+    .filter((line) => line)
+    .flatMap((item) => [item, <br key={item} />]);
+
   return (
-    <>
-      {getAddressIcon(address.type)}
-      <address>
-        <Typography>
-          {`${address["addr-lines"]?.join(", ")} ${address.city} ${
-            address["postal-code"]
-          } ${address.country}`}
-        </Typography>
-      </address>
-    </>
+    <Grid container spacing={1}>
+      <Grid item>{getAddressIcon(address.type)}</Grid>
+      <Grid item>
+        <Typography>{addrString}</Typography>
+      </Grid>
+    </Grid>
   );
 }
 
@@ -132,6 +136,30 @@ export function OSCALMetadataPartyDialog(props) {
     setOpen(false);
   };
 
+  const TYPE_MAPPING = (infoProps) => ({
+    address: <OSCALMetadataPartyAddress address={infoProps} />,
+    telephone: <OSCALMetadataPartyTelephone telephone={infoProps} />,
+    email: <OSCALMetadataPartyEmail email={infoProps} />,
+  });
+
+  const getPartyInfoList = (
+    list,
+    partyInfoType,
+    emptyMessage = "No information provided"
+  ) => {
+    if (!list?.length) {
+      return <Typography> {emptyMessage} </Typography>;
+    }
+
+    return list.map((item) => (
+      <ListItem
+        key={partyInfoType === "email" ? item : `${item?.type}--${item?.name}`}
+      >
+        {TYPE_MAPPING(item)[partyInfoType]}
+      </ListItem>
+    ));
+  };
+
   return (
     <CardActions>
       <Button size="small" onClick={handleOpen}>
@@ -150,43 +178,43 @@ export function OSCALMetadataPartyDialog(props) {
         <DialogContent>
           <Grid container spacing={1}>
             <Grid item xs={4}>
-              <Typography>
+              <Typography variant="h6" component="h3">
                 <MapIcon />
                 Addresses
               </Typography>
               <List>
-                {props.party.addresses?.map((address) => (
-                  <ListItem key={`${address.type}`}>
-                    <OSCALMetadataPartyAddress address={address} />
-                  </ListItem>
-                ))}
+                {getPartyInfoList(
+                  props.party.addresses,
+                  "address",
+                  "No address information provided"
+                )}
               </List>
             </Grid>
 
             <Grid item xs={4}>
-              <Typography>
+              <Typography variant="h6" component="h3">
                 <PhoneIcon />
                 Phone
               </Typography>
               <List>
-                {props.party["telephone-numbers"]?.map((telephone) => (
-                  <ListItem key={`${telephone.type}-${telephone.number}`}>
-                    <OSCALMetadataPartyTelephone telephone={telephone} />
-                  </ListItem>
-                ))}
+                {getPartyInfoList(
+                  props.party["telephone-numbers"],
+                  "telephone",
+                  "No telephone information provided"
+                )}
               </List>
             </Grid>
             <Grid item xs={4}>
-              <Typography>
+              <Typography variant="h6" component="h3">
                 <AlternateEmailIcon />
                 Email
               </Typography>
               <List>
-                {props.party["email-addresses"]?.map((email) => (
-                  <ListItem key={email}>
-                    <OSCALMetadataPartyEmail email={email} />
-                  </ListItem>
-                ))}
+                {getPartyInfoList(
+                  props.party["email-addresses"],
+                  "email",
+                  "No email information provided"
+                )}
               </List>
             </Grid>
           </Grid>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -93,6 +93,18 @@ function getAddressIcon(contactType) {
   return getIconOfType(ADDRESS_ICON_MAPPING, contactType);
 }
 
+function TextWithIcon(props) {
+  const { icon, text } = props;
+  return (
+    <Grid container spacing={1}>
+      <Grid item>{icon}</Grid>
+      <Grid item>
+        <Typography>{text}</Typography>
+      </Grid>
+    </Grid>
+  );
+}
+
 export function OSCALMetadataPartyAddress(props) {
   const { address } = props;
   const addrString = [
@@ -103,14 +115,7 @@ export function OSCALMetadataPartyAddress(props) {
     .filter((line) => line)
     .flatMap((item) => [item, <br key={item} />]);
 
-  return (
-    <Grid container spacing={1}>
-      <Grid item>{getAddressIcon(address.type)}</Grid>
-      <Grid item>
-        <Typography>{addrString}</Typography>
-      </Grid>
-    </Grid>
-  );
+  return <TextWithIcon icon={getAddressIcon(address.type)} text={addrString} />;
 }
 
 export function OSCALMetadataPartyEmail(props) {
@@ -123,11 +128,12 @@ export function OSCALMetadataPartyEmail(props) {
 
 export function OSCALMetadataPartyTelephone(props) {
   const { telephone } = props;
+
   return (
-    <Typography>
-      {getPhoneIcon(telephone.type)}
-      <Link href={`tel:${telephone.number}`}>{telephone.number}</Link>
-    </Typography>
+    <TextWithIcon
+      icon={getPhoneIcon(telephone.type)}
+      text={<Link href={`tel:${telephone.number}`}>{telephone.number}</Link>}
+    />
   );
 }
 

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -23,6 +23,7 @@ import HomeIcon from "@mui/icons-material/Home";
 import BusinessIcon from "@mui/icons-material/Business";
 import SmartphoneIcon from "@mui/icons-material/Smartphone";
 import Dialog from "@mui/material/Dialog";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import OSCALEditableTextField from "./OSCALEditableTextField";
 
 export const OSCALMetadataPartiesHeader = styled(ListSubheader)(
@@ -58,11 +59,39 @@ const OSCALMetadataPartiesCard = styled(Paper)(({ theme }) => ({
 // Returns a string with a locality-sensitive representation of this date
 const formatDate = (isoDate) => new Date(isoDate).toLocaleString();
 
+const TELEPHONE_ICON_MAPPING = {
+  home: <HomeIcon />,
+  mobile: <SmartphoneIcon />,
+  office: <BusinessIcon />,
+};
+
+const ADDRESS_ICON_MAPPING = {
+  home: <HomeIcon />,
+  work: <BusinessIcon />,
+};
+
+const UNKNOWN_TYPE_ICON = <HelpOutlineIcon />;
+
+function getIconOfType(mapping, contactType) {
+  if (!mapping || !contactType) {
+    return UNKNOWN_TYPE_ICON;
+  }
+  return mapping[contactType] ?? UNKNOWN_TYPE_ICON;
+}
+
+function getPhoneIcon(contactType) {
+  return getIconOfType(TELEPHONE_ICON_MAPPING, contactType);
+}
+
+function getAddressIcon(contactType) {
+  return getIconOfType(ADDRESS_ICON_MAPPING, contactType);
+}
+
 export function OSCALMetadataPartyAddress(props) {
   const { address } = props;
   return (
     <>
-      {address.type === "home" ? <HomeIcon /> : <BusinessIcon />}
+      {getAddressIcon(address.type)}
       <address>
         <Typography>
           {`${address["addr-lines"]?.join(", ")} ${address.city} ${
@@ -84,25 +113,9 @@ export function OSCALMetadataPartyEmail(props) {
 
 export function OSCALMetadataPartyTelephone(props) {
   const { telephone } = props;
-  let icon = null;
-
-  switch (telephone.type) {
-    case "home":
-      icon = <HomeIcon />;
-      break;
-    case "mobile":
-      icon = <SmartphoneIcon />;
-      break;
-    case "office":
-      icon = <BusinessIcon />;
-      break;
-    default:
-      break;
-  }
-
   return (
     <Typography>
-      {icon}
+      {getPhoneIcon(telephone.type)}
       <Link href={`tel:${telephone.number}`}>{telephone.number}</Link>
     </Typography>
   );

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -4,12 +4,11 @@ import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
-import List from "@mui/material/List";
 import ListSubheader from "@mui/material/ListSubheader";
-import ListItem from "@mui/material/ListItem";
-import ListItemText from "@mui/material/ListItemText";
-import ListItemAvatar from "@mui/material/ListItemAvatar";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 import Avatar from "@mui/material/Avatar";
+import Container from "@mui/material/Container";
 import GroupIcon from "@mui/icons-material/Group";
 import OSCALEditableTextField from "./OSCALEditableTextField";
 
@@ -20,6 +19,10 @@ export const OSCALMetadataPartiesHeader = styled(ListSubheader)(
 );
 const OSCALMetadataLabel = styled(Typography)`
   text-align: right;
+  color: #0000008a;
+`;
+
+const OSCALMetadataPartyInformation = styled(Container)`
   color: #0000008a;
 `;
 
@@ -39,7 +42,7 @@ const OSCALMetadataPartiesCard = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
   position: "relative",
   overflow: "auto",
-  maxHeight: "12em",
+  maxHeight: "18em",
 }));
 
 // Returns a string with a locality-sensitive representation of this date
@@ -60,38 +63,60 @@ export function OSCALMetadataPartyAddress(props) {
 }
 
 export function OSCALMetadataPartyEmail(props) {
-  return <Link href={`mailto:${props.email}`}>{props.email}</Link>;
+  return (
+    <Typography>
+      <Link href={`mailto:${props.email}`}>{props.email}</Link>
+    </Typography>
+  );
 }
 
 export function OSCALMetadataPartyTelephone(props) {
   // TODO: Show an icon for the telephone type (home, work, mobile)
   return (
-    <Link href={`tel:${props.telephone.number}`}>{props.telephone.number}</Link>
+    <Typography>
+      <Link href={`tel:${props.telephone.number}`}>
+        {props.telephone.number}
+      </Link>
+    </Typography>
   );
 }
 
 export function OSCALMetadataParty(props) {
   return (
-    <ListItem key={`${props.party.uuid}-parties-listItem`}>
-      <ListItemAvatar>
-        <Avatar>
-          {props.party.type === "organization" ? <GroupIcon /> : null}
-        </Avatar>
-      </ListItemAvatar>
-      <ListItemText
-        primary={props.party.name}
-        secondary={props.partyRolesText}
-      />
-      {props.party["telephone-numbers"]?.map((telephone) => (
-        <OSCALMetadataPartyTelephone telephone={telephone} />
-      ))}
-      {props.party["email-addresses"]?.map((email) => (
-        <OSCALMetadataPartyEmail email={email} />
-      ))}
-      {props.party.addresses?.map((address) => (
-        <OSCALMetadataPartyAddress address={address} />
-      ))}
-    </ListItem>
+    <Card>
+      <CardContent>
+        <Grid container spacing={2}>
+          <Grid item>
+            <Avatar>
+              {props.party.type === "organization" ? <GroupIcon /> : null}
+            </Avatar>
+          </Grid>
+          <Grid item>
+            <Typography>
+              {props.party.name}
+              {props.partyRolesText}
+            </Typography>
+          </Grid>
+        </Grid>
+        <OSCALMetadataPartyInformation>
+          {props.party["telephone-numbers"]?.map((telephone) => (
+            <OSCALMetadataPartyTelephone
+              key={`${telephone.type}-${telephone.number}`}
+              telephone={telephone}
+            />
+          ))}
+          {props.party["email-addresses"]?.map((email) => (
+            <OSCALMetadataPartyEmail key={email} email={email} />
+          ))}
+          {props.party.addresses?.map((address) => (
+            <OSCALMetadataPartyAddress
+              key={`${address.type}`}
+              address={address}
+            />
+          ))}
+        </OSCALMetadataPartyInformation>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -151,25 +176,14 @@ export default function OSCALMetadata(props) {
         <Grid container spacing={3}>
           <Grid item xs={8}>
             <OSCALMetadataPartiesCard>
-              <List
-                subheader={
-                  <OSCALMetadataPartiesHeader
-                    component="div"
-                    id="oscal-metadata-parties"
-                  >
-                    Parties
-                  </OSCALMetadataPartiesHeader>
-                }
-              >
-                {props.metadata.parties?.map((party) => (
-                  <OSCALMetadataParty
-                    key={party.uuid}
-                    party={party}
-                    partyRolesText={getPartyRolesText(party)}
-                  />
-                ))}
-                {props.metadata.parties?.map((party) => console.log(party))}
-              </List>
+              <OSCALMetadataPartiesHeader>Parties</OSCALMetadataPartiesHeader>
+              {props.metadata.parties?.map((party) => (
+                <OSCALMetadataParty
+                  key={party.uuid}
+                  party={party}
+                  partyRolesText={getPartyRolesText(party)}
+                />
+              ))}
             </OSCALMetadataPartiesCard>
           </Grid>
           <Grid item xs={4}>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -5,6 +5,7 @@ import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import ContactPageIcon from "@mui/icons-material/ContactPage";
 import DialogTitle from "@mui/material/DialogTitle";
 import Link from "@mui/material/Link";
 import ListSubheader from "@mui/material/ListSubheader";
@@ -168,7 +169,8 @@ export function OSCALMetadataPartyDialog(props) {
 
   return (
     <CardActions>
-      <Button size="small" onClick={handleOpen}>
+      <Button size="small" variant="outlined" onClick={handleOpen}>
+        <ContactPageIcon />
         Contact
       </Button>
       <Dialog
@@ -181,6 +183,7 @@ export function OSCALMetadataPartyDialog(props) {
         fullWidth
       >
         <DialogTitle id="scroll-dialog-title">{props.party.name}</DialogTitle>
+        <DialogContent>{props.partyRolesText}</DialogContent>
         <DialogContent>
           <Grid container spacing={1}>
             <Grid item xs={4}>
@@ -246,14 +249,15 @@ export function OSCALMetadataParty(props) {
             </Avatar>
           </Grid>
           <Grid item>
-            <Typography>
-              {props.party.name}
-              {props.partyRolesText}
-            </Typography>
+            <Typography>{props.party.name}</Typography>
+            <Typography variant="subtitle2">{props.partyRolesText}</Typography>
+            <OSCALMetadataPartyDialog
+              party={props.party}
+              partyRolesText={props.partyRolesText}
+            />
           </Grid>
         </Grid>
       </CardContent>
-      <OSCALMetadataPartyDialog party={props.party} />
     </Card>
   );
 }

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -44,24 +44,35 @@ const OSCALMetadataPartiesCard = styled(Paper)(({ theme }) => ({
 // Returns a string with a locality-sensitive representation of this date
 const formatDate = (isoDate) => new Date(isoDate).toLocaleString();
 
-export default function OSCALMetadata(props) {
-  if (!props.metadata) {
-    return null;
-  }
-
+function OSCALMetadataParty(partyName, partyUuid, partyType, metadata) {
   const getRoleLabel = (roleId) =>
-    props.metadata.roles.find((role) => role.id === roleId)?.title;
+    metadata.roles.find((role) => role.id === roleId)?.title;
 
-  const getPartyRolesText = (party) =>
-    props.metadata["responsible-parties"]
+  const getPartyRolesText = () =>
+    metadata["responsible-parties"]
       ?.filter((responsibleParty) =>
-        responsibleParty["party-uuids"]?.includes(party.uuid)
+        responsibleParty["party-uuids"]?.includes(partyUuid)
       )
       .map((item) => item["role-id"])
       .map(getRoleLabel)
       // Remove empty/falsey items from the list
       .filter((item) => item)
       .join(", ");
+
+  return (
+    <ListItem key={`${partyUuid}-parties-listItem`}>
+      <ListItemAvatar>
+        <Avatar>{partyType === "organization" ? <GroupIcon /> : null}</Avatar>
+      </ListItemAvatar>
+      <ListItemText primary={partyName} secondary={getPartyRolesText()} />{" "}
+    </ListItem>
+  );
+}
+
+export default function OSCALMetadata(props) {
+  if (!props.metadata) {
+    return null;
+  }
 
   return (
     <Grid container>
@@ -111,19 +122,14 @@ export default function OSCALMetadata(props) {
                   </OSCALMetadataPartiesHeader>
                 }
               >
-                {props.metadata.parties?.map((party) => (
-                  <ListItem key={`${party.uuid}-parties-listItem`}>
-                    <ListItemAvatar>
-                      <Avatar>
-                        {party.type === "organization" ? <GroupIcon /> : null}
-                      </Avatar>
-                    </ListItemAvatar>
-                    <ListItemText
-                      primary={party.name}
-                      secondary={getPartyRolesText(party)}
-                    />
-                  </ListItem>
-                ))}
+                {props.metadata.parties?.map((party) =>
+                  OSCALMetadataParty(
+                    party.name,
+                    party.uuid,
+                    party.type,
+                    props.metadata
+                  )
+                )}
               </List>
             </OSCALMetadataPartiesCard>
           </Grid>

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -93,9 +93,8 @@ describe("OSCALMetadata", () => {
     });
 
     button.click();
-
     expect(screen.getByText("Addresses")).toBeVisible();
-    expect(screen.getByText(/0000 st, suite 3 city 0000 us/i)).toBeVisible();
+    expect(screen.getByText(/0000 stsuite 3city, state 0000us/i)).toBeVisible();
   });
 
   test(`displays home address info`, () => {
@@ -106,7 +105,7 @@ describe("OSCALMetadata", () => {
     button.click();
 
     expect(screen.getByText("Addresses")).toBeVisible();
-    expect(screen.getByText(/1111 road st city 0000 us/i)).toBeVisible();
+    expect(screen.getByText(/1111 road stcity, state 0000us/i)).toBeVisible();
   });
 
   test(`displays unknown type address info`, () => {
@@ -117,6 +116,6 @@ describe("OSCALMetadata", () => {
     button.click();
 
     expect(screen.getByText("Addresses")).toBeVisible();
-    expect(screen.getByText(/2222 st city 0000 us/i)).toBeVisible();
+    expect(screen.getByText(/2222 stcity, state 0000us/i)).toBeVisible();
   });
 });

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -1,33 +1,78 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import OSCALMetadata from "./OSCALMetadata";
 import { metadataTestData } from "../test-data/CommonData";
 
-function metadataRenderer() {
-  render(<OSCALMetadata metadata={metadataTestData} />);
-}
+describe("OSCALMetadata", () => {
+  beforeEach(() => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
+  });
 
-export default function testOSCALMetadata(parentElementName, renderer) {
-  test(`${parentElementName} displays title`, () => {
-    renderer();
+  test(`displays title`, () => {
     const result = screen.getByRole("heading", { name: "Test Title" });
     expect(result).toBeVisible();
   });
 
-  test(`${parentElementName} displays version`, () => {
-    renderer();
+  test(`displays version`, () => {
     const result = screen.getByText("Revision 5");
     expect(result).toBeVisible();
   });
 
-  test(`${parentElementName} displays parties`, () => {
-    renderer();
-    const partiesElement = screen.getByText("Parties").closest("ul");
-    const result = within(partiesElement).getByText("Some group of people");
+  test(`displays parties`, () => {
+    const result = screen.getByText("Some group of people");
     expect(result).toBeVisible();
   });
-}
 
-if (!require.main) {
-  testOSCALMetadata("OSCALMetadata", metadataRenderer);
-}
+  test(`displays Contact button`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+
+    expect(button).toBeVisible();
+  });
+
+  test(`displays email contact info`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+
+    button.click();
+
+    expect(screen.getByText("Email")).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /owners@email\.org/i })
+    ).toBeVisible();
+  });
+
+  test(`displays telephone mobile number info`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+    button.click();
+
+    expect(screen.getByText("Phone")).toBeVisible();
+    expect(screen.getByRole("link", { name: /\+18005555555/i })).toBeVisible();
+  });
+
+  test(`displays telephone office number info`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+
+    button.click();
+
+    expect(screen.getByText("Phone")).toBeVisible();
+    expect(screen.getByRole("link", { name: /\+18004444444/i })).toBeVisible();
+  });
+
+  test(`displays address info`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+
+    button.click();
+
+    expect(screen.getByText("Addresses")).toBeVisible();
+    expect(screen.getByText(/0000 st, suite 3 city 0000 us/i)).toBeVisible();
+  });
+});

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -65,6 +65,18 @@ describe("OSCALMetadata", () => {
     expect(screen.getByRole("link", { name: /\+18004444444/i })).toBeVisible();
   });
 
+  test(`displays unknown type telephone number info`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+
+    button.click();
+
+    expect(screen.getByText("Phone")).toBeVisible();
+    expect(screen.getByTestId("HelpOutlineIcon")).toBeVisible();
+    expect(screen.getByRole("link", { name: /\+1800666666/i })).toBeVisible();
+  });
+
   test(`displays address info`, () => {
     const button = screen.getByRole("button", {
       name: /contact/i,

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -65,6 +65,17 @@ describe("OSCALMetadata", () => {
     expect(screen.getByRole("link", { name: /\+18004444444/i })).toBeVisible();
   });
 
+  test(`displays telephone home number info`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+
+    button.click();
+
+    expect(screen.getByText("Phone")).toBeVisible();
+    expect(screen.getByRole("link", { name: /\+18007777777/i })).toBeVisible();
+  });
+
   test(`displays unknown type telephone number info`, () => {
     const button = screen.getByRole("button", {
       name: /contact/i,
@@ -73,11 +84,10 @@ describe("OSCALMetadata", () => {
     button.click();
 
     expect(screen.getByText("Phone")).toBeVisible();
-    expect(screen.getByTestId("HelpOutlineIcon")).toBeVisible();
     expect(screen.getByRole("link", { name: /\+1800666666/i })).toBeVisible();
   });
 
-  test(`displays address info`, () => {
+  test(`displays work address info`, () => {
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -86,5 +96,27 @@ describe("OSCALMetadata", () => {
 
     expect(screen.getByText("Addresses")).toBeVisible();
     expect(screen.getByText(/0000 st, suite 3 city 0000 us/i)).toBeVisible();
+  });
+
+  test(`displays home address info`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+
+    button.click();
+
+    expect(screen.getByText("Addresses")).toBeVisible();
+    expect(screen.getByText(/1111 road st city 0000 us/i)).toBeVisible();
+  });
+
+  test(`displays unknown type address info`, () => {
+    const button = screen.getByRole("button", {
+      name: /contact/i,
+    });
+
+    button.click();
+
+    expect(screen.getByText("Addresses")).toBeVisible();
+    expect(screen.getByText(/2222 st city 0000 us/i)).toBeVisible();
   });
 });

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -93,7 +93,7 @@ describe("OSCALMetadata", () => {
     });
 
     button.click();
-    expect(screen.getByText("Addresses")).toBeVisible();
+    expect(screen.getByText("Address")).toBeVisible();
     expect(screen.getByText(/0000 stsuite 3city, state 0000us/i)).toBeVisible();
   });
 
@@ -104,7 +104,7 @@ describe("OSCALMetadata", () => {
 
     button.click();
 
-    expect(screen.getByText("Addresses")).toBeVisible();
+    expect(screen.getByText("Address")).toBeVisible();
     expect(screen.getByText(/1111 road stcity, state 0000us/i)).toBeVisible();
   });
 
@@ -115,7 +115,7 @@ describe("OSCALMetadata", () => {
 
     button.click();
 
-    expect(screen.getByText("Addresses")).toBeVisible();
+    expect(screen.getByText("Address")).toBeVisible();
     expect(screen.getByText(/2222 stcity, state 0000us/i)).toBeVisible();
   });
 });

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -8,7 +8,6 @@ import {
 } from "@testing-library/react";
 import { OSCALProfileLoader } from "./OSCALLoader";
 import OSCALProfile from "./OSCALProfile";
-import testOSCALMetadata from "./OSCALMetadata.test";
 import testOSCALBackMatter from "./OSCALBackMatter.test";
 import { parentUrlTestData } from "../test-data/Urls";
 import profileTestData from "../test-data/ProfileData";
@@ -50,8 +49,6 @@ function testOSCALProfile(parentElementName, renderer) {
     expect(await screen.findByText("at least every 3 years")).toBeVisible();
   });
 }
-
-testOSCALMetadata("OSCALProfile", profileRenderer);
 
 testOSCALProfile("OSCALProfile", profileRenderer);
 

--- a/src/components/OSCALSsp.test.js
+++ b/src/components/OSCALSsp.test.js
@@ -4,7 +4,6 @@ import { OSCALSSPLoader } from "./OSCALLoader";
 import OSCALSsp from "./OSCALSsp";
 import testOSCALSystemCharacteristics from "./OSCALSystemCharacteristics.test";
 import testOSCALSystemImplementation from "./OSCALSystemImplementation.test";
-import testOSCALMetadata from "./OSCALMetadata.test";
 import { sspTestData } from "../test-data/SystemData";
 import testOSCALEditableFieldActions from "./OSCALEditableFieldActions.test";
 import testOSCALEditableTextField from "./OSCALEditableTextField.test";
@@ -32,8 +31,6 @@ function sspRendererRestMode() {
 testOSCALSystemCharacteristics("OSCALSsp", sspRenderer);
 
 testOSCALSystemImplementation("OSCALSsp", sspRenderer);
-
-testOSCALMetadata("OSCALSsp", sspRenderer);
 
 testOSCALEditableFieldActions("OSCALSsp", sspRendererRestMode);
 

--- a/src/stories/OSCALMetadataParty.stories.js
+++ b/src/stories/OSCALMetadataParty.stories.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { OSCALMetadataParty } from "../components/OSCALMetadata";
+
+import { exampleParties } from "../test-data/CommonData";
+
+export default {
+  title: "Components/Metadata Party",
+  component: OSCALMetadataParty,
+};
+
+function Template(args) {
+  return <OSCALMetadataParty {...args} />;
+}
+
+export const Default = Template.bind({});
+
+Default.args = {
+  party: exampleParties[0],
+  partyRolesText: "Example party role text",
+};

--- a/src/stories/OSCALMetadataPartyAddress.stories.js
+++ b/src/stories/OSCALMetadataPartyAddress.stories.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { OSCALMetadataPartyAddress } from "../components/OSCALMetadata";
+
+import { exampleParties } from "../test-data/CommonData";
+
+export default {
+  title: "Components/Metadata Party Address",
+  component: OSCALMetadataPartyAddress,
+};
+
+function Template(args) {
+  return <OSCALMetadataPartyAddress {...args} />;
+}
+
+export const Home = Template.bind({});
+
+export const Work = Template.bind({});
+
+export const Unknown = Template.bind({});
+
+Home.args = {
+  address: exampleParties[0].addresses[0],
+};
+
+Work.args = {
+  address: exampleParties[0].addresses[1],
+};
+
+Unknown.args = {
+  address: exampleParties[0].addresses[2],
+};

--- a/src/stories/OSCALMetadataPartyDialog.stories.js
+++ b/src/stories/OSCALMetadataPartyDialog.stories.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { OSCALMetadataPartyDialog } from "../components/OSCALMetadata";
+
+import { exampleParties } from "../test-data/CommonData";
+
+export default {
+  title: "Components/Metadata Party Dialog",
+  component: OSCALMetadataPartyDialog,
+};
+
+function Template(args) {
+  return <OSCALMetadataPartyDialog {...args} />;
+}
+
+export const Default = Template.bind({});
+
+Default.args = {
+  party: exampleParties[0],
+};

--- a/src/stories/OSCALMetadataPartyEmail.stories.js
+++ b/src/stories/OSCALMetadataPartyEmail.stories.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { OSCALMetadataPartyEmail } from "../components/OSCALMetadata";
+
+import { exampleParties } from "../test-data/CommonData";
+
+export default {
+  title: "Components/Metadata Party Email",
+  component: OSCALMetadataPartyEmail,
+};
+
+function Template(args) {
+  return <OSCALMetadataPartyEmail {...args} />;
+}
+
+export const Default = Template.bind({});
+
+Default.args = {
+  email: exampleParties[0]["email-addresses"][0],
+};

--- a/src/stories/OSCALMetadataPartyTelephone.stories.js
+++ b/src/stories/OSCALMetadataPartyTelephone.stories.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { OSCALMetadataPartyTelephone } from "../components/OSCALMetadata";
+
+import { exampleParties } from "../test-data/CommonData";
+
+export default {
+  title: "Components/Metadata Party Telephone",
+  component: OSCALMetadataPartyTelephone,
+};
+
+function Template(args) {
+  return <OSCALMetadataPartyTelephone {...args} />;
+}
+
+export const Mobile = Template.bind({});
+
+export const Office = Template.bind({});
+
+export const Unknown = Template.bind({});
+
+export const Home = Template.bind({});
+
+Mobile.args = {
+  telephone: exampleParties[0]["telephone-numbers"][0],
+};
+
+Office.args = {
+  telephone: exampleParties[0]["telephone-numbers"][1],
+};
+
+Unknown.args = {
+  telephone: exampleParties[0]["telephone-numbers"][2],
+};
+
+Home.args = {
+  telephone: exampleParties[0]["telephone-numbers"][3],
+};

--- a/src/test-data/CommonData.js
+++ b/src/test-data/CommonData.js
@@ -13,6 +13,9 @@ export const exampleParties = [
         type: "office",
         number: "+18004444444",
       },
+      {
+        number: "+18006666666",
+      },
     ],
     addresses: [
       {

--- a/src/test-data/CommonData.js
+++ b/src/test-data/CommonData.js
@@ -16,11 +16,30 @@ export const exampleParties = [
       {
         number: "+18006666666",
       },
+      {
+        type: "home",
+        number: "+18007777777",
+      },
     ],
     addresses: [
       {
         type: "work",
         "addr-lines": ["0000 St", "Suite 3"],
+        city: "City",
+        state: "State",
+        "postal-code": "0000",
+        country: "US",
+      },
+      {
+        type: "home",
+        "addr-lines": ["1111 Road St"],
+        city: "City",
+        state: "State",
+        "postal-code": "0000",
+        country: "US",
+      },
+      {
+        "addr-lines": ["2222 St"],
         city: "City",
         state: "State",
         "postal-code": "0000",

--- a/src/test-data/CommonData.js
+++ b/src/test-data/CommonData.js
@@ -3,6 +3,27 @@ export const exampleParties = [
     uuid: "party-1",
     type: "organization",
     name: "Some group of people",
+    "email-addresses": ["owners@email.org"],
+    "telephone-numbers": [
+      {
+        type: "mobile",
+        number: "+18005555555",
+      },
+      {
+        type: "office",
+        number: "+18004444444",
+      },
+    ],
+    addresses: [
+      {
+        type: "work",
+        "addr-lines": ["0000 St", "Suite 3"],
+        city: "City",
+        state: "State",
+        "postal-code": "0000",
+        country: "US",
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
This adds a `Contact` dialog box to metadata parties. When clicked, it opens a dialog displaying all the parties contact information. This also rewrites the tests a bit to no longer have parent components of `OSCALMetadata` test functionality. 

### Testing file

https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/f03073fddf33b0d65d3d0e84a7ad76c74e7be6c9/system-security-plans/ssp-example.json gives a good example of party contact info to view

### Reviewing / Things to look for
This pr seems a bit more complex than it actually is upon further investigation. Here is a list of what changes have been made for reviewing. 
- `OSCALMetadata` has new sub components being used to display part contact information.
- The tests have been expanded upon, they are more imperative and verbose now. 
- The storybook has additional components. This is fairly repetitive. Running `npm run build-storybook && npm run storybook` will let you view it locally. 
- New sample data has been added to be used in the tests / storybook.


closes #405
