### PR TITLE
Make table header sticky for `SystemImplementation` tables

### DIFF
--- a/src/components/OSCALSystemImplementationComponents.js
+++ b/src/components/OSCALSystemImplementationComponents.js
@@ -4,7 +4,6 @@ import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import StyledTooltip from "./OSCALStyledTooltip";
 import OSCALResponsibleRoles from "./OSCALResponsibleRoles";
@@ -13,6 +12,7 @@ import {
   StyledHeaderTableCell,
   StyledTableRow,
   ComponentTableCell,
+  StyledTableHead,
 } from "./OSCALSystemImplementationTableStyles";
 import PropertiesTable from "./OSCALSystemImplementationPropertiesTable";
 
@@ -24,7 +24,7 @@ export default function OSCALSystemImplementationComponents(props) {
       </OSCALSystemImplementationTableTitle>
       <TableContainer sx={{ maxHeight: "25em" }}>
         <Table aria-label="Components" sx={{ height: "max-content" }}>
-          <TableHead>
+          <StyledTableHead>
             <TableRow>
               <StyledHeaderTableCell>Component</StyledHeaderTableCell>
               <StyledHeaderTableCell>Type</StyledHeaderTableCell>
@@ -32,7 +32,7 @@ export default function OSCALSystemImplementationComponents(props) {
               <StyledHeaderTableCell>Properties</StyledHeaderTableCell>
               <StyledHeaderTableCell>Responsible Roles</StyledHeaderTableCell>
             </TableRow>
-          </TableHead>
+          </StyledTableHead>
           <TableBody>
             {props.components.map((component) => (
               <StyledTableRow key={component.uuid}>

--- a/src/components/OSCALSystemImplementationInventoryItems.js
+++ b/src/components/OSCALSystemImplementationInventoryItems.js
@@ -3,12 +3,12 @@ import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import {
   OSCALSystemImplementationTableTitle,
   StyledHeaderTableCell,
   StyledTableRow,
+  StyledTableHead,
 } from "./OSCALSystemImplementationTableStyles";
 import PropertiesTable from "./OSCALSystemImplementationPropertiesTable";
 
@@ -85,7 +85,7 @@ export default function OSCALOSCALSystemImplementationTableTitleInventoryItems(
 
       <TableContainer sx={{ maxHeight: "25em" }}>
         <Table aria-label="Inventory Items" sx={{ height: "max-content" }}>
-          <TableHead>
+          <StyledTableHead>
             <TableRow>
               <StyledHeaderTableCell>Item</StyledHeaderTableCell>
               <StyledHeaderTableCell>Properties</StyledHeaderTableCell>
@@ -95,7 +95,7 @@ export default function OSCALOSCALSystemImplementationTableTitleInventoryItems(
               </StyledHeaderTableCell>
               <StyledHeaderTableCell>Remarks</StyledHeaderTableCell>
             </TableRow>
-          </TableHead>
+          </StyledTableHead>
           <TableBody>
             {props.inventoryItems.map((inventoryItem) => (
               <StyledTableRow key={inventoryItem.uuid}>

--- a/src/components/OSCALSystemImplementationTableStyles.js
+++ b/src/components/OSCALSystemImplementationTableStyles.js
@@ -2,6 +2,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import TableCell, { tableCellClasses } from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
+import TableHead from "@mui/material/TableHead";
 
 export const SmallTableCell = styled(TableCell)`
   text-align: right;
@@ -27,6 +28,11 @@ export const StyledHeaderTableCell = styled(TableCell)(({ theme }) => ({
   textAlign: "left",
   minWidth: "10em",
 }));
+
+export const StyledTableHead = styled(TableHead)`
+  position: sticky;
+  top: 0;
+`;
 
 export const StyledTableRow = styled(TableRow)(({ theme }) => ({
   // Use hover color for even numbered rows

--- a/src/components/OSCALSystemImplementationUsers.js
+++ b/src/components/OSCALSystemImplementationUsers.js
@@ -4,13 +4,13 @@ import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import StyledTooltip from "./OSCALStyledTooltip";
 import {
   OSCALSystemImplementationTableTitle,
   StyledHeaderTableCell,
   StyledTableRow,
+  StyledTableHead,
 } from "./OSCALSystemImplementationTableStyles";
 import PropertiesTable from "./OSCALSystemImplementationPropertiesTable";
 
@@ -79,17 +79,17 @@ export default function OSCALSystemImplementationUsers(props) {
       </OSCALSystemImplementationTableTitle>
       <TableContainer sx={{ maxHeight: "25em" }}>
         <Table aria-label="Components" sx={{ height: "max-content" }}>
-          <TableHead>
+          <StyledTableHead>
             <TableRow>
               <StyledHeaderTableCell>Title</StyledHeaderTableCell>
               <StyledHeaderTableCell>Short Name</StyledHeaderTableCell>
               <StyledHeaderTableCell>Properties</StyledHeaderTableCell>
-              <StyledHeaderTableCell>Roll IDs</StyledHeaderTableCell>
+              <StyledHeaderTableCell>Role IDs</StyledHeaderTableCell>
               <StyledHeaderTableCell>
                 Authorized Privileges
               </StyledHeaderTableCell>
             </TableRow>
-          </TableHead>
+          </StyledTableHead>
           <TableBody>
             {props.users.map((user) => (
               <StyledTableRow key={user.uuid}>


### PR DESCRIPTION
To better understand which category a cells align to, the header titles will remain viewable on the page at all times even after scrolling.