### PR TITLE
Add aria label to Contact Button

### DIFF
--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -303,7 +303,12 @@ export function OSCALMetadataParty(props) {
         subheader={props.partyRolesText}
       />
       <CardActions>
-        <Button size="small" variant="outlined" onClick={handleOpen}>
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={handleOpen}
+          aria-label={`${props.party.name} contact button`}
+        >
           <ContactPageIcon />
           Contact
         </Button>


### PR DESCRIPTION
In order to increase accessibility and give our Cypress tests something to look for, we added an aria label.
