### PR TITLE
feat(backmatter): Support viewing base64 data

### DIFF
--- a/src/components/OSCALDiagram.js
+++ b/src/components/OSCALDiagram.js
@@ -15,7 +15,7 @@ export default function OSCALDiagram(props) {
       props.backMatter,
       link.href,
       props.parentUrl.startsWith(".") ? null : props.parentUrl,
-      "image/png",
+      /^image\//,
       false
     );
   } catch (err) {

--- a/src/components/OSCALDiagram.js
+++ b/src/components/OSCALDiagram.js
@@ -15,7 +15,8 @@ export default function OSCALDiagram(props) {
       props.backMatter,
       link.href,
       props.parentUrl.startsWith(".") ? null : props.parentUrl,
-      /^image\//
+      "image/png",
+      false
     );
   } catch (err) {
     // Silently fail on unresolved diagram resources

--- a/src/components/oscal-utils/OSCALBackMatterUtils.js
+++ b/src/components/oscal-utils/OSCALBackMatterUtils.js
@@ -12,7 +12,7 @@ export default class BackMatterLookup {
 
   /**
    * @param uuid {string}
-   * @param mediaType {?string}
+   * @param mediaType {?RegExp}
    *
    * @returns ResolvedUri {string} or undefined
    */
@@ -27,7 +27,7 @@ export default class BackMatterLookup {
         if (!mediaType || !rlinkMediaType) {
           return true;
         }
-        return rlinkMediaType === mediaType;
+        return mediaType.test(rlinkMediaType);
       });
 
       if (rlink) {
@@ -43,6 +43,10 @@ export default class BackMatterLookup {
     // is plain text. This will cause a whole mess that we'd really rather avoid.
     // In the future, this may throw an error.
     if (!base64?.["media-type"]) {
+      return undefined;
+    }
+
+    if (mediaType && !mediaType.test(base64["media-type"])) {
       return undefined;
     }
 

--- a/src/components/oscal-utils/OSCALBackMatterUtils.js
+++ b/src/components/oscal-utils/OSCALBackMatterUtils.js
@@ -1,41 +1,75 @@
-/**
- * Gets a resource from the given back matter's resource by the given HREF UUID.
- */
-export function getResourceFromBackMatterByHref(backMatter, href) {
-  if (!href.startsWith("#")) {
-    throw new Error("not an internal href");
-  }
-  // Dig into back-matter to look for absolute href
-  const importUuid = href.substring(1);
+export default class BackMatterLookup {
+  #backMatter;
 
-  return backMatter?.resources?.find(
-    (resource) => resource.uuid === importUuid
-  );
-}
+  #preferBase64 = false;
 
-/**
- * Gets an rlink URI from the given back matter's resource by the given HREF UUID.
- *
- * @see {@link https://pages.nist.gov/OSCAL/documentation/schema/implementation-layer/component/xml-schema/##local_back-matter-resource-rlink_def-h3}
- */
-export default function getUriFromBackMatterByHref(
-  backMatter,
-  href,
-  mediaTypeRegex
-) {
-  const foundResource = getResourceFromBackMatterByHref(backMatter, href);
-
-  if (!foundResource) {
-    throw new Error("resource not found for href");
+  // the `preferBase64` parameter would allow operating "offline" without access to
+  // public resources
+  constructor(backMatter, preferBase64) {
+    this.#backMatter = backMatter;
+    this.#preferBase64 = preferBase64;
   }
 
-  const foundLink = foundResource.rlinks.find((rlink) =>
-    mediaTypeRegex.test(rlink["media-type"])
-  );
+  /**
+   * @param uuid {string}
+   * @param mediaType {?string}
+   *
+   * @returns ResolvedUri {string} or undefined
+   */
+  resolveUuid(uuid, mediaType) {
+    const resource = this.#backMatter.resources.find(
+      (item) => item.uuid === uuid
+    );
 
-  if (!foundLink) {
-    throw new Error("resource not found for href");
+    if (!this.#preferBase64) {
+      const rlink = resource?.rlinks?.find((item) => {
+        const rlinkMediaType = item["media-type"];
+        if (!mediaType || !rlinkMediaType) {
+          return true;
+        }
+        return rlinkMediaType === mediaType;
+      });
+
+      if (rlink) {
+        return { uri: rlink.href, mediaType: rlink["media-type"] };
+      }
+    }
+
+    const base64 = resource?.base64;
+
+    // We require media type to be present. In most cases in existing OSCAL documents,
+    // media type is missing; however, the underlying document is not actually plain-text
+    // data. If we don't specify a media type in the URI, the browser will assume that it
+    // is plain text. This will cause a whole mess that we'd really rather avoid.
+    // In the future, this may throw an error.
+    if (!base64?.["media-type"]) {
+      return undefined;
+    }
+
+    if (!base64?.value) {
+      return undefined;
+    }
+
+    return {
+      uri: `data:${base64["media-type"]};base64,${base64.value.replace(
+        "\n",
+        ""
+      )}`,
+      mediaType: base64["media-type"],
+    };
   }
 
-  return foundLink;
+  /**
+   * @param uri {string}
+   * @param mediaType {?string}
+   *
+   * @returns ResolvedUri {string} or undefined
+   */
+  resolve(uri, mediaType) {
+    if (uri.startsWith("#")) {
+      return this.resolveUuid(uri.slice(1), mediaType);
+    }
+
+    return { uri, mediaType: undefined };
+  }
 }

--- a/src/components/oscal-utils/OSCALBackMatterUtils.test.js
+++ b/src/components/oscal-utils/OSCALBackMatterUtils.test.js
@@ -1,0 +1,146 @@
+import BackMatterLookup from "./OSCALBackMatterUtils";
+
+const mediaTypeRegex = /^image\//;
+const mediaType = "image/png";
+
+const base64Value = "aaabbbccc";
+
+const rlinkResource = {
+  uuid: "7e56057e-194b-4f66-b1fb-9c318b3fc701",
+  uri: "#7e56057e-194b-4f66-b1fb-9c318b3fc701",
+  href: "test-image.png",
+};
+
+const base64Resource = {
+  uuid: "93abfff9-1196-4dfe-b802-7f6676a828ae",
+  uri: "#93abfff9-1196-4dfe-b802-7f6676a828ae",
+};
+
+const base64ResourceNoMediaType = {
+  uuid: "fe980d37-6866-4edc-9f93-916bbb59328b",
+  uri: "#fe980d37-6866-4edc-9f93-916bbb59328b",
+};
+
+const base64ResourceNoValue = {
+  uuid: "817d5cbf-aa38-45bb-91e9-1f59f5f9e522",
+  uri: "#817d5cbf-aa38-45bb-91e9-1f59f5f9e522",
+};
+
+const base64ResourceWrongMediaType = {
+  uuid: "efd827a3-8ff2-449a-bcde-b710fde34ff8",
+  uri: "#efd827a3-8ff2-449a-bcde-b710fde34ff8",
+};
+
+const backMatter = {
+  resources: [
+    {
+      uuid: rlinkResource.uuid,
+      rlinks: [
+        {
+          href: rlinkResource.href,
+          "media-type": mediaType,
+        },
+      ],
+    },
+    {
+      uuid: base64Resource.uuid,
+      base64: {
+        "media-type": mediaType,
+        value: base64Value,
+      },
+    },
+    {
+      uuid: base64ResourceNoMediaType,
+      base64: {
+        value: base64Value,
+      },
+    },
+    {
+      uuid: base64ResourceNoValue.uuid,
+      base64: {
+        "media-type": mediaType,
+      },
+    },
+    {
+      uuid: base64ResourceWrongMediaType.uuid,
+      base64: {
+        value: base64Value,
+        "media-type": "html",
+      },
+    },
+  ],
+};
+
+describe("BackMatterLookup", () => {
+  test("can be created", () => {
+    const lookup = new BackMatterLookup(backMatter);
+
+    expect(lookup).toBeInstanceOf(BackMatterLookup);
+    expect(lookup.resolve("", "")).toBeDefined();
+  });
+
+  test("resolves valid rlink resource", () => {
+    const lookup = new BackMatterLookup(backMatter);
+
+    const resource = lookup.resolve(rlinkResource.uri, mediaTypeRegex);
+
+    expect(resource.mediaType).toBe(mediaType);
+    expect(resource.uri).toBe(rlinkResource.href);
+  });
+
+  test("doesn't return rlink when preferring base64", () => {
+    const lookup = new BackMatterLookup(backMatter, true);
+
+    const resource = lookup.resolve(rlinkResource.uri, mediaTypeRegex);
+
+    expect(resource).toBeUndefined();
+  });
+
+  test("only checks backmatter for items with #", () => {
+    const lookup = new BackMatterLookup(backMatter);
+
+    const resource = lookup.resolve(rlinkResource.uuid, mediaTypeRegex);
+
+    expect(resource.mediaType).toBeUndefined();
+    expect(resource.uri).toBe(rlinkResource.uuid);
+  });
+
+  test("resolves valid base64 resource", () => {
+    const lookup = new BackMatterLookup(backMatter);
+
+    const resource = lookup.resolve(base64Resource.uri, mediaTypeRegex);
+
+    expect(resource.mediaType).toBe(mediaType);
+    expect(resource.uri).toBe(`data:${mediaType};base64,${base64Value}`);
+  });
+
+  test("handles base64 resource without mediaType", () => {
+    const lookup = new BackMatterLookup(backMatter);
+
+    const resource = lookup.resolve(
+      base64ResourceNoMediaType.uri,
+      mediaTypeRegex
+    );
+
+    expect(resource).toBeUndefined();
+  });
+
+  test("handles base64 resource without value", () => {
+    const lookup = new BackMatterLookup(backMatter);
+
+    const resource = lookup.resolve(base64ResourceNoValue.uri, mediaTypeRegex);
+
+    expect(resource).toBeUndefined();
+  });
+
+  test("handles base64 resource with wrong media type", () => {
+    const lookup = new BackMatterLookup(backMatter);
+
+    const resource = lookup.resolve(
+      base64ResourceWrongMediaType.uri,
+      mediaTypeRegex
+    );
+
+    expect(resource).toBeUndefined();
+  });
+});

--- a/src/components/oscal-utils/OSCALLinkUtils.js
+++ b/src/components/oscal-utils/OSCALLinkUtils.js
@@ -1,4 +1,4 @@
-import getUriFromBackMatterByHref from "./OSCALBackMatterUtils";
+import BackMatterLookup from "./OSCALBackMatterUtils";
 
 export function getAbsoluteUrl(href, parentUrl) {
   if (
@@ -16,14 +16,11 @@ export default function resolveLinkHref(
   backMatter,
   href,
   parentUrl,
-  mediaTypeRegex
+  mediaType,
+  preferBase64 = false
 ) {
-  return getAbsoluteUrl(
-    !href.startsWith("#")
-      ? href
-      : getUriFromBackMatterByHref(backMatter, href, mediaTypeRegex).href,
-    parentUrl
-  );
+  const lookup = new BackMatterLookup(backMatter, preferBase64);
+  return getAbsoluteUrl(lookup.resolve(href, mediaType).uri, parentUrl);
 }
 
 /**

--- a/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/src/components/oscal-utils/OSCALProfileResolver.js
@@ -1,6 +1,6 @@
 import resolveLinkHref from "./OSCALLinkUtils";
 
-const OSCAL_MEDIA_TYPE = "application/oscal.catalog+json";
+const OSCAL_MEDIA_TYPE = /^application\/oscal.*\+json$/;
 /**
  * Profiles are brought in through different methods in OSCAL models.
  *

--- a/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/src/components/oscal-utils/OSCALProfileResolver.js
@@ -1,6 +1,6 @@
 import resolveLinkHref from "./OSCALLinkUtils";
 
-const OSCAL_MEDIA_TYPE_REGEX = /^application\/oscal.*\+json$/;
+const OSCAL_MEDIA_TYPE = "application/oscal.catalog+json";
 /**
  * Profiles are brought in through different methods in OSCAL models.
  *
@@ -77,7 +77,8 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
               profileBackMatter,
               profileImport.href,
               null,
-              OSCAL_MEDIA_TYPE_REGEX
+              OSCAL_MEDIA_TYPE,
+              false
             );
             OSCALResolveProfileOrCatalogUrlControls(
               resolvedControls,
@@ -132,7 +133,8 @@ export function OSCALResolveProfile(profile, parentUrl, onSuccess, onError) {
         profile?.["back-matter"] ?? [],
         imp.href,
         parentUrl,
-        OSCAL_MEDIA_TYPE_REGEX
+        OSCAL_MEDIA_TYPE,
+        false
       ),
       parentUrl,
       profile?.["back-matter"] ?? [],


### PR DESCRIPTION
This reworks how we resolve links in backmatter to not always assume data will be in an `rlink`.

The `BackMatterLookup` class will make resolving back matter a lot easier in the future.

### Testing

http://localhost:3000/system-security-plan/?url=https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/tuckerzp/base64/system-security-plans/ssp-example.json

The dataflow diagram is in base64

![image](https://user-images.githubusercontent.com/39490074/229220843-945580e5-1e13-4428-8cea-8dc4c86e3622.png)

closes #671
