### PR TITLE
Remove ignore rules from ESLint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,20 +31,9 @@
       "react/destructuring-assignment": [0],
       "react/jsx-props-no-spreading": "off",
       "prettier/prettier": "error",
+      "import/no-extraneous-dependencies": ["error", {"packageDir": ["./", "./example"]}],
       "import/no-anonymous-default-export": "off",
-      "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrorsIgnorePattern": "^_" }],
-
-      "import/no-extraneous-dependencies": "off",
-      "jest/valid-expect": "off",
-      "jest/no-identical-title": "off",
-      "react-hooks/exhaustive-deps": "off",
-      "react-hooks/rules-of-hooks": "off",
-      "testing-library/await-async-query": "off",
-      "testing-library/no-render-in-setup": "off",
-      "testing-library/no-unnecessary-act": "off",
-      "testing-library/no-node-access": "off",
-      "testing-library/no-wait-for-multiple-assertions": "off",
-      "testing-library/render-result-naming-convention": "off"
+      "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrorsIgnorePattern": "^_" }]
     },
     "overrides": [
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,8 +31,8 @@
       "react/destructuring-assignment": [0],
       "react/jsx-props-no-spreading": "off",
       "prettier/prettier": "error",
-      "import/no-extraneous-dependencies": ["error", {"packageDir": ["./", "./example"]}],
       "import/no-anonymous-default-export": "off",
+      "import/no-extraneous-dependencies": ["error", { "devDependencies": ["**/*.test.js", "**/setupTests.js", "**/TestUtils.js"] }],
       "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrorsIgnorePattern": "^_" }]
     },
     "overrides": [

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.5.2-0",
       "dependencies": {
         "@EasyDynamics/oscal-react-library": "file:..",
+        "@mui/icons-material": "file:../node_modules/@mui/icons-material",
+        "@mui/material": "file:../node_modules/@mui/material",
         "history": "file:../node_modules/history",
         "react": "file:../node_modules/react",
         "react-dom": "file:../node_modules/react-dom",

--- a/example/package.json
+++ b/example/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@EasyDynamics/oscal-react-library": "file:..",
+    "@mui/icons-material": "file:../node_modules/@mui/icons-material",
+    "@mui/material": "file:../node_modules/@mui/material",
     "history": "file:../node_modules/history",
     "react": "file:../node_modules/react",
     "react-dom": "file:../node_modules/react-dom",

--- a/src/components/OSCALBackMatter.test.js
+++ b/src/components/OSCALBackMatter.test.js
@@ -77,7 +77,7 @@ export default function testOSCALBackMatter(parentElementName, renderer) {
     const button = screen.getByRole("button", {
       name: "PNG",
     });
-    expect(button.getAttribute("href"));
+    expect(button.getAttribute("href")).toBeTruthy();
   });
 
   test(`${parentElementName} renders "Unknown" media type extension`, async () => {
@@ -90,7 +90,7 @@ export default function testOSCALBackMatter(parentElementName, renderer) {
     const button = screen.getByRole("button", {
       name: "Unknown",
     });
-    expect(button.getAttribute("href"));
+    expect(button.getAttribute("href")).toBeTruthy();
   });
 }
 

--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -3,7 +3,7 @@ import ExpandMore from "@mui/icons-material/ExpandMore";
 import Paper from "@mui/material/Paper";
 import Collapse from "@mui/material/Collapse";
 import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
 import ListItemText from "@mui/material/ListItemText";
 import { styled } from "@mui/material/styles";
 import React from "react";
@@ -14,7 +14,7 @@ export const OSCALControlList = styled(List)`
   padding-right: 2em;
 `;
 
-const StyledListItem = styled(ListItem)(({ theme }) => ({
+const StyledListItem = styled(ListItemButton)(({ theme }) => ({
   borderRadius: "0.5em",
   marginBottom: "1em",
   backgroundColor: theme.palette.grey[50],
@@ -37,7 +37,7 @@ function CollapseableListItem(props) {
 
   return (
     <StyledListItemPaper>
-      <StyledListItem button onClick={handleClick}>
+      <StyledListItem onClick={handleClick}>
         <ListItemText primary={props.itemText} />
         {open ? <ExpandLess /> : <ExpandMore />}
       </StyledListItem>

--- a/src/components/OSCALCatalogGroups.test.js
+++ b/src/components/OSCALCatalogGroups.test.js
@@ -36,11 +36,8 @@ const testGroups = [
 ];
 
 describe("OSCALCatalogGroup", () => {
-  beforeEach(() => {
-    render(<OSCALCatalogGroups groups={testGroups} />);
-  });
-
   test("displays param legend", () => {
+    render(<OSCALCatalogGroups groups={testGroups} />);
     const placeholderBox = screen.getByLabelText("legend-placeholder-label");
     expect(placeholderBox).toBeVisible();
     const placeholderBoxLabel = screen.getByText("Placeholder");
@@ -53,6 +50,7 @@ describe("OSCALCatalogGroup", () => {
   });
 
   test("displays nested groups", () => {
+    render(<OSCALCatalogGroups groups={testGroups} />);
     const expand1 = screen.getByText("Access Control");
     fireEvent.click(expand1);
 
@@ -66,6 +64,7 @@ describe("OSCALCatalogGroup", () => {
   });
 
   test("displays sibling control group", () => {
+    render(<OSCALCatalogGroups groups={testGroups} />);
     const expand1 = screen.getByText("Sibling Title");
     fireEvent.click(expand1);
 

--- a/src/components/OSCALControlImplementationImplReq.test.js
+++ b/src/components/OSCALControlImplementationImplReq.test.js
@@ -84,8 +84,8 @@ export default function testOSCALControlImplementationImplReq(
         timeout: 10000,
       })
     ).toBeInTheDocument();
-    expect(() =>
-      screen.findByRole("button").toThrow("Unable to find an element")
+    await expect(() => screen.findByRole("button")).rejects.toThrow(
+      'Unable to find role="button"'
     );
   });
 }

--- a/src/components/OSCALControlModification.js
+++ b/src/components/OSCALControlModification.js
@@ -99,16 +99,15 @@ function getModifications(controlPartId, controlId, modList, modText) {
 }
 
 export default function OSCALControlModification(props) {
+  const [open, setOpen] = React.useState(false);
+
   // Finds the control-id within alters and matches it with a resolved control
   const alter = props.modificationAlters?.find(
     (element) => element["control-id"] === props.controlId
   );
-
   if (!alter) {
     return null;
   }
-
-  const [open, setOpen] = React.useState(false);
 
   const handleClick = () => {
     setOpen(!open);

--- a/src/components/OSCALDrawerSelector.js
+++ b/src/components/OSCALDrawerSelector.js
@@ -46,7 +46,8 @@ const StyledTreeView = styled(TreeView)`
   max-width: ${drawerWidth};
 `;
 
-function createTree(backendUrl, handleClose) {
+function DocumentTree(props) {
+  const { backendUrl, handleClose } = props;
   const [oscalObjects, setOscalObjects] = useState({});
 
   useEffect(() => {
@@ -58,7 +59,7 @@ function createTree(backendUrl, handleClose) {
         }))
       )
     );
-  }, []);
+  }, [backendUrl]);
 
   return (
     <StyledTreeView
@@ -113,7 +114,10 @@ export default function OSCALDrawerSelector(props) {
         </IconButton>
       </DrawerHeader>
       <Divider />
-      {createTree(props.backendUrl, props.handleClose)}
+      <DocumentTree
+        backendUrl={props.backendUrl}
+        handleClose={props.handleClose}
+      />
       <Divider />
     </StyledDrawer>
   );

--- a/src/components/OSCALJsonEditor.test.js
+++ b/src/components/OSCALJsonEditor.test.js
@@ -1,6 +1,5 @@
 import { React } from "react";
 import {
-  act,
   render,
   screen,
   waitFor,
@@ -89,15 +88,13 @@ describe("OSCALJsonEditor", () => {
     const container = await screen.findByTestId("container");
     const saveButton = within(container).getByTestId("save-button");
 
-    act(() => {
-      fireEvent.click(saveButton);
-    });
+    fireEvent.click(saveButton);
 
     await waitFor(() => {
       expect(mockEditorRef.getValue).toBeCalledTimes(1);
-      expect(handleSave).toBeCalledTimes(1);
-      expect(handleSave).lastReturnedWith(oscalData);
     });
+    expect(handleSave).toBeCalledTimes(1);
+    expect(handleSave).lastReturnedWith(oscalData);
   });
 
   it("should replace original value after clicking cancel", async () => {
@@ -117,15 +114,13 @@ describe("OSCALJsonEditor", () => {
     const container = await screen.findByTestId("container");
     const cancelButton = within(container).getByTestId("cancel-button");
 
-    act(() => {
-      fireEvent.click(cancelButton);
-    });
+    fireEvent.click(cancelButton);
 
     await waitFor(() => {
       expect(mockEditorRef.setValue).toBeCalledTimes(1);
-      expect(mockEditorRef.setValue).toHaveBeenLastCalledWith(
-        oscalData.oscalSource
-      );
     });
+    expect(mockEditorRef.setValue).toHaveBeenLastCalledWith(
+      oscalData.oscalSource
+    );
   });
 });

--- a/src/components/OSCALMarkupProse.test.js
+++ b/src/components/OSCALMarkupProse.test.js
@@ -1,19 +1,19 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import ReactDomServer from "react-dom/server";
 import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
-const asHtml = (input) => ReactDomServer.renderToStaticMarkup(input);
+const asHtml = (component) => render(component).container.innerHTML;
+
 test(`OSCALMarkupLine converts plaintext to HTML`, () => {
-  const testerString = asHtml(<OSCALMarkupLine>Test</OSCALMarkupLine>);
-  expect(testerString).toEqual("Test");
+  const html = asHtml(<OSCALMarkupLine>Test</OSCALMarkupLine>);
+  expect(html).toBe("Test");
 });
 
 test(`OSCALMarkupLine converts Italics, Bold and Plaintext`, () => {
-  const testerString = asHtml(
+  const html = asHtml(
     <OSCALMarkupLine>*Hello*, **world** I am in markdown</OSCALMarkupLine>
   );
-  expect(testerString).toEqual(
+  expect(html).toEqual(
     "<em>Hello</em>, <strong>world</strong> I am in markdown"
   );
 });
@@ -31,26 +31,22 @@ test(`OSCALMarkupLine converts hyperlinks to HTML`, () => {
 
 test(`OSCALMarkupLine converts images to HTML`, () => {
   const altText = `![alt text](url "title text")`;
-  const testerString = asHtml(<OSCALMarkupLine>{altText}</OSCALMarkupLine>);
-  expect(testerString).toEqual(
-    '<img src="url" alt="alt text" title="title text"/>'
-  );
+  const html = asHtml(<OSCALMarkupLine>{altText}</OSCALMarkupLine>);
+  expect(html).toEqual('<img src="url" alt="alt text" title="title text">');
 });
 
-test(`OSCALMarkupLine converts images to HTML`, () => {
-  const testerString = asHtml(
+test(`OSCALMarkupLine converts code to HTML`, () => {
+  const html = asHtml(
     <OSCALMarkupLine>`Inserting Tester Code`</OSCALMarkupLine>
   );
-  expect(testerString).toEqual("<code>Inserting Tester Code</code>");
+  expect(html).toEqual("<code>Inserting Tester Code</code>");
 });
 
 test(`OSCALMarkupLine converts script to HTML`, () => {
   const nastyBoi = `<script>alert('Nasty script!')</script>`;
-  const testerString = asHtml(<OSCALMarkupLine>{nastyBoi}</OSCALMarkupLine>);
+  const html = asHtml(<OSCALMarkupLine>{nastyBoi}</OSCALMarkupLine>);
 
-  expect(testerString).toEqual(
-    "&lt;script&gt;alert(&#x27;Nasty script!&#x27;)&lt;/script&gt;"
-  );
+  expect(html).toEqual("&lt;script&gt;alert('Nasty script!')&lt;/script&gt;");
 });
 
 test(`OSCALMarkupMultiLine converts a multiline string to HTML`, () => {
@@ -75,10 +71,10 @@ test(`OSCALMarkupMultiLine converts a multiline string to HTML`, () => {
 <h3>h3 Heading</h3>
 <p>This is in heading 3</p>
 <h4><strong>h4 Heading</strong></h4>`;
-  const testerString = asHtml(
+  const html = asHtml(
     <OSCALMarkupMultiLine>{multilineMarkdown}</OSCALMarkupMultiLine>
   );
-  expect(testerString).toEqual(multilineAsHTML);
+  expect(html).toEqual(multilineAsHTML);
 });
 
 test(`OSCALMarkupLine Handles titles of links`, () => {

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -4,26 +4,26 @@ import OSCALMetadata from "./OSCALMetadata";
 import { metadataTestData } from "../test-data/CommonData";
 
 describe("OSCALMetadata", () => {
-  beforeEach(() => {
-    render(<OSCALMetadata metadata={metadataTestData} />);
-  });
-
   test(`displays title`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const result = screen.getByRole("heading", { name: "Test Title" });
     expect(result).toBeVisible();
   });
 
   test(`displays version`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const result = screen.getByText("Revision 5");
     expect(result).toBeVisible();
   });
 
   test(`displays parties`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const result = screen.getByText("Some group of people");
     expect(result).toBeVisible();
   });
 
   test(`displays Contact button`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -32,6 +32,7 @@ describe("OSCALMetadata", () => {
   });
 
   test(`displays email contact info`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -45,6 +46,7 @@ describe("OSCALMetadata", () => {
   });
 
   test(`displays telephone mobile number info`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -55,6 +57,7 @@ describe("OSCALMetadata", () => {
   });
 
   test(`displays telephone office number info`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -66,6 +69,7 @@ describe("OSCALMetadata", () => {
   });
 
   test(`displays telephone home number info`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -77,6 +81,7 @@ describe("OSCALMetadata", () => {
   });
 
   test(`displays unknown type telephone number info`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -88,6 +93,7 @@ describe("OSCALMetadata", () => {
   });
 
   test(`displays work address info`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -98,6 +104,7 @@ describe("OSCALMetadata", () => {
   });
 
   test(`displays home address info`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });
@@ -109,6 +116,7 @@ describe("OSCALMetadata", () => {
   });
 
   test(`displays unknown type address info`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
       name: /contact/i,
     });

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { OSCALProfileLoader } from "./OSCALLoader";
 import OSCALProfile from "./OSCALProfile";
 import testOSCALBackMatter from "./OSCALBackMatter.test";
@@ -23,9 +23,7 @@ function profileRenderer() {
 function testOSCALProfile(parentElementName, renderer) {
   jest.setTimeout(6000);
   test(`${parentElementName} displays controls`, async () => {
-    act(() => {
-      renderer();
-    });
+    renderer();
     const result = await screen.findByText("ac-1", {
       timeout: 5000,
     });

--- a/src/components/OSCALProfileCatalogInheritance.test.js
+++ b/src/components/OSCALProfileCatalogInheritance.test.js
@@ -4,25 +4,33 @@ import { profileCatalogInheritanceData } from "../test-data/CommonData";
 import OSCALProfileCatalogInheritance from "./OSCALProfileCatalogInheritance";
 
 describe("OSCALProfileCatalogInheritance", () => {
-  beforeEach(() => {
+  test("displays top-level Catalog", () => {
     render(
       <OSCALProfileCatalogInheritance
         inheritedProfilesAndCatalogs={profileCatalogInheritanceData}
       />
     );
-  });
 
-  test("displays top-level Catalog", () => {
     const resultCatalog = screen.getByText("Example Catalog");
     expect(resultCatalog).toBeVisible();
   });
 
   test("displays top-level Profile", () => {
+    render(
+      <OSCALProfileCatalogInheritance
+        inheritedProfilesAndCatalogs={profileCatalogInheritanceData}
+      />
+    );
     const resultProfile = screen.getByText("Example Inherited Profile");
     expect(resultProfile).toBeVisible();
   });
 
   test("displays Catalog imported from Profile", () => {
+    render(
+      <OSCALProfileCatalogInheritance
+        inheritedProfilesAndCatalogs={profileCatalogInheritanceData}
+      />
+    );
     screen.getByText("Example Inherited Profile").click();
 
     const nestedCatalog = screen.getByText("Nested Inherited Catalog");

--- a/src/components/OSCALResponsibleRoles.test.js
+++ b/src/components/OSCALResponsibleRoles.test.js
@@ -7,16 +7,14 @@ import {
 } from "../test-data/CommonData";
 
 describe("OSCALResponsibleRoles", () => {
-  beforeEach(() => {
+  test(`shows component roles`, () => {
     render(
       <OSCALResponsibleRoles
         responsibleRoles={responsibleRolesTestData}
         parties={metadataTestData.parties}
       />
     );
-  });
 
-  test(`shows component roles`, () => {
     const roleTypeResult = screen.getByText("provider");
     expect(roleTypeResult).toBeVisible();
 

--- a/src/components/OSCALResponsibleRoles.test.js
+++ b/src/components/OSCALResponsibleRoles.test.js
@@ -15,12 +15,14 @@ describe("OSCALResponsibleRoles", () => {
       />
     );
 
-    const roleTypeResult = screen.getByText("provider");
-    expect(roleTypeResult).toBeVisible();
+    const responsibleRolesRow = screen.getByRole("row");
 
-    const rolePartyResult = within(roleTypeResult.closest("tr")).getByText(
+    const rowHeader = within(responsibleRolesRow).getByRole("rowheader");
+    expect(rowHeader).toHaveTextContent("provider");
+
+    const rowData = within(responsibleRolesRow).getByText(
       "Some group of people"
     );
-    expect(rolePartyResult).toBeVisible();
+    expect(rowData).toBeVisible();
   });
 });

--- a/src/components/OSCALSystemImplementation.test.js
+++ b/src/components/OSCALSystemImplementation.test.js
@@ -4,16 +4,13 @@ import { systemImplementationTestData } from "../test-data/SystemData";
 import OSCALSystemImplementation from "./OSCALSystemImplementation";
 
 describe("SystemImplementation", () => {
-  beforeEach(() => {
+  test(`shows remarks`, () => {
     render(
       <OSCALSystemImplementation
         systemImplementation={systemImplementationTestData}
         parties={metadataTestData.parties}
       />
     );
-  });
-
-  test(`shows remarks`, () => {
     const result = screen.getByText("Example system implementation remarks.");
     expect(result).toBeVisible();
   });

--- a/src/components/OSCALSystemImplementationComponents.test.js
+++ b/src/components/OSCALSystemImplementationComponents.test.js
@@ -5,26 +5,35 @@ import { componentsTestData } from "../test-data/SystemData";
 import OSCALSystemImplementationComponents from "./OSCALSystemImplementationComponents";
 
 describe("OSCALSystemImplementationComponents", () => {
-  beforeEach(() => {
+  test("shows Components section title", () => {
     render(
       <OSCALSystemImplementationComponents
         components={componentsTestData}
         parties={responsiblePartiesTestData}
       />
     );
-  });
-
-  test("shows Components section title", () => {
     const result = screen.getByText("Components");
     expect(result).toBeVisible();
   });
 
   test(`shows component title`, () => {
+    render(
+      <OSCALSystemImplementationComponents
+        components={componentsTestData}
+        parties={responsiblePartiesTestData}
+      />
+    );
     const result = screen.getByText("Example Component");
     expect(result).toBeVisible();
   });
 
   test(`shows component description`, async () => {
+    render(
+      <OSCALSystemImplementationComponents
+        components={componentsTestData}
+        parties={responsiblePartiesTestData}
+      />
+    );
     await userEvent.hover(screen.getByText("Example Component"));
     expect(
       await screen.findByText("An example component.")
@@ -32,18 +41,36 @@ describe("OSCALSystemImplementationComponents", () => {
   });
 
   test(`shows component status`, () => {
+    render(
+      <OSCALSystemImplementationComponents
+        components={componentsTestData}
+        parties={responsiblePartiesTestData}
+      />
+    );
     const component = screen.getByText("Example Component").closest("tr");
     const result = within(component).getByText("operational");
     expect(result).toBeVisible();
   });
 
   test(`shows component type`, () => {
+    render(
+      <OSCALSystemImplementationComponents
+        components={componentsTestData}
+        parties={responsiblePartiesTestData}
+      />
+    );
     const component = screen.getByText("Example Component").closest("tr");
     const result = within(component).getByText("software");
     expect(result).toBeVisible();
   });
 
   test(`shows component version`, () => {
+    render(
+      <OSCALSystemImplementationComponents
+        components={componentsTestData}
+        parties={responsiblePartiesTestData}
+      />
+    );
     const component = screen.getByText("Example Component").closest("tr");
     const propNameResult = within(component).getByText("version");
     expect(propNameResult).toBeVisible();

--- a/src/components/OSCALSystemImplementationComponents.test.js
+++ b/src/components/OSCALSystemImplementationComponents.test.js
@@ -47,8 +47,17 @@ describe("OSCALSystemImplementationComponents", () => {
         parties={responsiblePartiesTestData}
       />
     );
-    const component = screen.getByText("Example Component").closest("tr");
-    const result = within(component).getByText("operational");
+    // Grab example party row beneath heading row
+    const exampleResponsiblePartiesRow = screen.getAllByRole("row")[1];
+
+    const component = within(exampleResponsiblePartiesRow).getByText(
+      "Example Component"
+    );
+    expect(component).toBeVisible();
+
+    const result = within(exampleResponsiblePartiesRow).getByText(
+      "operational"
+    );
     expect(result).toBeVisible();
   });
 
@@ -59,8 +68,15 @@ describe("OSCALSystemImplementationComponents", () => {
         parties={responsiblePartiesTestData}
       />
     );
-    const component = screen.getByText("Example Component").closest("tr");
-    const result = within(component).getByText("software");
+    // Grab example party row beneath heading row
+    const exampleResponsiblePartiesRow = screen.getAllByRole("row")[1];
+
+    const component = within(exampleResponsiblePartiesRow).getByText(
+      "Example Component"
+    );
+    expect(component).toBeVisible();
+
+    const result = within(exampleResponsiblePartiesRow).getByText("software");
     expect(result).toBeVisible();
   });
 
@@ -71,10 +87,21 @@ describe("OSCALSystemImplementationComponents", () => {
         parties={responsiblePartiesTestData}
       />
     );
-    const component = screen.getByText("Example Component").closest("tr");
-    const propNameResult = within(component).getByText("version");
+    // Grab example party row beneath heading row
+    const exampleResponsiblePartiesRow = screen.getAllByRole("row")[1];
+
+    const component = within(exampleResponsiblePartiesRow).getByText(
+      "Example Component"
+    );
+    expect(component).toBeVisible();
+
+    const propNameResult = within(exampleResponsiblePartiesRow).getByText(
+      "version"
+    );
     expect(propNameResult).toBeVisible();
-    const propValueResult = within(component).getByText("1.1");
+    const propValueResult = within(exampleResponsiblePartiesRow).getByText(
+      "1.1"
+    );
     expect(propValueResult).toBeVisible();
   });
 });

--- a/src/components/OSCALSystemImplementationInventoryItems.test.js
+++ b/src/components/OSCALSystemImplementationInventoryItems.test.js
@@ -6,48 +6,55 @@ import {
 } from "../test-data/SystemData";
 import OSCALSystemImplementationInventoryItems from "./OSCALSystemImplementationInventoryItems";
 
-describe("OSCALSystemImplementationInventoryItems", () => {
-  beforeEach(() => {
-    render(
-      <OSCALSystemImplementationInventoryItems
-        inventoryItems={inventoryItemsTestData}
-        parties={responsiblePartiesTestData}
-        components={componentsTestData}
-      />
-    );
-  });
+const setup = () => {
+  render(
+    <OSCALSystemImplementationInventoryItems
+      inventoryItems={inventoryItemsTestData}
+      parties={responsiblePartiesTestData}
+      components={componentsTestData}
+    />
+  );
+};
 
+describe("OSCALSystemImplementationInventoryItems", () => {
   test(`shows description`, () => {
+    setup();
     const result = screen.getByText("An example inventory item.");
     expect(result).toBeVisible();
   });
 
   test(`shows remarks`, () => {
+    setup();
     const result = screen.getByText("Additional information about this item.");
     expect(result).toBeVisible();
   });
 
   test(`shows prop name`, async () => {
+    setup();
     const result = screen.getByText("prop-1");
     expect(result).toBeVisible();
   });
 
   test(`shows prop value`, async () => {
+    setup();
     const result = screen.getByText("An example property.");
     expect(result).toBeVisible();
   });
 
   test(`shows parties`, () => {
+    setup();
     const result = screen.getByText("provider");
     expect(result).toBeVisible();
   });
 
   test(`shows implemented components name`, () => {
+    setup();
     const result = screen.getByText("Example Component");
     expect(result).toBeVisible();
   });
 
   test(`shows implemented component type`, () => {
+    setup();
     const component = screen.getByText("Example Component").closest("tr");
     const result = within(component).getByText("software");
     expect(result).toBeVisible();

--- a/src/components/OSCALSystemImplementationInventoryItems.test.js
+++ b/src/components/OSCALSystemImplementationInventoryItems.test.js
@@ -55,8 +55,18 @@ describe("OSCALSystemImplementationInventoryItems", () => {
 
   test(`shows implemented component type`, () => {
     setup();
-    const component = screen.getByText("Example Component").closest("tr");
-    const result = within(component).getByText("software");
-    expect(result).toBeVisible();
+
+    // Grab example party row beneath heading row
+    const exampleResponsiblePartiesRow = screen.getAllByRole("row")[1];
+
+    const component = within(exampleResponsiblePartiesRow).getByText(
+      "Example Component"
+    );
+    expect(component).toBeVisible();
+
+    const propNameResult = within(exampleResponsiblePartiesRow).getByText(
+      "software"
+    );
+    expect(propNameResult).toBeVisible();
   });
 });

--- a/src/components/OSCALSystemImplementationUsers.test.js
+++ b/src/components/OSCALSystemImplementationUsers.test.js
@@ -23,11 +23,6 @@ describe("OSCALSystemImplementationUsers", () => {
     expect(result).toBeVisible();
   });
 
-  test("shows name of a user listed", () => {
-    const result = screen.getByText("User 1");
-    expect(result).toBeVisible();
-  });
-
   test("shows name of a privilege listed", () => {
     const result = screen.getByText("privilege title");
     expect(result).toBeVisible();

--- a/src/components/OSCALSystemImplementationUsers.test.js
+++ b/src/components/OSCALSystemImplementationUsers.test.js
@@ -4,41 +4,44 @@ import { usersTestData } from "../test-data/SystemData";
 import OSCALSystemImplementationUsers from "./OSCALSystemImplementationUsers";
 
 describe("OSCALSystemImplementationUsers", () => {
-  beforeEach(() => {
-    render(<OSCALSystemImplementationUsers users={usersTestData} />);
-  });
-
   test("shows 'Users' section title", () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     const result = screen.getByText("Users");
     expect(result).toBeVisible();
   });
 
   test("shows 'Title' column", () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     const result = screen.getByText("Title");
     expect(result).toBeVisible();
   });
 
   test("shows 'Authorized Privileges' column", () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     const result = screen.getByText("Authorized Privileges");
     expect(result).toBeVisible();
   });
 
   test("shows name of a privilege listed", () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     const result = screen.getByText("privilege title");
     expect(result).toBeVisible();
   });
 
   test("shows name of a user listed", async () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     await userEvent.hover(screen.getByText("User 1"));
     expect(await screen.findByText("A system user")).toBeInTheDocument();
   });
 
   test("shows 'Authorized Privileges' title", () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     const result = screen.getByText("privilege title");
     expect(result).toBeVisible();
   });
 
   test("shows 'Authorized Privileges' description", async () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     await userEvent.hover(screen.getByText("privilege title"));
     expect(
       await screen.findByText("privilege description")
@@ -46,11 +49,13 @@ describe("OSCALSystemImplementationUsers", () => {
   });
 
   test("shows read function preformed", () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     const result = screen.getByText("reading function");
     expect(result).toBeVisible();
   });
 
   test("shows write function preformed", () => {
+    render(<OSCALSystemImplementationUsers users={usersTestData} />);
     const result = screen.getByText("writing function");
     expect(result).toBeVisible();
   });


### PR DESCRIPTION
In a recent pull request, we disabled many ESLint rules because they were finally being
detected. This adds corrections for many of them. This is largely a duplicate of #640;
however, in #640 there are some commits that cause rendering loops and this PR does not
include those (we will still need to address them but they can be merged separately).

