### PR TITLE
Display System Short Name and Description for SSP

### DIFF
--- a/src/components/OSCALSystemCharacteristics.js
+++ b/src/components/OSCALSystemCharacteristics.js
@@ -25,9 +25,18 @@ export default function OSCALSystemCharacteristics(props) {
             <Grid item xs={12}>
               <OSCALSectionHeader>System Characteristics</OSCALSectionHeader>
             </Grid>
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <Typography variant="h6">
                 {props.systemCharacteristics["system-name"]}
+                {/* Render the system's short name in parentheses next to the name,
+                but only if the short name exists. */}
+                {props.systemCharacteristics["system-name-short"] &&
+                  " (" + props.systemCharacteristics["system-name-short"] + ")"}
+              </Typography>
+            </Grid>
+            <Grid item xs={6}>
+              <Typography variant="body2">
+                {props.systemCharacteristics["description"]}
               </Typography>
             </Grid>
             <Grid item xs={6}>

--- a/src/components/OSCALSystemCharacteristics.js
+++ b/src/components/OSCALSystemCharacteristics.js
@@ -28,15 +28,17 @@ export default function OSCALSystemCharacteristics(props) {
             <Grid item xs={12}>
               <Typography variant="h6">
                 {props.systemCharacteristics["system-name"]}
-                {/* Render the system's short name in parentheses next to the name,
-                but only if the short name exists. */}
-                {props.systemCharacteristics["system-name-short"] &&
-                  " (" + props.systemCharacteristics["system-name-short"] + ")"}
+                {
+                  // Render the system's short name in parentheses next to the name,
+                  // but only if the short name exists.
+                  props.systemCharacteristics["system-name-short"] &&
+                    ` (${props.systemCharacteristics["system-name-short"]})`
+                }
               </Typography>
             </Grid>
             <Grid item xs={6}>
               <Typography variant="body2">
-                {props.systemCharacteristics["description"]}
+                {props.systemCharacteristics.description}
               </Typography>
             </Grid>
             <Grid item xs={6}>


### PR DESCRIPTION
Add to the System Characteristics section of the SSP Viewer to display the system's short name next to the system name, and display the description underneath the system name.

The short name functionality can be tested using [FedRAMP's SSP Template.](https://github.com/GSA/fedramp-automation/blob/master/dist/content/templates/ssp/json/FedRAMP-SSP-OSCAL-Template.json)