### PR TITLE
Rework profile catalog inheritance

### DIFF
--- a/src/components/OSCALProfileCatalogInheritance.js
+++ b/src/components/OSCALProfileCatalogInheritance.js
@@ -1,86 +1,43 @@
-import React, { useState } from "react";
-import { styled } from "@mui/material/styles";
-import { TreeItem, TreeView } from "@mui/lab";
+import React from "react";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import { Grid, IconButton, List, Paper, ListSubheader } from "@mui/material";
-
-const CatalogInheritancePaper = styled(Paper)(
-  ({ theme }) => `
-  margin-top: ${theme.spacing(2)};
-  margin-bottom: ${theme.spacing(2)};
-  position: relative;
-  overflow: auto;
-`
-);
-
-function generateLabel(title, type) {
-  return type === "profile" ? `Profile: ${title}` : `Catalog: ${title}`;
-}
-
-function createTree(tree, ids) {
-  if (tree.inherited == null) {
-    return null;
-  }
-
-  const children = [];
-
-  tree.inherited.forEach((childProfileOrCatalog) => {
-    ids.push(`${childProfileOrCatalog.uuid} #${ids.length + 1}`);
-    children.push(
-      <TreeItem
-        nodeId={`${childProfileOrCatalog.uuid} #${ids.length}`}
-        key={`${childProfileOrCatalog.uuid} #${ids.length}`}
-        label={generateLabel(
-          childProfileOrCatalog.title,
-          childProfileOrCatalog.type
-        )}
-      >
-        {createTree(childProfileOrCatalog, ids)}
-      </TreeItem>
-    );
-  });
-
-  return children;
-}
+import { TreeItem, TreeView } from "@mui/lab";
+import Card from "@mui/material/Card";
+import Stack from "@mui/material/Stack";
+import Chip from "@mui/material/Chip";
+import Typography from "@mui/material/Typography";
+import CardContent from "@mui/material/CardContent";
+import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 
 export default function OSCALProfileCatalogInheritance(props) {
-  const [expandedIds, setExpandedIds] = useState([]);
-  const ids = [];
+  const documentLabel = (item) => (
+    <Stack direction="row" spacing={2}>
+      <Typography>{item.title}</Typography>
+      <Chip label={item.type[0].toUpperCase() + item.type.slice(1)} />
+    </Stack>
+  );
 
-  const children = createTree(props.inheritedProfilesAndCatalogs, ids);
-
-  if (ids.length > 0 && expandedIds.length === 0) {
-    setExpandedIds(ids);
-  }
-
-  return expandedIds.length > 0 ? (
-    <Grid item>
-      <CatalogInheritancePaper>
-        <List
-          subheader={
-            <ListSubheader component="div" id="oscal-metadata-parties">
-              Profiles/Catalog Inheritance
-            </ListSubheader>
-          }
-        >
+  const inheritedListItem = (item) => (
+    <TreeItem key={item.uuid} nodeId={item.uuid} label={documentLabel(item)}>
+      {item.inherited?.map((inherited) => inheritedListItem(inherited))}
+    </TreeItem>
+  );
+  return (
+    <OSCALSection>
+      <Card>
+        <CardContent>
+          <OSCALSectionHeader>Profiles/Catalog Inheritance</OSCALSectionHeader>
           <TreeView
-            defaultExpandIcon={
-              <IconButton size="large">
-                <ExpandMoreIcon />
-              </IconButton>
-            }
-            defaultCollapseIcon={
-              <IconButton size="large">
-                <ExpandLessIcon />
-              </IconButton>
-            }
-            defaultExpanded={expandedIds}
+            defaultCollapseIcon={<ExpandMoreIcon />}
+            defaultExpandIcon={<ChevronRightIcon />}
+            multiSelect
           >
-            {children}
+            {props.inheritedProfilesAndCatalogs.inherited?.map((item) =>
+              inheritedListItem(item)
+            )}
           </TreeView>
-        </List>
-      </CatalogInheritancePaper>
-    </Grid>
-  ) : null;
+        </CardContent>
+      </Card>
+    </OSCALSection>
+  );
 }

--- a/src/components/OSCALProfileCatalogInheritance.test.js
+++ b/src/components/OSCALProfileCatalogInheritance.test.js
@@ -1,38 +1,31 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { profileCatalogInheritanceData } from "../test-data/CommonData";
 import OSCALProfileCatalogInheritance from "./OSCALProfileCatalogInheritance";
 
-function profileCatalogInheritanceRenderer() {
-  render(
-    <OSCALProfileCatalogInheritance
-      inheritedProfilesAndCatalogs={profileCatalogInheritanceData}
-    />
-  );
-}
+describe("OSCALProfileCatalogInheritance", () => {
+  beforeEach(() => {
+    render(
+      <OSCALProfileCatalogInheritance
+        inheritedProfilesAndCatalogs={profileCatalogInheritanceData}
+      />
+    );
+  });
 
-test("OSCALProfileCatalogInheritance displays top-level inherited objects", async () => {
-  profileCatalogInheritanceRenderer();
-  const resultCatalog = await waitFor(
-    () => screen.getByText("Catalog: Example Catalog"),
-    { timeout: 5000 }
-  );
-  expect(resultCatalog).toBeVisible();
+  test("displays top-level Catalog", () => {
+    const resultCatalog = screen.getByText("Example Catalog");
+    expect(resultCatalog).toBeVisible();
+  });
 
-  const resultProfile = await waitFor(
-    () => screen.getByText("Profile: Example Inherited Profile"),
-    { timeout: 5000 }
-  );
+  test("displays top-level Profile", () => {
+    const resultProfile = screen.getByText("Example Inherited Profile");
+    expect(resultProfile).toBeVisible();
+  });
 
-  expect(resultProfile).toBeVisible();
-});
+  test("displays Catalog imported from Profile", () => {
+    screen.getByText("Example Inherited Profile").click();
 
-test("OSCALProfileCatalogInheritance displays nested inherited objects", async () => {
-  profileCatalogInheritanceRenderer();
-  const nestedCatalog = await waitFor(
-    () => screen.getByText("Catalog: Nested Inherited Catalog"),
-    { timeout: 5000 }
-  );
-
-  expect(nestedCatalog).toBeVisible();
+    const nestedCatalog = screen.getByText("Nested Inherited Catalog");
+    expect(nestedCatalog).toBeVisible();
+  });
 });

--- a/src/test-data/CommonData.js
+++ b/src/test-data/CommonData.js
@@ -54,14 +54,17 @@ export const profileCatalogInheritanceData = {
     {
       title: "Example Catalog",
       type: "catalog",
+      uuid: "0988f548-8ece-41b8-b098-dc340e02c344",
     },
     {
       title: "Example Inherited Profile",
       type: "profile",
+      uuid: "8f204564-3e62-406b-a138-03888c6bcd08",
       inherited: [
         {
           title: "Nested Inherited Catalog",
           type: "catalog",
+          uuid: "09dc20e1-85a2-4a06-9f82-1eee6104e12f",
         },
       ],
     },


### PR DESCRIPTION
This improves and simplifies the structure of the
`OSCALProfileCatalogInheritance` component. The `TreeItem`s are simplified
to leverage a recursive structure and to work generically between document
types that can import one another. Additionally, an emphasis is now placed
on the document _title_ instead of the document _type_ with the type moving
to a pill/chip component after the title (so the information is not lost).

Tests are added and improved to ensure that this remains working in the
future as well.

Closes #614
