### PR TITLE
fix(control): change "Guidance" to "Discussion"

### DIFF
--- a/src/components/OSCALControlGuidance.js
+++ b/src/components/OSCALControlGuidance.js
@@ -43,7 +43,7 @@ export default function OSCALControlGuidance(props) {
         size="small"
         onClick={handleClick}
       >
-        Read Guidance
+        Read Discussion
       </OSCALControlGuidanceButton>
       <Dialog
         open={open}
@@ -53,7 +53,7 @@ export default function OSCALControlGuidance(props) {
         aria-describedby="scroll-dialog-description"
       >
         <DialogTitle id="scroll-dialog-title">
-          {`${props.id.toUpperCase()} ${props.title} Guidance`}
+          {`${props.id.toUpperCase()} ${props.title} Discussion`}
         </DialogTitle>
         <DialogContent dividers>
           <DialogContentText


### PR DESCRIPTION
"Discussion" is the terminology used in the SP 800-53 PDF document,
whereas "Guidance" is the term used within the OSCAL document. According
to the [800-53rev5 Example][1] from NIST, `guidance` was retained from
an earlier version of the data and tools reading and displaying it are
free to make appropriate adjustments. To keep terminology consistent
between the viewed version of the document and the expected PDF, we
should use "Discussion". Within code, we should continue using
"Guidance" (at least for now) because this is the terminology used in
the source code.

[1]: https://pages.nist.gov/OSCAL/concepts/layer/control/catalog/sp800-53rev5-example/

### Examples

#### Control List View

![image](https://user-images.githubusercontent.com/850893/221688166-e0971363-22fd-4144-b434-e775272f610d.png)

#### Control Discussion Modal

![image](https://user-images.githubusercontent.com/850893/221688232-021d0dfc-1e90-4d4e-aba7-ec9ef4b942f3.png)
