### PR TITLE
fix(catalog): Withdrawn "top" controls display correctly

### DIFF
--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -8,6 +8,7 @@ import ListItemText from "@mui/material/ListItemText";
 import { styled } from "@mui/material/styles";
 import React from "react";
 import OSCALControl from "./OSCALControl";
+import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
 
 export const OSCALControlList = styled(List)`
   padding-left: 2em;
@@ -52,11 +53,12 @@ function CollapseableListItem(props) {
 
 function OSCALCatalogControlListItem(props) {
   const { control } = props;
-
-  return (
-    <CollapseableListItem
-      itemText={`${control.id.toUpperCase()} ${control.title}`}
-    >
+  // Determine if control is withdrawn
+  const withdrawn = isWithdrawn(control);
+  const itemText = `${control.id.toUpperCase()} ${control.title}`;
+  // Make collapsible item when not a withdrawn control
+  return !withdrawn ? (
+    <CollapseableListItem itemText={itemText}>
       <OSCALControl
         showInList
         control={control}
@@ -64,6 +66,16 @@ function OSCALCatalogControlListItem(props) {
         key={control.id}
       />
     </CollapseableListItem>
+  ) : (
+    <StyledListItemPaper>
+      <StyledListItem>
+        <ListItemText
+          primary={itemText}
+          withdrawn={withdrawn}
+          style={{ textDecoration: "line-through", color: "#d4d4d4" }}
+        />
+      </StyledListItem>
+    </StyledListItemPaper>
   );
 }
 

--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -25,7 +25,7 @@ const StyledListItemPaper = styled(Paper)`
   border-radius: 0.5em;
 `;
 
-const StyledListItemText = styled(ListItemText)(({ theme }) => ({
+const WithdrawnListItemText = styled(ListItemText)(({ theme }) => ({
   textDecoration: "line-through",
   color: theme.palette.grey[400],
 }));
@@ -73,7 +73,7 @@ function OSCALCatalogControlListItem(props) {
   ) : (
     <StyledListItemPaper>
       <StyledListItem>
-        <StyledListItemText primary={itemText} withdrawn={withdrawn} />
+        <WithdrawnListItemText primary={itemText} withdrawn={withdrawn} />
       </StyledListItem>
     </StyledListItemPaper>
   );

--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -73,10 +73,7 @@ function OSCALCatalogControlListItem(props) {
   ) : (
     <StyledListItemPaper>
       <StyledListItem>
-        <StyledListItemText
-          primary={itemText}
-          withdrawn={withdrawn}
-        />
+        <StyledListItemText primary={itemText} withdrawn={withdrawn} />
       </StyledListItem>
     </StyledListItemPaper>
   );

--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -25,6 +25,11 @@ const StyledListItemPaper = styled(Paper)`
   border-radius: 0.5em;
 `;
 
+const StyledListItemText = styled(ListItemText)(({ theme }) => ({
+  textDecoration: "line-through",
+  color: theme.palette.grey[400],
+}));
+
 const StyledControlDescriptionWrapper = styled("div")`
   padding: 1em;
 `;
@@ -53,10 +58,9 @@ function CollapseableListItem(props) {
 
 function OSCALCatalogControlListItem(props) {
   const { control } = props;
-  // Determine if control is withdrawn
   const withdrawn = isWithdrawn(control);
   const itemText = `${control.id.toUpperCase()} ${control.title}`;
-  // Make collapsible item when not a withdrawn control
+
   return !withdrawn ? (
     <CollapseableListItem itemText={itemText}>
       <OSCALControl
@@ -69,10 +73,9 @@ function OSCALCatalogControlListItem(props) {
   ) : (
     <StyledListItemPaper>
       <StyledListItem>
-        <ListItemText
+        <StyledListItemText
           primary={itemText}
           withdrawn={withdrawn}
-          style={{ textDecoration: "line-through", color: "#d4d4d4" }}
         />
       </StyledListItem>
     </StyledListItemPaper>

--- a/src/components/OSCALControl.js
+++ b/src/components/OSCALControl.js
@@ -6,14 +6,7 @@ import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
 import OSCALControlPart from "./OSCALControlPart";
 import OSCALControlModification from "./OSCALControlModification";
-
-// TODO: This is probably 800-53 specific and it should be made more
-// generic to allow the library to work with other frameworks.
-// https://github.com/EasyDynamics/oscal-react-library/issues/504
-const isWithdrawn = (control) =>
-  control?.props?.find(
-    (prop) => prop.name === "status" && prop.value === "withdrawn"
-  );
+import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
 
 const OSCALControlCard = styled(Card, {
   // https://github.com/mui/material-ui/blob/c34935814b81870ca325099cdf41a1025a85d4b5/packages/mui-system/src/createStyled.js#L56

--- a/src/components/OSCALControl.js
+++ b/src/components/OSCALControl.js
@@ -21,7 +21,8 @@ const OSCALControlCard = styled(Card, {
   margin-right: ${(props) => (props.childLevel > 0 ? "1.5em" : "0")};
   ${(props) => props.childLevel > 0 && "background-color: #fffcf0;"}
   ${(props) =>
-    props.withdrawn && `text-decoration: line-through; color: ${props.theme.palette.grey[400]};`}
+    props.withdrawn &&
+    `text-decoration: line-through; color: ${props.theme.palette.grey[400]};`}
 `;
 
 function ControlsList(props) {

--- a/src/components/OSCALControl.js
+++ b/src/components/OSCALControl.js
@@ -21,7 +21,7 @@ const OSCALControlCard = styled(Card, {
   margin-right: ${(props) => (props.childLevel > 0 ? "1.5em" : "0")};
   ${(props) => props.childLevel > 0 && "background-color: #fffcf0;"}
   ${(props) =>
-    props.withdrawn && `text-decoration: line-through; color: #d4d4d4;`}
+    props.withdrawn && `text-decoration: line-through; color: ${props.theme.palette.grey[400]};`}
 `;
 
 function ControlsList(props) {

--- a/src/components/oscal-utils/OSCALCatalogUtils.js
+++ b/src/components/oscal-utils/OSCALCatalogUtils.js
@@ -1,0 +1,15 @@
+/**
+ * Determines if a control is withdrawn.
+ *
+ * TODO: This is probably 800-53 specific and it should be made more
+ * generic to allow the library to work with other frameworks.
+ * https://github.com/EasyDynamics/oscal-react-library/issues/504
+ *
+ * @param {object} control
+ * @returns a boolean describing whether the control is withdrawn
+ */
+export default function isWithdrawn(control) {
+  return control?.props?.find(
+    (prop) => prop.name === "status" && prop.value === "withdrawn"
+  );
+}

--- a/src/components/oscal-utils/OSCALCatalogUtils.js
+++ b/src/components/oscal-utils/OSCALCatalogUtils.js
@@ -3,10 +3,6 @@ import matchingProp from "./OSCALPropUtils";
 /**
  * Determines if a control is withdrawn.
  *
- * TODO: This is probably 800-53 specific and it should be made more
- * generic to allow the library to work with other frameworks.
- * https://github.com/EasyDynamics/oscal-react-library/issues/504
- *
  * @param {object} control
  * @returns a boolean describing whether the control is withdrawn
  */

--- a/src/components/oscal-utils/OSCALCatalogUtils.js
+++ b/src/components/oscal-utils/OSCALCatalogUtils.js
@@ -3,8 +3,8 @@ import matchingProp from "./OSCALPropUtils";
 /**
  * Determines if a control is withdrawn.
  *
- * @param {object} control
- * @returns a boolean describing whether the control is withdrawn
+ * @param {object} control A catalog control
+ * @returns {boolean} true if control is withdrawn
  */
 export default function isWithdrawn(control) {
   // By default controls are *not* withdrawn

--- a/src/components/oscal-utils/OSCALCatalogUtils.js
+++ b/src/components/oscal-utils/OSCALCatalogUtils.js
@@ -1,3 +1,5 @@
+import matchingProp from "./OSCALPropUtils";
+
 /**
  * Determines if a control is withdrawn.
  *
@@ -9,7 +11,9 @@
  * @returns a boolean describing whether the control is withdrawn
  */
 export default function isWithdrawn(control) {
-  return control?.props?.find(
-    (prop) => prop.name === "status" && prop.value === "withdrawn"
-  );
+  // By default controls are *not* withdrawn
+  if (!control.props) {
+    return false;
+  }
+  return !!matchingProp(control.props, { name: "status", value: "withdrawn" });
 }

--- a/src/components/oscal-utils/OSCALPropUtils.js
+++ b/src/components/oscal-utils/OSCALPropUtils.js
@@ -18,14 +18,13 @@ export function namespaceOf(ns) {
  * @param filter the attributes to match against
  */
 export default function matchingProp(props, filter) {
-  const ns = namespaceOf(filter.ns);
   if ((!filter.value && !filter.filter) || (filter.value && filter.filter)) {
     throw new Error("Exactly one of filter or value must be specified");
   }
 
   return props.find(
     (prop) =>
-      namespaceOf(prop.ns) === ns &&
+      namespaceOf(prop.ns) === namespaceOf(filter.ns) &&
       prop.name === filter.name &&
       (!filter.value || prop.value === filter.value) &&
       (!filter.filter || filter.filter(prop.value))

--- a/src/components/oscal-utils/OSCALPropUtils.js
+++ b/src/components/oscal-utils/OSCALPropUtils.js
@@ -25,7 +25,7 @@ export default function matchingProp(props, filter) {
 
   return props.find(
     (prop) =>
-      namespaceOf(prop.ns) === namespaceOf(filter.ns) &&
+      namespaceOf(prop.ns) === ns &&
       prop.name === filter.name &&
       (!filter.value || prop.value === filter.value) &&
       (!filter.filter || filter.filter(prop.value))

--- a/src/components/oscal-utils/OSCALPropUtils.js
+++ b/src/components/oscal-utils/OSCALPropUtils.js
@@ -6,16 +6,40 @@ const NIST_DEFAULT_NAMESPACE = "https://csrc.nist.gov/ns/oscal";
 
 /**
  * Return the given namespace, or if undefined, the default namespace.
+ *
+ * @param {string | undefined} ns the namespace
+ * @returns {string} the given namespace or the the default namespace
  */
 export function namespaceOf(ns) {
   return ns ?? NIST_DEFAULT_NAMESPACE;
 }
 
 /**
+ * @callback PropertyFilterValueMatcher
+ * @param {string} value - the value to check against
+ * @returns {boolean} whether the given property matches
+ */
+
+/**
+ * A filter to apply to properties to find a matching property.
+ *
+ * This allows matching based on the namespace (defaulting to the default namespace),
+ * the name, and the value. Exactly one of `value` or `filter` must be supplied.
+ *
+ * @typedef PropertyFilter
+ * @type {object}
+ * @property {string|undefined} ns - the namespace to check in
+ * @property {string| name} name - the name of the field to match
+ * @property {string} value - the value of the field to match
+ * @property {PropertyFilterValueMatcher} filter - a function to match the value against
+ */
+
+/**
  * Returns the first matching property in the given list.
  *
- * @param props the list of properties to check
- * @param filter the attributes to match against
+ * @param {Array.<object>} props the list of properties to check
+ * @param {PropertyFilter} filter attributes to match against
+ * @return {object} the matching property
  */
 export default function matchingProp(props, filter) {
   if ((!filter.value && !filter.filter) || (filter.value && filter.filter)) {

--- a/src/components/oscal-utils/OSCALPropUtils.js
+++ b/src/components/oscal-utils/OSCALPropUtils.js
@@ -39,7 +39,7 @@ export function namespaceOf(ns) {
  *
  * @param {Array.<object>} props the list of properties to check
  * @param {PropertyFilter} filter attributes to match against
- * @return {object} the matching property
+ * @returns {object} the matching property
  */
 export default function matchingProp(props, filter) {
   if ((!filter.value && !filter.filter) || (filter.value && filter.filter)) {

--- a/src/components/oscal-utils/OSCALPropUtils.js
+++ b/src/components/oscal-utils/OSCALPropUtils.js
@@ -1,0 +1,33 @@
+/**
+ * When a namespace is not specified for a property, the assumption is that the
+ * namespace is default namespace.
+ */
+const NIST_DEFAULT_NAMESPACE = "https://csrc.nist.gov/ns/oscal";
+
+/**
+ * Return the given namespace, or if undefined, the default namespace.
+ */
+export function namespaceOf(ns) {
+  return ns ?? NIST_DEFAULT_NAMESPACE;
+}
+
+/**
+ * Returns the first matching property in the given list.
+ *
+ * @param props the list of properties to check
+ * @param filter the attributes to match against
+ */
+export default function matchingProp(props, filter) {
+  const ns = namespaceOf(filter.ns);
+  if ((!filter.value && !filter.filter) || (filter.value && filter.filter)) {
+    throw new Error("Exactly one of filter or value must be specified");
+  }
+
+  return props.find(
+    (prop) =>
+      namespaceOf(prop.ns) === namespaceOf(filter.ns) &&
+      prop.name === filter.name &&
+      (!filter.value || prop.value === filter.value) &&
+      (!filter.filter || filter.filter(prop.value))
+  );
+}


### PR DESCRIPTION
This fixes the "state" of withdrawn "top-level"
controls. Instead of being a collapsible item
that shows a blank box when selected, the
control no longer opens and closes, as
indicated by no presence of an arrow
appearing to the far right of the item. The
item text is also styled to appear a light-gray
and has a strikethrough, like the "sub-level"
controls.

Resolves #635 