### PR TITLE
Display editable title field icons

### DIFF
--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -43,7 +43,7 @@ const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
   color: theme.palette.text.secondary,
 }));
 
-const OSCALMetadataTitle = styled("div")`
+const OSCALMetadataTitle = styled(Grid)`
   height: 56px;
 `;
 


### PR DESCRIPTION
Changes to the OSCALMetadataParties section hid the cancel & save icons
when editing an SSP title. This changes the `Div` to a `Grid` to fix how
the icons are displayed.
