### PR TITLE
fix(control): controls display id instead of label

### DIFF
--- a/src/components/OSCALCatalogGroup.js
+++ b/src/components/OSCALCatalogGroup.js
@@ -9,6 +9,8 @@ import { styled } from "@mui/material/styles";
 import React from "react";
 import OSCALControl from "./OSCALControl";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
+import OSCALControlLabel from "./OSCALControlLabel";
+import { propWithName } from "./oscal-utils/OSCALPropUtils";
 
 export const OSCALControlList = styled(List)`
   padding-left: 2em;
@@ -59,7 +61,16 @@ function CollapseableListItem(props) {
 function OSCALCatalogControlListItem(props) {
   const { control } = props;
   const withdrawn = isWithdrawn(control);
-  const itemText = `${control.id.toUpperCase()} ${control.title}`;
+  const itemText = (
+    <>
+      <OSCALControlLabel
+        label={propWithName(control.props, "label")?.value}
+        id={control.id}
+        component="span"
+      />
+      {control.title}
+    </>
+  );
 
   return !withdrawn ? (
     <CollapseableListItem itemText={itemText}>

--- a/src/components/OSCALCatalogGroups.test.js
+++ b/src/components/OSCALCatalogGroups.test.js
@@ -35,6 +35,22 @@ const testGroups = [
   },
 ];
 
+function getTextByChildren(text) {
+  function result(_content, node) {
+    const hasText = (checkNode) => checkNode.textContent === text;
+    const nodeHasText = hasText(node);
+    // This is necessary because we are providing a query function to override how
+    // text search is performed.
+    // eslint-disable-next-line testing-library/no-node-access
+    const childrenDontHaveText = Array.from(node.children).every(
+      (child) => !hasText(child)
+    );
+
+    return nodeHasText && childrenDontHaveText;
+  }
+  return result;
+}
+
 describe("OSCALCatalogGroup", () => {
   test("displays param legend", () => {
     render(<OSCALCatalogGroups groups={testGroups} />);
@@ -58,7 +74,7 @@ describe("OSCALCatalogGroup", () => {
     fireEvent.click(expand2);
 
     const expand3 = screen.getByText(
-      "CONTROL-ID Access Control Policy and Procedures"
+      getTextByChildren("control-id Access Control Policy and Procedures")
     );
     fireEvent.click(expand3);
   });
@@ -68,7 +84,9 @@ describe("OSCALCatalogGroup", () => {
     const expand1 = screen.getByText("Sibling Title");
     fireEvent.click(expand1);
 
-    const expand2 = screen.getByText("CONTROL2-ID Audit Events");
+    const expand2 = screen.getByText(
+      getTextByChildren("control2-id Audit Events")
+    );
     fireEvent.click(expand2);
   });
 });

--- a/src/components/OSCALControl.js
+++ b/src/components/OSCALControl.js
@@ -4,6 +4,7 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
+import OSCALControlLabel from "./OSCALControlLabel";
 import OSCALControlPart from "./OSCALControlPart";
 import OSCALControlModification from "./OSCALControlModification";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
@@ -103,9 +104,11 @@ export default function OSCALControl(props) {
               component="h2"
               style={props.childLevel ? { fontSize: "1.1rem" } : undefined}
             >
-              <span style={{ textTransform: label ? "" : "uppercase" }}>
-                {label ?? props.control.id}
-              </span>{" "}
+              <OSCALControlLabel
+                component="span"
+                label={label}
+                id={props.control.id}
+              />{" "}
               {props.control.title} {modificationDisplay}
             </Typography>
           </Grid>

--- a/src/components/OSCALControl.js
+++ b/src/components/OSCALControl.js
@@ -7,6 +7,7 @@ import Grid from "@mui/material/Grid";
 import OSCALControlPart from "./OSCALControlPart";
 import OSCALControlModification from "./OSCALControlModification";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
+import { propWithName } from "./oscal-utils/OSCALPropUtils";
 
 const OSCALControlCard = styled(Card, {
   // https://github.com/mui/material-ui/blob/c34935814b81870ca325099cdf41a1025a85d4b5/packages/mui-system/src/createStyled.js#L56
@@ -85,6 +86,8 @@ export default function OSCALControl(props) {
     );
   }
 
+  const label = propWithName(props.control.props, "label")?.value;
+
   return props.showInList ? (
     <ControlsList {...props} />
   ) : (
@@ -100,8 +103,8 @@ export default function OSCALControl(props) {
               component="h2"
               style={props.childLevel ? { fontSize: "1.1rem" } : undefined}
             >
-              <span style={{ textTransform: "uppercase" }}>
-                {props.control.id}
+              <span style={{ textTransform: label ? "" : "uppercase" }}>
+                {label ?? props.control.id}
               </span>{" "}
               {props.control.title} {modificationDisplay}
             </Typography>

--- a/src/components/OSCALControlGuidance.js
+++ b/src/components/OSCALControlGuidance.js
@@ -53,7 +53,7 @@ export default function OSCALControlGuidance(props) {
         aria-describedby="scroll-dialog-description"
       >
         <DialogTitle id="scroll-dialog-title">
-          {`${props.id.toUpperCase()} ${props.title} Discussion`}
+          {`${props.label ?? props.id.toUpperCase()} ${props.title} Discussion`}
         </DialogTitle>
         <DialogContent dividers>
           <DialogContentText

--- a/src/components/OSCALControlGuidance.js
+++ b/src/components/OSCALControlGuidance.js
@@ -7,6 +7,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
+import OSCALControlLabel from "./OSCALControlLabel";
 
 const OSCALControlGuidanceButton = styled(Button)(
   ({ theme }) => `
