### PR TITLE
feat(metadata): Display role description

### DIFF
--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -334,15 +334,41 @@ export function OSCALMetadataParty(props) {
 }
 
 export function OSCALMetadataRole(props) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    if (props.role.description) {
+      setOpen(true);
+    }
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
   return (
     <Card>
       <CardHeader
         title={props.role.title}
         avatar={<MetadataAvatar text={props.role.title.toUpperCase()} />}
-        subheader={
-          <OSCALMarkupMultiLine>{props.role.description}</OSCALMarkupMultiLine>
-        }
+        onClick={handleOpen}
       />
+      <CardActions>
+        <Dialog
+          open={open}
+          onClose={handleClose}
+          scroll="paper"
+          maxWidth="md"
+          fullWidth
+        >
+          <DialogTitle>{props.role.title}</DialogTitle>
+          <DialogContent dividers>
+            <OSCALMarkupMultiLine>
+              {props.role.description}
+            </OSCALMarkupMultiLine>
+          </DialogContent>
+        </Dialog>
+      </CardActions>
     </Card>
   );
 }

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -353,6 +353,7 @@ export function OSCALMetadataRole(props) {
           variant="outlined"
           onClick={handleOpen}
           aria-label={`${props.role.title} details button`}
+          disabled={!props.role?.description}
         >
           <InfoIcon />
           Details

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -200,18 +200,7 @@ export function OSCALMetadataPartyDialog(props) {
           <Stack direction="column">
             {props.party.name}
             {props.partyRolesText?.map((role) => (
-              <StyledTooltip
-                title={
-                  role.description ? (
-                    <Typography> {role.description} </Typography>
-                  ) : (
-                    ""
-                  )
-                }
-                key={role.title}
-              >
-                <Typography> {role.title} </Typography>
-              </StyledTooltip>
+              <Typography key={role.title}> {role.title} </Typography>
             ))}
           </Stack>
         </Stack>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -1,12 +1,10 @@
 import BusinessIcon from "@mui/icons-material/Business";
-import ContactPageIcon from "@mui/icons-material/ContactPage";
 import EmailIcon from "@mui/icons-material/Email";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import HomeIcon from "@mui/icons-material/Home";
 import MapIcon from "@mui/icons-material/Map";
 import PhoneIcon from "@mui/icons-material/Phone";
 import SmartphoneIcon from "@mui/icons-material/Smartphone";
-import { CardActionArea, CardContent } from "@mui/material";
 import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
@@ -26,6 +24,7 @@ import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import InfoIcon from "@mui/icons-material/Info";
 import OSCALEditableTextField from "./OSCALEditableTextField";
 import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
@@ -316,9 +315,9 @@ export function OSCALMetadataParty(props) {
           size="small"
           variant="outlined"
           onClick={handleOpen}
-          aria-label={`${props.party.name} contact button`}
+          aria-label={`${props.party.name} details button`}
         >
-          <ContactPageIcon />
+          <InfoIcon />
           Details
         </Button>
         <OSCALMetadataPartyDialog
@@ -334,45 +333,11 @@ export function OSCALMetadataParty(props) {
   );
 }
 
-function OSCALRoleCardWithDescription(props) {
-  return (
-    <CardActionArea onClick={props.handleOpen}>
-      <OSCALRoleCardContent role={props.role} />
-      <CardActions>
-        <Dialog
-          open={props.open}
-          onClose={props.handleClose}
-          scroll="paper"
-          maxWidth="md"
-          fullWidth
-        >
-          <DialogTitle>{props.role.title}</DialogTitle>
-          <DialogContent dividers>
-            <OSCALMarkupMultiLine>
-              {props.role.description}
-            </OSCALMarkupMultiLine>
-          </DialogContent>
-        </Dialog>
-      </CardActions>
-    </CardActionArea>
-  );
-}
-
-function OSCALRoleCardContent(props) {
-  return (
-    <CardContent>
-      <Typography>{props.role.title}</Typography>
-    </CardContent>
-  );
-}
-
 export function OSCALMetadataRole(props) {
   const [open, setOpen] = React.useState(false);
 
   const handleOpen = () => {
-    if (props.role.description) {
-      setOpen(true);
-    }
+    setOpen(true);
   };
 
   const handleClose = () => {
@@ -381,16 +346,32 @@ export function OSCALMetadataRole(props) {
 
   return (
     <Card>
-      {props.role.description ? (
-        <OSCALRoleCardWithDescription
-          role={props.role}
+      <CardHeader subheader={props.role.title} />
+      <CardActions>
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={handleOpen}
+          aria-label={`${props.role.title} details button`}
+        >
+          <InfoIcon />
+          Details
+        </Button>
+        <Dialog
           open={open}
-          handleOpen={handleOpen}
-          handleClose={handleClose}
-        />
-      ) : (
-        <OSCALRoleCardContent role={props.role} />
-      )}
+          onClose={handleClose}
+          scroll="paper"
+          maxWidth="md"
+          fullWidth
+        >
+          <DialogTitle>{props.role.title}</DialogTitle>
+          <DialogContent dividers>
+            <OSCALMarkupMultiLine>
+              {props.role?.description}
+            </OSCALMarkupMultiLine>
+          </DialogContent>
+        </Dialog>
+      </CardActions>
     </Card>
   );
 }

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -6,6 +6,7 @@ import HomeIcon from "@mui/icons-material/Home";
 import MapIcon from "@mui/icons-material/Map";
 import PhoneIcon from "@mui/icons-material/Phone";
 import SmartphoneIcon from "@mui/icons-material/Smartphone";
+import { CardActionArea, CardContent } from "@mui/material";
 import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
@@ -333,6 +334,38 @@ export function OSCALMetadataParty(props) {
   );
 }
 
+function OSCALRoleCardWithDescription(props) {
+  return (
+    <CardActionArea onClick={props.handleOpen}>
+      <OSCALRoleCardContent role={props.role} />
+      <CardActions>
+        <Dialog
+          open={props.open}
+          onClose={props.handleClose}
+          scroll="paper"
+          maxWidth="md"
+          fullWidth
+        >
+          <DialogTitle>{props.role.title}</DialogTitle>
+          <DialogContent dividers>
+            <OSCALMarkupMultiLine>
+              {props.role.description}
+            </OSCALMarkupMultiLine>
+          </DialogContent>
+        </Dialog>
+      </CardActions>
+    </CardActionArea>
+  );
+}
+
+function OSCALRoleCardContent(props) {
+  return (
+    <CardContent>
+      <Typography>{props.role.title}</Typography>
+    </CardContent>
+  );
+}
+
 export function OSCALMetadataRole(props) {
   const [open, setOpen] = React.useState(false);
 
@@ -348,27 +381,16 @@ export function OSCALMetadataRole(props) {
 
   return (
     <Card>
-      <CardHeader
-        title={props.role.title}
-        avatar={<MetadataAvatar text={props.role.title.toUpperCase()} />}
-        onClick={handleOpen}
-      />
-      <CardActions>
-        <Dialog
+      {props.role.description ? (
+        <OSCALRoleCardWithDescription
+          role={props.role}
           open={open}
-          onClose={handleClose}
-          scroll="paper"
-          maxWidth="md"
-          fullWidth
-        >
-          <DialogTitle>{props.role.title}</DialogTitle>
-          <DialogContent dividers>
-            <OSCALMarkupMultiLine>
-              {props.role.description}
-            </OSCALMarkupMultiLine>
-          </DialogContent>
-        </Dialog>
-      </CardActions>
+          handleOpen={handleOpen}
+          handleClose={handleClose}
+        />
+      ) : (
+        <OSCALRoleCardContent role={props.role} />
+      )}
     </Card>
   );
 }

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -152,6 +152,7 @@ function OSCALMetadataPartyContactTypeHeader(props) {
 }
 
 export function OSCALMetadataPartyDialog(props) {
+  console.log(props.partyRolesText);
   const PartyInfoTypes = {
     address: "address",
     telephone: "telephone",
@@ -197,7 +198,13 @@ export function OSCALMetadataPartyDialog(props) {
           {props.avatar}
           <Stack direction="column">
             {props.party.name}
-            <Typography variant="body2">{props.partyRolesText}</Typography>
+            {props.partyRolesText.map((role) => (
+              <Typography>
+                {`${role.title} ${
+                  role.description ? ` - ${role.description}` : ""
+                }`}
+              </Typography>
+            ))}
           </Stack>
         </Stack>
       </DialogTitle>
@@ -300,7 +307,7 @@ export function OSCALMetadataParty(props) {
       <CardHeader
         avatar={avatar}
         title={props.party.name}
-        subheader={props.partyRolesText}
+        subheader={props.partyRolesText.map((role) => role.title).join(", ")}
       />
       <CardActions>
         <Button
@@ -330,7 +337,7 @@ export default function OSCALMetadata(props) {
     return null;
   }
   const getRoleLabel = (roleId) =>
-    props.metadata.roles.find((role) => role.id === roleId)?.title;
+    props.metadata.roles.find((role) => role.id === roleId);
 
   const getPartyRolesText = (party) =>
     props.metadata["responsible-parties"]
@@ -339,9 +346,7 @@ export default function OSCALMetadata(props) {
       )
       .map((item) => item["role-id"])
       .map(getRoleLabel)
-      // Remove empty/falsey items from the list
-      .filter((item) => item)
-      .join(", ");
+      .filter((item) => item);
 
   return (
     <Grid container>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -324,7 +324,7 @@ export function OSCALMetadataParty(props) {
           aria-label={`${props.party.name} contact button`}
         >
           <ContactPageIcon />
-          Contact
+          Details
         </Button>
         <OSCALMetadataPartyDialog
           open={open}

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -198,7 +198,7 @@ export function OSCALMetadataPartyDialog(props) {
           {props.avatar}
           <Stack direction="column">
             {props.party.name}
-            {props.partyRolesText.map((role) => (
+            {props.partyRolesText?.map((role) => (
               <StyledTooltip
                 title={
                   role.description ? (

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -267,17 +267,7 @@ export function OSCALMetadataPartyDialog(props) {
   );
 }
 
-export function OSCALMetadataParty(props) {
-  const [open, setOpen] = React.useState(false);
-
-  const handleOpen = () => {
-    setOpen(true);
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-  };
-
+function MetadataAvatar(props) {
   const avatarColor = (name) => {
     // This implementation hashes the given string to create a
     // color string. This is based of the example algorithm given
@@ -296,6 +286,7 @@ export function OSCALMetadataParty(props) {
     }
     return color;
   };
+
   const avatarValue = (name) =>
     name
       ?.split(" ")
@@ -303,11 +294,25 @@ export function OSCALMetadataParty(props) {
       .join("")
       .substring(0, 2);
 
-  const avatar = (
-    <Avatar sx={{ bgcolor: avatarColor(props.party.name) }}>
-      {avatarValue(props.party.name)}
+  return (
+    <Avatar sx={{ bgcolor: avatarColor(props.text) }}>
+      {avatarValue(props.text)}
     </Avatar>
   );
+}
+
+export function OSCALMetadataParty(props) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const avatar = <MetadataAvatar text={props.party.name} />;
 
   return (
     <Card>
@@ -335,6 +340,18 @@ export function OSCALMetadataParty(props) {
           avatar={avatar}
         />
       </CardActions>
+    </Card>
+  );
+}
+
+export function OSCALMetadataRole(props) {
+  return (
+    <Card>
+      <CardHeader
+        title={props.role.title}
+        avatar={<MetadataAvatar text={props.role.title.toUpperCase()} />}
+        subheader={props.role.description}
+      />
     </Card>
   );
 }
@@ -371,15 +388,15 @@ export default function OSCALMetadata(props) {
             partialRestData={
               props.isEditable
                 ? {
-                    [Object.keys(props.partialRestData)[0]]: {
-                      uuid: props.partialRestData[
-                        Object.keys(props.partialRestData)[0]
-                      ].uuid,
-                      metadata: {
-                        title: props.metadata.title,
-                      },
+                  [Object.keys(props.partialRestData)[0]]: {
+                    uuid: props.partialRestData[
+                      Object.keys(props.partialRestData)[0]
+                    ].uuid,
+                    metadata: {
+                      title: props.metadata.title,
                     },
-                  }
+                  },
+                }
                 : null
             }
             size={6}
@@ -390,6 +407,18 @@ export default function OSCALMetadata(props) {
         </OSCALMetadataTitle>
       </Grid>
       <Grid container spacing={1}>
+        <Grid component={Paper} item xs={8}>
+          <Grid item xs={12}>
+            <OSCALMetadataPartiesHeader>Roles</OSCALMetadataPartiesHeader>
+          </Grid>
+          <OSCALMetadataPartiesCardHolder container spacing={1} wrap="wrap">
+            {props.metadata.roles?.map((role) => (
+              <Grid item xs={12} md={4} key={role.id}>
+                <OSCALMetadataRole key={role.id} role={role} />
+              </Grid>
+            ))}
+          </OSCALMetadataPartiesCardHolder>
+        </Grid>
         <Grid component={Paper} item xs={8}>
           <Grid item xs={12}>
             <OSCALMetadataPartiesHeader>Parties</OSCALMetadataPartiesHeader>
@@ -406,6 +435,7 @@ export default function OSCALMetadata(props) {
             ))}
           </OSCALMetadataPartiesCardHolder>
         </Grid>
+
         <Grid item md={3} xs={12}>
           <Grid item xs={12}>
             <OSCALMetadataAdditional>
@@ -421,25 +451,25 @@ export default function OSCALMetadata(props) {
                   editedField={
                     props.isEditable
                       ? [
-                          Object.keys(props.partialRestData)[0],
-                          "metadata",
-                          "version",
-                        ]
+                        Object.keys(props.partialRestData)[0],
+                        "metadata",
+                        "version",
+                      ]
                       : null
                   }
                   onFieldSave={props.onFieldSave}
                   partialRestData={
                     props.isEditable
                       ? {
-                          [Object.keys(props.partialRestData)[0]]: {
-                            uuid: props.partialRestData[
-                              Object.keys(props.partialRestData)[0]
-                            ].uuid,
-                            metadata: {
-                              version: props.metadata.version,
-                            },
+                        [Object.keys(props.partialRestData)[0]]: {
+                          uuid: props.partialRestData[
+                            Object.keys(props.partialRestData)[0]
+                          ].uuid,
+                          metadata: {
+                            version: props.metadata.version,
                           },
-                        }
+                        },
+                      }
                       : null
                   }
                   size={4}

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -401,18 +401,6 @@ export default function OSCALMetadata(props) {
       <Grid container spacing={1}>
         <Grid component={Paper} item xs={8}>
           <Grid item xs={12}>
-            <OSCALMetadataPartiesHeader>Roles</OSCALMetadataPartiesHeader>
-          </Grid>
-          <OSCALMetadataPartiesCardHolder container spacing={1} wrap="wrap">
-            {props.metadata.roles?.map((role) => (
-              <Grid item xs={12} md={4} key={role.id}>
-                <OSCALMetadataRole key={role.id} role={role} />
-              </Grid>
-            ))}
-          </OSCALMetadataPartiesCardHolder>
-        </Grid>
-        <Grid component={Paper} item xs={8}>
-          <Grid item xs={12}>
             <OSCALMetadataPartiesHeader>Parties</OSCALMetadataPartiesHeader>
           </Grid>
           <OSCALMetadataPartiesCardHolder container spacing={1} wrap="wrap">
@@ -427,7 +415,6 @@ export default function OSCALMetadata(props) {
             ))}
           </OSCALMetadataPartiesCardHolder>
         </Grid>
-
         <Grid item md={3} xs={12}>
           <Grid item xs={12}>
             <OSCALMetadataAdditional>
@@ -496,6 +483,18 @@ export default function OSCALMetadata(props) {
               </Grid>
             </OSCALMetadataAdditional>
           </Grid>
+        </Grid>
+        <Grid component={Paper} item xs={8}>
+          <Grid item xs={12}>
+            <OSCALMetadataPartiesHeader>Roles</OSCALMetadataPartiesHeader>
+          </Grid>
+          <OSCALMetadataPartiesCardHolder container spacing={1} wrap="wrap">
+            {props.metadata.roles?.map((role) => (
+              <Grid item xs={12} md={4} key={role.id}>
+                <OSCALMetadataRole key={role.id} role={role} />
+              </Grid>
+            ))}
+          </OSCALMetadataPartiesCardHolder>
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -27,6 +27,7 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 import OSCALEditableTextField from "./OSCALEditableTextField";
 import StyledTooltip from "./OSCALStyledTooltip";
+import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
 export const OSCALMetadataPartiesHeader = styled(ListSubheader)(
   ({ theme }) => `
@@ -350,7 +351,9 @@ export function OSCALMetadataRole(props) {
       <CardHeader
         title={props.role.title}
         avatar={<MetadataAvatar text={props.role.title.toUpperCase()} />}
-        subheader={props.role.description}
+        subheader={
+          <OSCALMarkupMultiLine>{props.role.description}</OSCALMarkupMultiLine>
+        }
       />
     </Card>
   );
@@ -388,15 +391,15 @@ export default function OSCALMetadata(props) {
             partialRestData={
               props.isEditable
                 ? {
-                  [Object.keys(props.partialRestData)[0]]: {
-                    uuid: props.partialRestData[
-                      Object.keys(props.partialRestData)[0]
-                    ].uuid,
-                    metadata: {
-                      title: props.metadata.title,
+                    [Object.keys(props.partialRestData)[0]]: {
+                      uuid: props.partialRestData[
+                        Object.keys(props.partialRestData)[0]
+                      ].uuid,
+                      metadata: {
+                        title: props.metadata.title,
+                      },
                     },
-                  },
-                }
+                  }
                 : null
             }
             size={6}
@@ -451,25 +454,25 @@ export default function OSCALMetadata(props) {
                   editedField={
                     props.isEditable
                       ? [
-                        Object.keys(props.partialRestData)[0],
-                        "metadata",
-                        "version",
-                      ]
+                          Object.keys(props.partialRestData)[0],
+                          "metadata",
+                          "version",
+                        ]
                       : null
                   }
                   onFieldSave={props.onFieldSave}
                   partialRestData={
                     props.isEditable
                       ? {
-                        [Object.keys(props.partialRestData)[0]]: {
-                          uuid: props.partialRestData[
-                            Object.keys(props.partialRestData)[0]
-                          ].uuid,
-                          metadata: {
-                            version: props.metadata.version,
+                          [Object.keys(props.partialRestData)[0]]: {
+                            uuid: props.partialRestData[
+                              Object.keys(props.partialRestData)[0]
+                            ].uuid,
+                            metadata: {
+                              version: props.metadata.version,
+                            },
                           },
-                        },
-                      }
+                        }
                       : null
                   }
                   size={4}

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -26,6 +26,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import OSCALEditableTextField from "./OSCALEditableTextField";
+import StyledTooltip from "./OSCALStyledTooltip";
 
 export const OSCALMetadataPartiesHeader = styled(ListSubheader)(
   ({ theme }) => `
@@ -152,7 +153,6 @@ function OSCALMetadataPartyContactTypeHeader(props) {
 }
 
 export function OSCALMetadataPartyDialog(props) {
-  console.log(props.partyRolesText);
   const PartyInfoTypes = {
     address: "address",
     telephone: "telephone",
@@ -199,11 +199,18 @@ export function OSCALMetadataPartyDialog(props) {
           <Stack direction="column">
             {props.party.name}
             {props.partyRolesText.map((role) => (
-              <Typography>
-                {`${role.title} ${
-                  role.description ? ` - ${role.description}` : ""
-                }`}
-              </Typography>
+              <StyledTooltip
+                title={
+                  role.description ? (
+                    <Typography> {role.description} </Typography>
+                  ) : (
+                    ""
+                  )
+                }
+                key={role.title}
+              >
+                <Typography> {role.title} </Typography>
+              </StyledTooltip>
             ))}
           </Stack>
         </Stack>
@@ -307,7 +314,7 @@ export function OSCALMetadataParty(props) {
       <CardHeader
         avatar={avatar}
         title={props.party.name}
-        subheader={props.partyRolesText.map((role) => role.title).join(", ")}
+        subheader={props.partyRolesText?.map((role) => role.title).join(", ")}
       />
       <CardActions>
         <Button

--- a/src/components/OSCALMetadata.js
+++ b/src/components/OSCALMetadata.js
@@ -26,7 +26,6 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import OSCALEditableTextField from "./OSCALEditableTextField";
-import StyledTooltip from "./OSCALStyledTooltip";
 import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
 export const OSCALMetadataPartiesHeader = styled(ListSubheader)(

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -126,4 +126,22 @@ describe("OSCALMetadata", () => {
     expect(screen.getByText("Address")).toBeVisible();
     expect(screen.getByText(/2222 stcity, state 0000us/i)).toBeVisible();
   });
+
+  test(`displays role title`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
+
+    const role1 = screen.getByText("Document creator");
+    const role2 = screen.getByText("Contact");
+
+    expect(role1).toBeVisible();
+    expect(role2).toBeVisible();
+  });
+
+  test(`displays role description`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
+
+    const role1 = screen.getByText("Creates documents");
+
+    expect(role1).toBeVisible();
+  });
 });

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -25,7 +25,7 @@ describe("OSCALMetadata", () => {
   test(`displays Contact button`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
 
     expect(button).toBeVisible();
@@ -34,7 +34,7 @@ describe("OSCALMetadata", () => {
   test(`displays email contact info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
 
     button.click();
@@ -48,7 +48,7 @@ describe("OSCALMetadata", () => {
   test(`displays telephone mobile number info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
     button.click();
 
@@ -59,7 +59,7 @@ describe("OSCALMetadata", () => {
   test(`displays telephone office number info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
 
     button.click();
@@ -71,7 +71,7 @@ describe("OSCALMetadata", () => {
   test(`displays telephone home number info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
 
     button.click();
@@ -83,7 +83,7 @@ describe("OSCALMetadata", () => {
   test(`displays unknown type telephone number info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
 
     button.click();
@@ -95,7 +95,7 @@ describe("OSCALMetadata", () => {
   test(`displays work address info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
 
     button.click();
@@ -106,7 +106,7 @@ describe("OSCALMetadata", () => {
   test(`displays home address info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
 
     button.click();
@@ -117,8 +117,9 @@ describe("OSCALMetadata", () => {
 
   test(`displays unknown type address info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
+
     const button = screen.getByRole("button", {
-      name: /contact/i,
+      name: /some group of people details button/i,
     });
 
     button.click();
@@ -137,14 +138,18 @@ describe("OSCALMetadata", () => {
     expect(role2).toBeVisible();
   });
 
-  test(`displays role description`, () => {
+  test(`displays role dialog box`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
 
-    const role1 = screen.getByText("Document creator");
-    role1.click();
+    const button = screen.getByRole("button", {
+      name: /document creator details button/i,
+    });
+    button.click();
 
+    const title = screen.getByRole("heading", { name: /document creator/i });
     const description = screen.getByText("Creates documents");
 
+    expect(title).toBeVisible();
     expect(description).toBeVisible();
   });
 });

--- a/src/components/OSCALMetadata.test.js
+++ b/src/components/OSCALMetadata.test.js
@@ -140,8 +140,11 @@ describe("OSCALMetadata", () => {
   test(`displays role description`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
 
-    const role1 = screen.getByText("Creates documents");
+    const role1 = screen.getByText("Document creator");
+    role1.click();
 
-    expect(role1).toBeVisible();
+    const description = screen.getByText("Creates documents");
+
+    expect(description).toBeVisible();
   });
 });

--- a/src/test-data/CommonData.js
+++ b/src/test-data/CommonData.js
@@ -49,6 +49,18 @@ export const exampleParties = [
   },
 ];
 
+export const exampleRoles = [
+  {
+    id: "creator",
+    title: "Document creator",
+    description: "Creates documents",
+  },
+  {
+    id: "contact",
+    title: "Contact",
+  },
+];
+
 export const profileCatalogInheritanceData = {
   inherited: [
     {
@@ -74,6 +86,7 @@ export const profileCatalogInheritanceData = {
 export const metadataTestData = {
   title: "Test Title",
   parties: exampleParties,
+  roles: exampleRoles,
   version: "Revision 5",
 };
 


### PR DESCRIPTION
`metadata.roles` may contain a description. The description
will now be included when you view the `Contact` information.

To test, load my temporary [example rev 5 catalog](http://localhost:3000/catalog/?url=https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/tuckerzp/test-role-description/catalogs/NIST_SP-800-53_rev5_catalog.json). Then click the `Contact` button.

Closes #408