@@ -53,7 +54,12 @@ export default function OSCALControlGuidance(props) {
         aria-describedby="scroll-dialog-description"
       >
         <DialogTitle id="scroll-dialog-title">
-          {`${props.label ?? props.id.toUpperCase()} ${props.title} Discussion`}
+          <OSCALControlLabel
+            id={props.id}
+            label={props.label}
+            component="span"
+          />
+          {` ${props.title} Discussion`}
         </DialogTitle>
         <DialogContent dividers>
           <DialogContentText

--- a/src/components/OSCALControlGuidance.test.js
+++ b/src/components/OSCALControlGuidance.test.js
@@ -8,7 +8,9 @@ describe("OSCALControlGuidance", () => {
     const prose = "Access control policy";
     const id = "AC-1";
     const title = "Sample Title";
-    render(<OSCALControlGuidance prose={prose} id={id} title={title} />);
+    render(
+      <OSCALControlGuidance prose={prose} id={id} title={title} label={id} />
+    );
     await userEvent.click(screen.getByRole("button"));
     const result = screen.getByText("Access control policy");
     expect(result).toBeVisible();

--- a/src/components/OSCALControlLabel.js
+++ b/src/components/OSCALControlLabel.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { styled } from "@mui/material/styles";
+import { Typography } from "@mui/material";
+
+const FallbackIdAsLabel = styled(Typography)(({ theme }) => ({
+  color: theme.palette.grey[400],
+  textTransform: "uppercase",
+}));
+
+export default function OSCALControlLabel(props) {
+  const { label, id, children, ...rest } = props;
+  if (label) {
+    return (
+      <Typography {...rest}>
+        {label} {children}
+      </Typography>
+    );
+  }
+  return (
+    <FallbackIdAsLabel {...rest}>
+      {id} {children}
+    </FallbackIdAsLabel>
+  );
+}

--- a/src/components/OSCALControlPart.js
+++ b/src/components/OSCALControlPart.js
@@ -26,7 +26,8 @@ export default function OSCALControlPart(props) {
     return null;
   }
 
-  const label = propWithName(props.part.props, "label")?.value;
+  const partLabel = propWithName(props.part?.props, "label")?.value;
+  const controlLabel = propWithName(props.control?.props, "label")?.value;
 
   if (props.part.name === "guidance") {
     return (
@@ -34,7 +35,7 @@ export default function OSCALControlPart(props) {
         prose={props.part.prose}
         id={props.control.id}
         title={props.control.title}
-        label={label}
+        label={controlLabel}
       />
     );
   }
@@ -54,7 +55,7 @@ export default function OSCALControlPart(props) {
   if (props.implementedRequirement) {
     replacedProse = (
       <OSCALReplacedProseWithByComponentParameterValue
-        label={label}
+        label={partLabel}
         prose={props.part.prose}
         parameters={props.parameters}
         implementedRequirement={props.implementedRequirement}
@@ -71,7 +72,7 @@ export default function OSCALControlPart(props) {
   } else {
     replacedProse = (
       <OSCALReplacedProseWithParameterLabel
-        label={label}
+        label={partLabel}
         prose={props.part.prose}
         parameters={props.parameters}
         modificationSetParameters={props.modificationSetParameters}

--- a/src/components/OSCALControlPart.js
+++ b/src/components/OSCALControlPart.js
@@ -6,6 +6,7 @@ import {
   OSCALReplacedProseWithByComponentParameterValue,
   OSCALReplacedProseWithParameterLabel,
 } from "./OSCALControlProse";
+import { propWithName } from "./oscal-utils/OSCALPropUtils";
 
 const OSCALControlPartWrapper = styled("div", {
   shouldForwardProp: (prop) =>
@@ -13,12 +14,6 @@ const OSCALControlPartWrapper = styled("div", {
 })`
   padding-left: ${(props) => (props.partName !== "statement" ? "2em" : "0")};
 `;
-
-// TODO: This is probably 800-53 specific and it should be made more
-// generic to allow the library to work with other frameworks.
-// https://github.com/EasyDynamics/oscal-react-library/issues/504
-const getPartLabel = (props) =>
-  props?.find((property) => property.name === "label")?.value;
 
 export default function OSCALControlPart(props) {
   // Don't display assessment if we're displaying a control implementation
@@ -31,12 +26,15 @@ export default function OSCALControlPart(props) {
     return null;
   }
 
+  const label = propWithName(props.part.props, "label")?.value;
+
   if (props.part.name === "guidance") {
     return (
       <OSCALControlGuidance
         prose={props.part.prose}
         id={props.control.id}
         title={props.control.title}
+        label={label}
       />
     );
   }
@@ -51,8 +49,6 @@ export default function OSCALControlPart(props) {
       />
     );
   }
-
-  const label = getPartLabel(props.part.props);
 
   let replacedProse;
   if (props.implementedRequirement) {

--- a/src/components/OSCALControlProse.js
+++ b/src/components/OSCALControlProse.js
@@ -343,16 +343,14 @@ export function OSCALReplacedProseWithParameterLabel(props) {
   if (!props.isImplemented) {
     return (
       <NotImplementedStatement>
-        {props.label}
-        {prose}
+        {props.label} {prose}
         {props.modificationDisplay}
       </NotImplementedStatement>
     );
   }
   return (
     <Typography>
-      {props.label}
-      {prose}
+      {props.label} {prose}
       {props.modificationDisplay}
     </Typography>
   );
@@ -488,7 +486,7 @@ export function OSCALReplacedProseWithByComponentParameterValue(props) {
           <Link underline="hover" href={`#${props.label}`}>
             {props.label}
           </Link>
-        </StyledTooltip>
+        </StyledTooltip>{" "}
         {proseDisplay}
         {props.modificationDisplay}
       </Grid>

--- a/src/components/OSCALProfile.test.js
+++ b/src/components/OSCALProfile.test.js
@@ -24,7 +24,7 @@ function testOSCALProfile(parentElementName, renderer) {
   jest.setTimeout(6000);
   test(`${parentElementName} displays controls`, async () => {
     renderer();
-    const result = await screen.findByText("ac-1", {
+    const result = await screen.findByText("AC-1", {
       timeout: 5000,
     });
     expect(result).toBeVisible();

--- a/src/components/oscal-utils/OSCALPropUtils.js
+++ b/src/components/oscal-utils/OSCALPropUtils.js
@@ -34,6 +34,10 @@ export function namespaceOf(ns) {
  * @property {PropertyFilterValueMatcher} filter - a function to match the value against
  */
 
+export function propWithName(props, name, ns) {
+  return matchingProp(props, { name, ns, filter: () => true });
+}
+
 /**
  * Returns the first matching property in the given list.
  *

--- a/src/components/oscal-utils/OSCALPropUtils.js
+++ b/src/components/oscal-utils/OSCALPropUtils.js
@@ -34,12 +34,23 @@ export function namespaceOf(ns) {
  * @property {PropertyFilterValueMatcher} filter - a function to match the value against
  */
 
+/**
+ * Returns the first prop with a matching name attribute.
+ *
+ * This is useful to look up the value of a specific prop under a namespace.
+ * To check whether a property has a specific value, prefer {@link matchingProp}.
+ *
+ * @param {Array.<object>} props - the list of properties to check
+ * @param {string} name - the name of the property to search for
+ * @param {string} [ns] - the namespace to search in
+ */
 export function propWithName(props, name, ns) {
   return matchingProp(props, { name, ns, filter: () => true });
 }
 
 /**
- * Returns the first matching property in the given list.
+ * Returns the first property in the given list with the correct name and
+ * a value that matches the filter.
  *
  * @param {Array.<object>} props the list of properties to check
  * @param {PropertyFilter} filter attributes to match against

--- a/src/components/oscal-utils/OSCALPropUtils.js
+++ b/src/components/oscal-utils/OSCALPropUtils.js
@@ -46,6 +46,9 @@ export function propWithName(props, name, ns) {
  * @returns {object} the matching property
  */
 export default function matchingProp(props, filter) {
+  if (!props || !filter) {
+    return undefined;
+  }
   if ((!filter.value && !filter.filter) || (filter.value && filter.filter)) {
     throw new Error("Exactly one of filter or value must be specified");
   }


### PR DESCRIPTION
Currently, controls are often displayed with their `id` in uppercase instead of using the `label` property. This means that the display is not necessarily always what a document author may intend (even if it perhaps is close).

The label is displayed matching the surrounding content. If the ID is used, it falls back to displaying using the ID (in our standard grey color).

This also fixes an issue where, for prose, the label was squished up against the text without a space.


### Screenshots - [Test Catalog](https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/test-content/catalogs/basic-test-catalog.json)

#### Before

![image](https://user-images.githubusercontent.com/850893/228004046-99870901-fa7c-42a8-8c13-0cdaca4c0e9d.png)

#### After

![image](https://user-images.githubusercontent.com/850893/228005449-6794e17e-a420-493d-89d4-3d74471e1fb5.png)

### Screenshots - [SP 800-53](https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/main/catalogs/NIST_SP-800-53_rev5_catalog.json)

#### Before

![image](https://user-images.githubusercontent.com/850893/228030191-9153c84d-87c5-4c66-bfd7-984d6ae4bc04.png)


#### After

![image](https://user-images.githubusercontent.com/850893/228030062-8c9d4300-837e-41e6-90bf-10c4b9a4c620.png)
