### PR TITLE
chore(lint): allow lines up to 100 characters

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 80,
+  "printWidth": 100,
   "singleQuote": false,
   "trailingComma": "es5",
   "tabWidth": 2,

--- a/packages/oscal-react-library/jest.config.ts
+++ b/packages/oscal-react-library/jest.config.ts
@@ -7,8 +7,7 @@ const config: Config = {
     "^.+\\.[tj]sx?$": "ts-jest",
     // For non-code files, use the file transform. This will just return the name of the
     // file, matching the behavior for these files in `react-scripts`.
-    "^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)":
-      "<rootDir>/tests/fileTransform.js",
+    "^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)": "<rootDir>/tests/fileTransform.js",
   },
   testMatch: ["**/*.test.(ts|tsx|js|jsx)"],
   testEnvironment: "jsdom",

--- a/packages/oscal-react-library/src/components/OSCALBackMatter.js
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.js
@@ -9,10 +9,7 @@ import FormatQuoteIcon from "@mui/icons-material/FormatQuote";
 import DescriptionIcon from "@mui/icons-material/Description";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import StyledTooltip from "./OSCALStyledTooltip";
-import {
-  getAbsoluteUrl,
-  guessExtensionFromHref,
-} from "./oscal-utils/OSCALLinkUtils";
+import { getAbsoluteUrl, guessExtensionFromHref } from "./oscal-utils/OSCALLinkUtils";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
@@ -49,11 +46,7 @@ function DescriptionDisplay(props) {
   }
   return (
     <StyledTooltip
-      title={
-        <OSCALMarkupMultiLine>
-          {props.resource.description}
-        </OSCALMarkupMultiLine>
-      }
+      title={<OSCALMarkupMultiLine>{props.resource.description}</OSCALMarkupMultiLine>}
     >
       <DescriptionIcon
         color="primary"
@@ -75,9 +68,7 @@ function CitationDisplay(props) {
     );
   }
   return (
-    <StyledTooltip
-      title={<OSCALMarkupLine>{props.resource.citation.text}</OSCALMarkupLine>}
-    >
+    <StyledTooltip title={<OSCALMarkupLine>{props.resource.citation.text}</OSCALMarkupLine>}>
       <FormatQuoteIcon
         color="primary"
         fontSize="small"
@@ -93,8 +84,7 @@ export default function OSCALBackMatter(props) {
   }
 
   const getMediaType = (rlink) =>
-    rlink["media-type"] ||
-    guessExtensionFromHref(getAbsoluteUrl(rlink.href, props.parentUrl));
+    rlink["media-type"] || guessExtensionFromHref(getAbsoluteUrl(rlink.href, props.parentUrl));
 
   const backMatterDisplay = (resource) => (
     <Grid item xs={3} key={resource.uuid}>
@@ -149,9 +139,7 @@ export default function OSCALBackMatter(props) {
             </Grid>
           </Grid>
           <Grid container spacing={2} padding={2}>
-            {props.backMatter.resources.map((resource) =>
-              backMatterDisplay(resource)
-            )}
+            {props.backMatter.resources.map((resource) => backMatterDisplay(resource))}
           </Grid>
         </CardContent>
       </Card>

--- a/packages/oscal-react-library/src/components/OSCALBackMatter.test.js
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.test.js
@@ -10,12 +10,7 @@ import {
 } from "../test-data/BackMatterData";
 
 function backMatterRenderer() {
-  render(
-    <OSCALBackMatter
-      backMatter={backMatterTestData}
-      parentUrl={parentUrlTestData}
-    />
-  );
+  render(<OSCALBackMatter backMatter={backMatterTestData} parentUrl={parentUrlTestData} />);
 }
 
 export default function testOSCALBackMatter(parentElementName, renderer) {
@@ -27,13 +22,9 @@ export default function testOSCALBackMatter(parentElementName, renderer) {
 
   test(`${parentElementName} displays resource description`, async () => {
     renderer();
-    const descriptionDisplay = screen.getByTitle(
-      "Resource Test Title-description"
-    );
+    const descriptionDisplay = screen.getByTitle("Resource Test Title-description");
     await userEvent.hover(descriptionDisplay);
-    expect(
-      await screen.findByText("This is a test description for resource")
-    ).toBeInTheDocument();
+    expect(await screen.findByText("This is a test description for resource")).toBeInTheDocument();
   });
 
   test(`${parentElementName} displays media-type`, async () => {

--- a/packages/oscal-react-library/src/components/OSCALCatalog.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.js
@@ -5,14 +5,7 @@ import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 import OSCALMetadata from "./OSCALMetadata";
 
 export default function OSCALCatalog(props) {
-  const {
-    onResolutionComplete,
-    catalog,
-    isEditable,
-    onFieldSave,
-    urlFragment,
-    parentUrl,
-  } = props;
+  const { onResolutionComplete, catalog, isEditable, onFieldSave, urlFragment, parentUrl } = props;
 
   useEffect(onResolutionComplete);
 
@@ -34,10 +27,7 @@ export default function OSCALCatalog(props) {
 
       <OSCALCatalogGroups groups={catalog.groups} urlFragment={urlFragment} />
 
-      <OSCALBackMatter
-        backMatter={catalog["back-matter"]}
-        parentUrl={parentUrl}
-      />
+      <OSCALBackMatter backMatter={catalog["back-matter"]} parentUrl={parentUrl} />
     </OSCALDocumentRoot>
   );
 }

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.js
@@ -75,13 +75,7 @@ function CollapsibleListItem(props) {
       const elementWithFragment = document.getElementById(control.id);
       elementWithFragment?.scrollIntoView?.({ behavior: "smooth" });
     }
-  }, [
-    urlFragment,
-    fragmentSuffix,
-    listItemOpened,
-    isSetListItemNavigatedTo,
-    control?.id,
-  ]);
+  }, [urlFragment, fragmentSuffix, listItemOpened, isSetListItemNavigatedTo, control?.id]);
 
   return (
     <StyledListItemPaper>
@@ -89,15 +83,8 @@ function CollapsibleListItem(props) {
         <ListItemText primary={itemText} />
         {isOpen ? <ExpandLess /> : <ExpandMore />}
       </StyledListItem>
-      <Collapse
-        in={isOpen}
-        timeout="auto"
-        onEntered={() => setListItemOpened(true)}
-        unmountOnExit
-      >
-        <StyledControlDescriptionWrapper>
-          {children}
-        </StyledControlDescriptionWrapper>
+      <Collapse in={isOpen} timeout="auto" onEntered={() => setListItemOpened(true)} unmountOnExit>
+        <StyledControlDescriptionWrapper>{children}</StyledControlDescriptionWrapper>
       </Collapse>
     </StyledListItemPaper>
   );
@@ -112,14 +99,11 @@ function OSCALCatalogControlListItem(props) {
     isControlListItemOpened,
     setIsControlListItemOpened,
   } = props;
-  const [isListItemNavigatedTo, isSetListItemNavigatedTo] =
-    React.useState(false);
+  const [isListItemNavigatedTo, isSetListItemNavigatedTo] = React.useState(false);
 
   const withdrawn = isWithdrawn(control);
   const itemText = (
-    <OSCALAnchorLinkHeader
-      value={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}
-    >
+    <OSCALAnchorLinkHeader value={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}>
       <OSCALControlLabel
         label={propWithName(control.props, "label")?.value}
         id={control.id}
@@ -198,10 +182,7 @@ function OSCALCatalogGroupList(props) {
             control={groupControl}
             key={groupControl.id}
             urlFragment={urlFragment}
-            fragmentPrefix={appendToFragmentPrefix(
-              fragmentPrefix,
-              groupControl
-            )}
+            fragmentPrefix={appendToFragmentPrefix(fragmentPrefix, groupControl)}
             fragmentSuffix={shiftFragmentSuffix(fragmentSuffix)}
             isControlListItemOpened={isControlListItemOpened}
             setIsControlListItemOpened={setIsControlListItemOpened}
@@ -213,12 +194,7 @@ function OSCALCatalogGroupList(props) {
 }
 
 export default function OSCALCatalogGroup(props) {
-  const {
-    group,
-    urlFragment,
-    isControlListItemOpened,
-    setIsControlListItemOpened,
-  } = props;
+  const { group, urlFragment, isControlListItemOpened, setIsControlListItemOpened } = props;
   // Note: "fragmentPrefix" is specific to setting up a fragment in the url, by adding groupings;
   // while "fragmentSuffix" is specific to finding a control from a fragment, trimming found groups
   const fragmentPrefix = group.id ?? conformLinkIdText(group.title) ?? "";

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroups.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroups.js
@@ -76,17 +76,14 @@ TabPanel.propTypes = {
 function determineControlExists(groups, controlLayers, rootLayer) {
   // Ensure catalog tab grouping exists
   let upperLayer = groups?.find(
-    (group) =>
-      group?.id === rootLayer || conformLinkIdText(group?.title) === rootLayer
+    (group) => group?.id === rootLayer || conformLinkIdText(group?.title) === rootLayer
   );
   if (!upperLayer) {
     return null;
   }
   // Ensure lowest/deepest control exists
   for (let i = 1; i < controlLayers.length && upperLayer; i += 1) {
-    upperLayer = upperLayer?.controls?.find(
-      (control) => control.id === controlLayers[i]
-    );
+    upperLayer = upperLayer?.controls?.find((control) => control.id === controlLayers[i]);
   }
   return upperLayer;
 }
@@ -94,8 +91,7 @@ function determineControlExists(groups, controlLayers, rootLayer) {
 export default function OSCALCatalogGroups(props) {
   const { groups, urlFragment } = props;
   const [openTab, setOpenTab] = React.useState(groups[0]?.id);
-  const [isControlListItemOpened, setIsControlListItemOpened] =
-    React.useState(false);
+  const [isControlListItemOpened, setIsControlListItemOpened] = React.useState(false);
 
   const handleChange = (event, newValue) => {
     setOpenTab(newValue);

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroups.test.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroups.test.js
@@ -42,9 +42,7 @@ function getTextByChildren(text) {
     // This is necessary because we are providing a query function to override how
     // text search is performed.
     // eslint-disable-next-line testing-library/no-node-access
-    const childrenDontHaveText = Array.from(node.children).every(
-      (child) => !hasText(child)
-    );
+    const childrenDontHaveText = Array.from(node.children).every((child) => !hasText(child));
 
     return nodeHasText && childrenDontHaveText;
   }
@@ -84,9 +82,7 @@ describe("OSCALCatalogGroup", () => {
     const expand1 = screen.getByText("Sibling Title");
     fireEvent.click(expand1);
 
-    const expand2 = screen.getByText(
-      getTextByChildren("control2-id Audit Events")
-    );
+    const expand2 = screen.getByText(getTextByChildren("control2-id Audit Events"));
     fireEvent.click(expand2);
   });
 });

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinition.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinition.js
@@ -10,8 +10,7 @@ import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 export default function OSCALComponentDefinition(props) {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [inheritedProfilesAndCatalogs, setInheritedProfilesAndCatalogs] =
-    useState({});
+  const [inheritedProfilesAndCatalogs, setInheritedProfilesAndCatalogs] = useState({});
 
   const partialRestData = {
     "component-definition": {
@@ -45,20 +44,18 @@ export default function OSCALComponentDefinition(props) {
   if (!isLoaded) {
     controlImpl = null;
   } else {
-    controlImpl = Object.entries(props.componentDefinition.components).map(
-      ([key, component]) => (
-        <OSCALComponentDefinitionControlImplementation
-          controlImplementations={component["control-implementations"]}
-          components={props.componentDefinition.components}
-          controls={props.componentDefinition.resolvedControls}
-          key={key}
-          isEditable={props.isEditable}
-          onRestSuccess={props.onRestSuccess}
-          onRestError={props.onRestError}
-          partialRestData={partialRestData}
-        />
-      )
-    );
+    controlImpl = Object.entries(props.componentDefinition.components).map(([key, component]) => (
+      <OSCALComponentDefinitionControlImplementation
+        controlImplementations={component["control-implementations"]}
+        components={props.componentDefinition.components}
+        controls={props.componentDefinition.resolvedControls}
+        key={key}
+        isEditable={props.isEditable}
+        onRestSuccess={props.onRestSuccess}
+        onRestError={props.onRestError}
+        partialRestData={partialRestData}
+      />
+    ));
   }
 
   return (
@@ -70,18 +67,14 @@ export default function OSCALComponentDefinition(props) {
         partialRestData={partialRestData}
         urlFragment={props.urlFragment}
       />
-      <OSCALProfileCatalogInheritance
-        inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs}
-      />
-      {Object.entries(props.componentDefinition.components).map(
-        ([key, component]) => (
-          <OSCALComponentDefinitionComponent
-            component={component}
-            parties={props.componentDefinition.metadata.parties}
-            key={key}
-          />
-        )
-      )}
+      <OSCALProfileCatalogInheritance inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs} />
+      {Object.entries(props.componentDefinition.components).map(([key, component]) => (
+        <OSCALComponentDefinitionComponent
+          component={component}
+          parties={props.componentDefinition.metadata.parties}
+          key={key}
+        />
+      ))}
       {controlImpl}
       <OSCALBackMatter
         backMatter={props.componentDefinition["back-matter"]}

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinition.test.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinition.test.js
@@ -10,11 +10,7 @@ test("OSCALComponentDefinition loads", () => {
 });
 
 function componentDefinitionRenderer() {
-  render(
-    <OSCALComponentDefinition
-      componentDefinition={componentDefinitionTestData}
-    />
-  );
+  render(<OSCALComponentDefinition componentDefinition={componentDefinitionTestData} />);
 }
 
 function testOSCALComponentDefinitionComponent(parentElementName, renderer) {
@@ -27,13 +23,8 @@ function testOSCALComponentDefinitionComponent(parentElementName, renderer) {
   test(`${parentElementName} shows component description`, async () => {
     renderer();
     await userEvent.hover(screen.getByText("Example Component"));
-    expect(
-      await screen.findByText("An example component.")
-    ).toBeInTheDocument();
+    expect(await screen.findByText("An example component.")).toBeInTheDocument();
   });
 }
 
-testOSCALComponentDefinitionComponent(
-  "OSCALComponentDefinition",
-  componentDefinitionRenderer
-);
+testOSCALComponentDefinitionComponent("OSCALComponentDefinition", componentDefinitionRenderer);

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinitionComponent.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinitionComponent.js
@@ -39,17 +39,13 @@ export default function OSCALComponentDefinitionComponent(props) {
                     <TableRow key={props.component.uuid}>
                       <TableCell component="th" scope="row">
                         <StyledTooltip title={props.component.description}>
-                          <Typography variant="body2">
-                            {props.component.title}
-                          </Typography>
+                          <Typography variant="body2">{props.component.title}</Typography>
                         </StyledTooltip>
                       </TableCell>
                       <TableCell>{props.component.type}</TableCell>
                       <TableCell>
                         <OSCALResponsibleRoles
-                          responsibleRoles={
-                            props.component["responsible-roles"]
-                          }
+                          responsibleRoles={props.component["responsible-roles"]}
                           parties={props.parties}
                         />
                       </TableCell>

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinitionControlImplementation.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinitionControlImplementation.js
@@ -30,22 +30,20 @@ export default function OSCALComponentDefinitionControlImplementation(props) {
                       {controlImpl.description}
                       <Grid item xs={12}>
                         <List>
-                          {controlImpl["implemented-requirements"].map(
-                            (implementedRequirement) => (
-                              <OSCALControlImplementationImplReq
-                                implementedRequirement={implementedRequirement}
-                                components={props.components}
-                                controls={props.controls}
-                                childLevel={0}
-                                key={implementedRequirement.uuid}
-                                modifications={controlImpl.modifications}
-                                isEditable={props.isEditable}
-                                onRestSuccess={props.onRestSuccess}
-                                onRestError={props.onRestError}
-                                partialRestData={props.partialRestData}
-                              />
-                            )
-                          )}
+                          {controlImpl["implemented-requirements"].map((implementedRequirement) => (
+                            <OSCALControlImplementationImplReq
+                              implementedRequirement={implementedRequirement}
+                              components={props.components}
+                              controls={props.controls}
+                              childLevel={0}
+                              key={implementedRequirement.uuid}
+                              modifications={controlImpl.modifications}
+                              isEditable={props.isEditable}
+                              onRestSuccess={props.onRestSuccess}
+                              onRestError={props.onRestError}
+                              partialRestData={props.partialRestData}
+                            />
+                          ))}
                         </List>
                       </Grid>
                     </ListItemText>

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinitionControlImplementation.test.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinitionControlImplementation.test.js
@@ -16,9 +16,7 @@ test("OSCALComponentDefinitionControlImplementation displays component implement
       controls={controlsData}
     />
   );
-  const result = screen.getByText(
-    "This is an example description for control implementation-1"
-  );
+  const result = screen.getByText("This is an example description for control implementation-1");
   expect(result).toBeVisible();
 });
 
@@ -43,13 +41,9 @@ test("OSCALComponentDefinitionControlImplementation displays component parameter
     />
   );
   const nonplaceholder1 = getByTextIncludingChildren(/Does something with/i);
-  const placeholderText1 = getByTextIncludingChildren(
-    /< control 1 \/ parameter 1 label >/i
-  );
+  const placeholderText1 = getByTextIncludingChildren(/< control 1 \/ parameter 1 label >/i);
   const nonplaceholder2 = getByTextIncludingChildren(/and/i);
-  const placeholderText2 = getByTextIncludingChildren(
-    /< control 1 \/ parameter 2 label >/i
-  );
+  const placeholderText2 = getByTextIncludingChildren(/< control 1 \/ parameter 2 label >/i);
 
   expect(nonplaceholder1).toBeVisible();
   expect(placeholderText1).toBeVisible();

--- a/packages/oscal-react-library/src/components/OSCALControl.js
+++ b/packages/oscal-react-library/src/components/OSCALControl.js
@@ -15,9 +15,7 @@ import { appendToFragmentPrefix } from "./oscal-utils/OSCALLinkUtils";
 const OSCALControlCard = styled(Card, {
   // https://github.com/mui/material-ui/blob/c34935814b81870ca325099cdf41a1025a85d4b5/packages/mui-system/src/createStyled.js#L56
   shouldForwardProp: (prop) =>
-    !["childLevel", "withdrawn", "ownerState", "theme", "sx", "as"].includes(
-      prop
-    ),
+    !["childLevel", "withdrawn", "ownerState", "theme", "sx", "as"].includes(prop),
 })`
   margin-top: 1em;
   margin-bottom: 1em;
@@ -25,8 +23,7 @@ const OSCALControlCard = styled(Card, {
   margin-right: ${(props) => (props.childLevel > 0 ? "1.5em" : "0")};
   ${(props) => props.childLevel > 0 && "background-color: #fffcf0;"}
   ${(props) =>
-    props.withdrawn &&
-    `text-decoration: line-through; color: ${props.theme.palette.grey[400]};`}
+    props.withdrawn && `text-decoration: line-through; color: ${props.theme.palette.grey[400]};`}
 `;
 
 function ControlsList(props) {
@@ -114,26 +111,17 @@ export default function OSCALControl(props) {
     elementWithFragment?.scrollIntoView?.({ behavior: "smooth" });
   }, [listItemOpened, isItemNavigatedTo, urlFragment]);
 
-  if (
-    !includeAll &&
-    (!control || (includeControlIds && !includeControlIds.includes(control.id)))
-  ) {
+  if (!includeAll && (!control || (includeControlIds && !includeControlIds.includes(control.id)))) {
     return null;
   }
-  if (
-    !control ||
-    (excludeControlIds && excludeControlIds.includes(control.id))
-  ) {
+  if (!control || (excludeControlIds && excludeControlIds.includes(control.id))) {
     return null;
   }
 
   let modificationDisplay;
   if (modificationAlters) {
     modificationDisplay = (
-      <OSCALControlModification
-        modificationAlters={modificationAlters}
-        controlId={control.id}
-      />
+      <OSCALControlModification modificationAlters={modificationAlters} controlId={control.id} />
     );
   }
 
@@ -142,30 +130,20 @@ export default function OSCALControl(props) {
   return showInList ? (
     <ControlsList {...props} />
   ) : (
-    <OSCALControlCard
-      childLevel={childLevel ?? 0}
-      withdrawn={isWithdrawn(control)}
-    >
+    <OSCALControlCard childLevel={childLevel ?? 0} withdrawn={isWithdrawn(control)}>
       <CardContent>
         <Grid container spacing={1}>
           <Grid item xs={12}>
             <OSCALAnchorLinkHeader
-              value={appendToFragmentPrefix(
-                fragmentPrefix,
-                control.id
-              ).toLowerCase()}
+              value={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}
             >
               <Typography
                 variant="h6"
                 component="h2"
                 style={childLevel ? { fontSize: "1.1rem" } : undefined}
               >
-                <OSCALControlLabel
-                  component="span"
-                  label={label}
-                  id={control.id}
-                />{" "}
-                {control.title} {modificationDisplay}
+                <OSCALControlLabel component="span" label={label} id={control.id} /> {control.title}{" "}
+                {modificationDisplay}
               </Typography>
             </OSCALAnchorLinkHeader>
           </Grid>

--- a/packages/oscal-react-library/src/components/OSCALControlGuidance.js
+++ b/packages/oscal-react-library/src/components/OSCALControlGuidance.js
@@ -39,11 +39,7 @@ export default function OSCALControlGuidance(props) {
 
   return (
     <>
-      <OSCALControlGuidanceButton
-        variant="outlined"
-        size="small"
-        onClick={handleClick}
-      >
+      <OSCALControlGuidanceButton variant="outlined" size="small" onClick={handleClick}>
         Read Discussion
       </OSCALControlGuidanceButton>
       <Dialog
@@ -54,11 +50,7 @@ export default function OSCALControlGuidance(props) {
         aria-describedby="scroll-dialog-description"
       >
         <DialogTitle id="scroll-dialog-title">
-          <OSCALControlLabel
-            id={props.id}
-            label={props.label}
-            component="span"
-          />
+          <OSCALControlLabel id={props.id} label={props.label} component="span" />
           {` ${props.title} Discussion`}
         </DialogTitle>
         <DialogContent dividers>

--- a/packages/oscal-react-library/src/components/OSCALControlGuidance.test.js
+++ b/packages/oscal-react-library/src/components/OSCALControlGuidance.test.js
@@ -8,9 +8,7 @@ describe("OSCALControlGuidance", () => {
     const prose = "Access control policy";
     const id = "AC-1";
     const title = "Sample Title";
-    render(
-      <OSCALControlGuidance prose={prose} id={id} title={title} label={id} />
-    );
+    render(<OSCALControlGuidance prose={prose} id={id} title={title} label={id} />);
     await userEvent.click(screen.getByRole("button"));
     const result = screen.getByText("Access control policy");
     expect(result).toBeVisible();

--- a/packages/oscal-react-library/src/components/OSCALControlImplementation.js
+++ b/packages/oscal-react-library/src/components/OSCALControlImplementation.js
@@ -18,8 +18,7 @@ import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
  * @returns The corresponding Control Implementation
  */
 export default function OSCALControlImplementation(props) {
-  const implementedRequirements =
-    props.controlImplementation["implemented-requirements"];
+  const implementedRequirements = props.controlImplementation["implemented-requirements"];
   const controlIds = implementedRequirements.map(
     (implementedControl) => implementedControl["control-id"]
   );

--- a/packages/oscal-react-library/src/components/OSCALControlImplementationAdd.js
+++ b/packages/oscal-react-library/src/components/OSCALControlImplementationAdd.js
@@ -23,14 +23,9 @@ export default function OSCALControlImplementationAdd(props) {
   const [inEditState, setInEditState] = useState(false);
   const [newControl, setNewControl] = useState("");
 
-  const rootOscalObjectName = props.restData
-    ? Object.keys(props.restData)[0]
-    : null;
+  const rootOscalObjectName = props.restData ? Object.keys(props.restData)[0] : null;
   const editedFieldContents = [rootOscalObjectName, "control-implementation"];
-  const controlIdsAndTitles = getControlIdsAndTitles(
-    props.controls,
-    props.implementedControls
-  );
+  const controlIdsAndTitles = getControlIdsAndTitles(props.controls, props.implementedControls);
 
   return inEditState ? (
     <Grid container item xs={12} justifyContent="flex-end" alignItems="center">
@@ -46,9 +41,7 @@ export default function OSCALControlImplementationAdd(props) {
             setNewControl(event.target.textContent);
           }}
           options={Object.keys(controlIdsAndTitles)}
-          renderInput={(params) => (
-            <TextField {...params} label="Select Control" />
-          )}
+          renderInput={(params) => <TextField {...params} label="Select Control" />}
         />
       </Grid>
       <Grid item>

--- a/packages/oscal-react-library/src/components/OSCALControlImplementationAdd.test.js
+++ b/packages/oscal-react-library/src/components/OSCALControlImplementationAdd.test.js
@@ -20,10 +20,7 @@ function OSCALControlImplementationAddRenderer() {
   );
 }
 
-export default function testOSCALControlImplementationAdd(
-  parentElementName,
-  renderer
-) {
+export default function testOSCALControlImplementationAdd(parentElementName, renderer) {
   test(`${parentElementName} displays the add button`, () => {
     renderer();
 

--- a/packages/oscal-react-library/src/components/OSCALControlImplementationImplReq.js
+++ b/packages/oscal-react-library/src/components/OSCALControlImplementationImplReq.js
@@ -12,9 +12,7 @@ import getControlOrSubControl from "./oscal-utils/OSCALControlResolver";
 const OSCALImplReqCard = styled(Card, {
   // https://github.com/mui/material-ui/blob/c34935814b81870ca325099cdf41a1025a85d4b5/packages/mui-system/src/createStyled.js#L56
   shouldForwardProp: (prop) =>
-    !["childLevel", "withdrawn", "ownerState", "theme", "sx", "as"].includes(
-      prop
-    ),
+    !["childLevel", "withdrawn", "ownerState", "theme", "sx", "as"].includes(prop),
 })`
   margin-top: 1em;
   margin-bottom: 1em;
@@ -130,11 +128,7 @@ export default function OSCALControlImplementationImplReq(props) {
             ))}
           </ComponentTabs>
           {Object.values(props.components).map((component, index) => (
-            <ComponentTabPanelScrollable
-              value={value}
-              index={index}
-              key={component.uuid}
-            >
+            <ComponentTabPanelScrollable value={value} index={index} key={component.uuid}>
               <OSCALControl
                 control={getControlOrSubControl(
                   props.controls,

--- a/packages/oscal-react-library/src/components/OSCALControlImplementationImplReq.test.js
+++ b/packages/oscal-react-library/src/components/OSCALControlImplementationImplReq.test.js
@@ -4,10 +4,7 @@ import userEvent from "@testing-library/user-event";
 import OSCALControlImplementation from "./OSCALControlImplementation";
 import getByTextIncludingChildren from "./oscal-utils/TestUtils";
 import { controlImplTestData, exampleControl } from "../test-data/ControlsData";
-import {
-  exampleComponents,
-  componentsTestData,
-} from "../test-data/ComponentsData";
+import { exampleComponents, componentsTestData } from "../test-data/ComponentsData";
 import { profileModifyTestData } from "../test-data/ModificationsData";
 import { sspRestData } from "../test-data/SystemData";
 
@@ -27,10 +24,7 @@ function controlImplementationImplReqRenderer() {
   );
 }
 
-export default function testOSCALControlImplementationImplReq(
-  parentElementName,
-  renderer
-) {
+export default function testOSCALControlImplementationImplReq(parentElementName, renderer) {
   test(`${parentElementName} displays control ID`, () => {
     renderer();
     const result = screen.getByText("control-1");
@@ -63,9 +57,7 @@ export default function testOSCALControlImplementationImplReq(
       })
     );
     expect(
-      await screen.findByText(
-        "Component 1 description of implementing control 1"
-      )
+      await screen.findByText("Component 1 description of implementing control 1")
     ).toBeInTheDocument();
   });
 
@@ -84,9 +76,7 @@ export default function testOSCALControlImplementationImplReq(
         timeout: 10000,
       })
     ).toBeInTheDocument();
-    await expect(() => screen.findByRole("button")).rejects.toThrow(
-      'Unable to find role="button"'
-    );
+    await expect(() => screen.findByRole("button")).rejects.toThrow('Unable to find role="button"');
   });
 }
 

--- a/packages/oscal-react-library/src/components/OSCALControlModification.js
+++ b/packages/oscal-react-library/src/components/OSCALControlModification.js
@@ -23,11 +23,7 @@ const OSCALControlModificationsButton = styled(IconButton)(
  * @param {String} controlPartId Control part ID to match
  * @returns html object
  */
-function getAlterAddsOrRemovesDisplay(
-  addsRemovesElements,
-  addsRemovesLabel,
-  controlPartId
-) {
+function getAlterAddsOrRemovesDisplay(addsRemovesElements, addsRemovesLabel, controlPartId) {
   if (!addsRemovesElements?.length) {
     return null;
   }
@@ -37,12 +33,7 @@ function getAlterAddsOrRemovesDisplay(
   const typographies = addsRemovesElements
     .flatMap((element) => element.props ?? [])
     .map((item) => (
-      <Typography
-        color="textSecondary"
-        paragraph
-        variant="body1"
-        key={controlPartId}
-      >
+      <Typography color="textSecondary" paragraph variant="body1" key={controlPartId}>
         Name: {item.name}, Value: {item.value}
       </Typography>
     ));
@@ -51,21 +42,14 @@ function getAlterAddsOrRemovesDisplay(
     removedTypographies = addsRemovesElements
       .flatMap((element) => element ?? [])
       .map((item) => (
-        <Typography
-          color="textSecondary"
-          paragraph
-          variant="body1"
-          key={item.id}
-        >
-          Attribute: {Object.keys.length > 0 ? Object.keys(item)[0] : ""},
-          Value: {Object.values.length > 0 ? Object.values(item)[0] : ""}
+        <Typography color="textSecondary" paragraph variant="body1" key={item.id}>
+          Attribute: {Object.keys.length > 0 ? Object.keys(item)[0] : ""}, Value:{" "}
+          {Object.values.length > 0 ? Object.values(item)[0] : ""}
         </Typography>
       ));
   }
 
-  const labelTypograhy = (
-    <Typography variant="h6">{addsRemovesLabel}</Typography>
-  );
+  const labelTypograhy = <Typography variant="h6">{addsRemovesLabel}</Typography>;
 
   return (
     <DialogContent dividers>
@@ -115,10 +99,7 @@ function getModifications(controlPartId, controlId, modList, modText) {
   );
 
   // return display & mod length
-  return [
-    getAlterAddsOrRemovesDisplay(controlParts, modText, controlPartId),
-    controlParts.length,
-  ];
+  return [getAlterAddsOrRemovesDisplay(controlParts, modText, controlPartId), controlParts.length];
 }
 
 export default function OSCALControlModification(props) {
@@ -149,12 +130,7 @@ export default function OSCALControlModification(props) {
 
   // Get all add modifications
   if (alter.adds) {
-    [addsDisplay, len] = getModifications(
-      controlPartId,
-      props.controlId,
-      alter.adds,
-      "Adds "
-    );
+    [addsDisplay, len] = getModifications(controlPartId, props.controlId, alter.adds, "Adds ");
     modLength += len;
   }
   // Get all remove modifications

--- a/packages/oscal-react-library/src/components/OSCALControlPart.js
+++ b/packages/oscal-react-library/src/components/OSCALControlPart.js
@@ -9,8 +9,7 @@ import {
 import { propWithName } from "./oscal-utils/OSCALPropUtils";
 
 const OSCALControlPartWrapper = styled("div", {
-  shouldForwardProp: (prop) =>
-    !["partName", "ownerState", "theme", "sx", "as"].includes(prop),
+  shouldForwardProp: (prop) => !["partName", "ownerState", "theme", "sx", "as"].includes(prop),
 })`
   padding-left: ${(props) => (props.partName !== "statement" ? "2em" : "0")};
 `;
@@ -18,9 +17,7 @@ const OSCALControlPartWrapper = styled("div", {
 export default function OSCALControlPart(props) {
   // Don't display assessment if we're displaying a control implementation
   if (
-    (props.implementedRequirement ||
-      props.modificationSetParameters ||
-      props.modificationAlters) &&
+    (props.implementedRequirement || props.modificationSetParameters || props.modificationAlters) &&
     (props.part.name === "objective" || props.part.name === "assessment")
   ) {
     return null;

--- a/packages/oscal-react-library/src/components/OSCALControlProse.js
+++ b/packages/oscal-react-library/src/components/OSCALControlProse.js
@@ -72,9 +72,7 @@ const styledParamValue = (keyValue, parameterValue) => (
  * @returns the parameter label
  */
 function getParameterLabelText(parameters, parameterId) {
-  const parameter = parameters.find(
-    (testParameter) => testParameter.id === parameterId
-  );
+  const parameter = parameters.find((testParameter) => testParameter.id === parameterId);
 
   if (!parameter) {
     return `< ${parameterId} >`;
@@ -95,17 +93,12 @@ function getParameterLabelText(parameters, parameterId) {
  * @param {String} parameterId
  * @returns the parameter label
  */
-function getParameterValue(
-  statementByComponent,
-  implReqSetParameters,
-  parameterId
-) {
+function getParameterValue(statementByComponent, implReqSetParameters, parameterId) {
   function parameterHasGivenId(parameterSetting) {
     return parameterSetting["param-id"] === parameterId;
   }
   // Locate set-parameters when found in the by-component
-  const setParameters =
-    statementByComponent?.["set-parameters"] || implReqSetParameters;
+  const setParameters = statementByComponent?.["set-parameters"] || implReqSetParameters;
   const foundParameterSetting = setParameters?.find(parameterHasGivenId);
 
   // Error checking: Exit function when parameter setting or it's values are not found
@@ -155,9 +148,9 @@ function getImplReqSetParameters(implReqStatements, componentId) {
   return (
     implReqStatements
       ?.find((statement) => statement["statement-id"].endsWith("_smt"))
-      ?.["by-components"]?.find(
-        (byComp) => byComp["component-uuid"] === componentId
-      )?.["set-parameters"] || null
+      ?.["by-components"]?.find((byComp) => byComp["component-uuid"] === componentId)?.[
+      "set-parameters"
+    ] || null
   );
 }
 
@@ -205,12 +198,7 @@ function SegmentTooltipWrapper(props) {
  * @param {String} key
  * @returns the parameter label segment component
  */
-function getParameterLabelSegment(
-  parameters,
-  parameterId,
-  modificationSetParameters,
-  key
-) {
+function getParameterLabelSegment(parameters, parameterId, modificationSetParameters, key) {
   let paramSegment;
   // First check for set-parameters in the profile/catalog
   let parameterValueText;
@@ -225,10 +213,7 @@ function getParameterLabelSegment(
     }
   }
   if (parameterValueText) {
-    paramSegment = styledParamValue(
-      `param-value-key-${key}`,
-      parameterValueText
-    );
+    paramSegment = styledParamValue(`param-value-key-${key}`, parameterValueText);
   } else {
     const parameterLabelText = getParameterLabelText(
       parameters,
@@ -241,10 +226,7 @@ function getParameterLabelSegment(
     );
   }
 
-  const constraintsDisplay = getConstraintsDisplay(
-    modificationSetParameters,
-    parameterId
-  );
+  const constraintsDisplay = getConstraintsDisplay(modificationSetParameters, parameterId);
 
   if (!constraintsDisplay) {
     return paramSegment;
@@ -277,15 +259,8 @@ function getParameterValueSegment(
   key,
   parameters
 ) {
-  const parameterValue = getParameterValue(
-    statementByComponent,
-    implReqSetParameters,
-    parameterId
-  );
-  const constraintsDisplay = getConstraintsDisplay(
-    modificationSetParameters,
-    parameterId
-  );
+  const parameterValue = getParameterValue(statementByComponent, implReqSetParameters, parameterId);
+  const constraintsDisplay = getConstraintsDisplay(modificationSetParameters, parameterId);
 
   const parameterLabelText = getParameterLabelText(
     parameters,
@@ -329,19 +304,17 @@ export function OSCALReplacedProseWithParameterLabel(props) {
     return null;
   }
   const prose = props.parameters
-    ? props.prose
-        .split(RegExp(prosePlaceholderRegexpString, "g"))
-        .map((segment, index) => {
-          if (index % 2 === 0) {
-            return getTextSegment(segment, index);
-          }
-          return getParameterLabelSegment(
-            props.parameters,
-            segment,
-            props.modificationSetParameters,
-            index
-          );
-        })
+    ? props.prose.split(RegExp(prosePlaceholderRegexpString, "g")).map((segment, index) => {
+        if (index % 2 === 0) {
+          return getTextSegment(segment, index);
+        }
+        return getParameterLabelSegment(
+          props.parameters,
+          segment,
+          props.modificationSetParameters,
+          index
+        );
+      })
     : getTextSegment(props.prose, 0);
 
   if (!props.isImplemented) {
@@ -379,13 +352,7 @@ export function OSCALReplacedProseWithParameterLabel(props) {
     ?.find((item) => item["control-id"] === controlId)
     ?.removes?.find((object) => object["by-item-name"] === controlPartId);
 
-  if (
-    removeByIds ||
-    removeByNames ||
-    removeByNS ||
-    removeByClass ||
-    removeByItemNames
-  ) {
+  if (removeByIds || removeByNames || removeByNS || removeByClass || removeByItemNames) {
     return (
       <OSCALControlProseRemove>
         {props.label} {prose}
@@ -430,17 +397,11 @@ export function OSCALReplacedProseWithByComponentParameterValue(props) {
   // render." This should be investigated further.
   // https://github.com/EasyDynamics/oscal-react-library/issues/499
   /* eslint-disable react-hooks/rules-of-hooks */
-  const statementByComponentDescription =
-    statementByComponent?.description || null;
-  const statementByComponentDescriptionMarkup =
-    statementByComponentDescription ? (
-      <OSCALMarkupMultiLine>
-        {statementByComponentDescription}
-      </OSCALMarkupMultiLine>
-    ) : null;
-  const statementByComponentDescriptionRef = useRef(
-    statementByComponentDescription
-  );
+  const statementByComponentDescription = statementByComponent?.description || null;
+  const statementByComponentDescriptionMarkup = statementByComponentDescription ? (
+    <OSCALMarkupMultiLine>{statementByComponentDescription}</OSCALMarkupMultiLine>
+  ) : null;
+  const statementByComponentDescriptionRef = useRef(statementByComponentDescription);
   const setParametersRefs = {};
   if (props.parameters?.length > 0) {
     props.parameters.forEach((parameter) => {
@@ -526,9 +487,7 @@ export function OSCALReplacedProseWithByComponentParameterValue(props) {
   return (
     <OSCALStatementEditing container spacing={2}>
       <Grid item xs={11}>
-        <StyledTooltip
-          title={statementByComponentDescriptionMarkup ?? props.componentId}
-        >
+        <StyledTooltip title={statementByComponentDescriptionMarkup ?? props.componentId}>
           <Link underline="hover" href={`#${props.label}`}>
             {props.label}
           </Link>
@@ -578,8 +537,7 @@ export function OSCALReplacedProseWithByComponentParameterValue(props) {
                       props.componentId,
                       statementByComponentDescriptionRef.current.value,
                       Object.keys(setParametersRefs).map((setParameterId) => {
-                        const setParameterValue =
-                          setParametersRefs[setParameterId]?.current?.value;
+                        const setParameterValue = setParametersRefs[setParameterId]?.current?.value;
                         return setParameterValue
                           ? {
                               "param-id": setParameterId,

--- a/packages/oscal-react-library/src/components/OSCALControlProse.test.js
+++ b/packages/oscal-react-library/src/components/OSCALControlProse.test.js
@@ -24,9 +24,7 @@ const labelTestDataDecimal = "label-1.1";
 function proseParamLabelsRenderer() {
   render(
     <OSCALReplacedProseWithParameterLabel
-      implementedRequirement={
-        controlImplTestData["implemented-requirements"][0]
-      }
+      implementedRequirement={controlImplTestData["implemented-requirements"][0]}
       label={labelTestData}
       prose={controlProseTestData}
       parameters={exampleParams}
@@ -53,9 +51,7 @@ function proseParamValuesEditingRenderer() {
       label={labelTestData}
       prose={controlProseTestData}
       parameters={exampleParams}
-      implementedRequirement={
-        controlImplTestData["implemented-requirements"][0]
-      }
+      implementedRequirement={controlImplTestData["implemented-requirements"][0]}
       statementId="control-1_smt.a"
       componentId="component-1"
       modificationSetParameters={exampleModificationSetParameters}
@@ -76,13 +72,9 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
 
     const descriptionTextField = screen.getByLabelText("Description");
     const paramValueTextField = screen.getByLabelText("control-1_prm_1");
-    expect(descriptionTextField.value).toBe(
-      "Component 1 description of implementing control 1"
-    );
+    expect(descriptionTextField.value).toBe("Component 1 description of implementing control 1");
 
-    expect(paramValueTextField.value).toBe(
-      "control 1 / component 1 / parameter 1 value"
-    );
+    expect(paramValueTextField.value).toBe("control 1 / component 1 / parameter 1 value");
   });
 
   test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
@@ -106,9 +98,7 @@ function testOSCALControlProseEditing(parentElementName, renderer) {
     expect(descriptionTextField.value).toBe("Test Description");
 
     screen.getByLabelText("control-1_prm_1");
-    expect(paramValueTextField.value).toBe(
-      "control 1 / component 1 / parameter 1 value"
-    );
+    expect(paramValueTextField.value).toBe("control 1 / component 1 / parameter 1 value");
   });
 
   test(`${parentElementName} saves changes to controller name and description values`, async () => {
@@ -149,9 +139,7 @@ function proseDecimalParamValuesEditingRenderer() {
       label={labelTestDataDecimal}
       prose={controlProseDecimalTestData}
       parameters={exampleDecimalParams}
-      implementedRequirement={
-        controlImplWithDecSmtTestData["implemented-requirements"][0]
-      }
+      implementedRequirement={controlImplWithDecSmtTestData["implemented-requirements"][0]}
       statementId="control-1.1_smt.a"
       componentId="component-1.1"
       modificationSetParameters={exampleModificationSetParametersDecimal}
@@ -172,13 +160,9 @@ function testOSCALControlDecimalProseEditing(parentElementName, renderer) {
 
     const descriptionTextField = screen.getByLabelText("Description");
     const paramValueTextField = screen.getByLabelText("control-1.1_prm_1");
-    expect(descriptionTextField.value).toBe(
-      "Component 1.1 description of implementing control 1"
-    );
+    expect(descriptionTextField.value).toBe("Component 1.1 description of implementing control 1");
 
-    expect(paramValueTextField.value).toBe(
-      "control 1.1 / component 1.1 / parameter 1 value"
-    );
+    expect(paramValueTextField.value).toBe("control 1.1 / component 1.1 / parameter 1 value");
   });
 
   test(`${parentElementName} handles edit with just description edit and keeps placeholders`, async () => {
@@ -202,9 +186,7 @@ function testOSCALControlDecimalProseEditing(parentElementName, renderer) {
     expect(descriptionTextField.value).toBe("Test Description");
 
     screen.getByLabelText("control-1.1_prm_1");
-    expect(paramValueTextField.value).toBe(
-      "control 1.1 / component 1.1 / parameter 1 value"
-    );
+    expect(paramValueTextField.value).toBe("control 1.1 / component 1.1 / parameter 1 value");
   });
 
   test(`${parentElementName} saves changes to controller name and description values`, async () => {

--- a/packages/oscal-react-library/src/components/OSCALDiagram.js
+++ b/packages/oscal-react-library/src/components/OSCALDiagram.js
@@ -25,11 +25,7 @@ export default function OSCALDiagram(props) {
 
   return (
     <>
-      <img
-        src={diagramUri}
-        alt={props.diagram.caption}
-        style={{ maxWidth: "100%" }}
-      />
+      <img src={diagramUri} alt={props.diagram.caption} style={{ maxWidth: "100%" }} />
       <Typography variant="caption" display="block" align="center" gutterBottom>
         {props.diagram.caption}
       </Typography>

--- a/packages/oscal-react-library/src/components/OSCALDiagram.test.js
+++ b/packages/oscal-react-library/src/components/OSCALDiagram.test.js
@@ -2,10 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import OSCALDiagram from "./OSCALDiagram";
 import { backMatterTestData } from "../test-data/BackMatterData";
-import {
-  localReferenceDiagram,
-  uriReferenceDiagram,
-} from "../test-data/DiagramData";
+import { localReferenceDiagram, uriReferenceDiagram } from "../test-data/DiagramData";
 
 function diagramRenderer(testData) {
   render(
@@ -17,12 +14,7 @@ function diagramRenderer(testData) {
   );
 }
 
-export default function testOSCALDiagram(
-  parentElementName,
-  renderer,
-  testData,
-  expectedSrc
-) {
+export default function testOSCALDiagram(parentElementName, renderer, testData, expectedSrc) {
   test(`${parentElementName} displays diagram`, () => {
     renderer(testData);
     const result = screen.getByAltText("Authorization Boundary Diagram");

--- a/packages/oscal-react-library/src/components/OSCALDrawerSelector.js
+++ b/packages/oscal-react-library/src/components/OSCALDrawerSelector.js
@@ -1,11 +1,4 @@
-import {
-  Divider,
-  Drawer,
-  IconButton,
-  Typography,
-  styled,
-  useTheme,
-} from "@mui/material";
+import { Divider, Drawer, IconButton, Typography, styled, useTheme } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import TreeView from "@mui/lab/TreeView";
@@ -13,10 +6,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import TreeItem from "@mui/lab/TreeItem";
 import { Link } from "react-router-dom";
-import {
-  oscalObjectTypes,
-  fetchAllResourcesOfType,
-} from "./oscal-utils/OSCALRestUtils";
+import { oscalObjectTypes, fetchAllResourcesOfType } from "./oscal-utils/OSCALRestUtils";
 import { OSCALMarkupLine } from "./OSCALMarkupProse";
 
 const DrawerHeader = styled("div")(({ theme }) => ({
@@ -85,9 +75,7 @@ function DocumentTree(props) {
                     onClick={handleClose}
                   >
                     <Typography noWrap>
-                      <OSCALMarkupLine>
-                        {oscalObject.metadata.title}
-                      </OSCALMarkupLine>
+                      <OSCALMarkupLine>{oscalObject.metadata.title}</OSCALMarkupLine>
                     </Typography>
                   </Link>
                 }
@@ -106,18 +94,11 @@ export default function OSCALDrawerSelector(props) {
     <StyledDrawer variant="persistent" anchor="left" open={props.open}>
       <DrawerHeader>
         <IconButton onClick={props.handleClose}>
-          {theme.direction === "ltr" ? (
-            <ChevronLeftIcon />
-          ) : (
-            <ChevronRightIcon />
-          )}
+          {theme.direction === "ltr" ? <ChevronLeftIcon /> : <ChevronRightIcon />}
         </IconButton>
       </DrawerHeader>
       <Divider />
-      <DocumentTree
-        backendUrl={props.backendUrl}
-        handleClose={props.handleClose}
-      />
+      <DocumentTree backendUrl={props.backendUrl} handleClose={props.handleClose} />
       <Divider />
     </StyledDrawer>
   );

--- a/packages/oscal-react-library/src/components/OSCALEditableFieldActions.test.js
+++ b/packages/oscal-react-library/src/components/OSCALEditableFieldActions.test.js
@@ -23,10 +23,7 @@ test("OSCALEditableFieldActions loads", () => {
   );
 });
 
-export default function testOSCALEditableFieldActions(
-  parentElementName,
-  renderer
-) {
+export default function testOSCALEditableFieldActions(parentElementName, renderer) {
   test(`${parentElementName} displays edit icon`, () => {
     renderer();
 
@@ -45,9 +42,7 @@ export default function testOSCALEditableFieldActions(
       })
       .click();
 
-    const textField = screen.getByTestId(
-      "textField-system-security-plan-metadata-title"
-    );
+    const textField = screen.getByTestId("textField-system-security-plan-metadata-title");
     expect(textField).toBeVisible();
   });
 

--- a/packages/oscal-react-library/src/components/OSCALEditableTextField.js
+++ b/packages/oscal-react-library/src/components/OSCALEditableTextField.js
@@ -1,17 +1,10 @@
 import React, { useRef, useState } from "react";
 import Typography from "@mui/material/Typography";
 import { Grid, TextField } from "@mui/material";
-import OSCALEditableFieldActions, {
-  getElementLabel,
-} from "./OSCALEditableFieldActions";
+import OSCALEditableFieldActions, { getElementLabel } from "./OSCALEditableFieldActions";
 import { OSCALMarkupLine } from "./OSCALMarkupProse";
 
-function textFieldWithEditableActions(
-  props,
-  reference,
-  inEditState,
-  setInEditState
-) {
+function textFieldWithEditableActions(props, reference, inEditState, setInEditState) {
   if (inEditState) {
     return (
       <>

--- a/packages/oscal-react-library/src/components/OSCALEditableTextField.test.js
+++ b/packages/oscal-react-library/src/components/OSCALEditableTextField.test.js
@@ -21,10 +21,7 @@ test("OSCALEditableTextField loads", () => {
   );
 });
 
-export default function testOSCALEditableTextField(
-  parentElementName,
-  renderer
-) {
+export default function testOSCALEditableTextField(parentElementName, renderer) {
   test(`${parentElementName} displays default value as "Test Title"`, () => {
     renderer();
 
@@ -34,9 +31,7 @@ export default function testOSCALEditableTextField(
       })
       .click();
 
-    const textField = screen.getByTestId(
-      "textField-system-security-plan-metadata-title"
-    );
+    const textField = screen.getByTestId("textField-system-security-plan-metadata-title");
     expect(textField.value).toEqual("Test Title");
     expect(textField).toBeVisible();
   });
@@ -50,9 +45,7 @@ export default function testOSCALEditableTextField(
       })
       .click();
 
-    const textField = screen.getByTestId(
-      "textField-system-security-plan-metadata-title"
-    );
+    const textField = screen.getByTestId("textField-system-security-plan-metadata-title");
 
     fireEvent.keyDown(textField, {
       key: "Escape",
@@ -71,18 +64,14 @@ export default function testOSCALEditableTextField(
       })
       .click();
 
-    const textField = screen.getByTestId(
-      "textField-system-security-plan-metadata-title"
-    );
+    const textField = screen.getByTestId("textField-system-security-plan-metadata-title");
 
     fireEvent.keyPress(textField, {
       key: "Enter",
       keyCode: 13,
     });
 
-    const textFieldAfterEvent = screen.getByTestId(
-      "textField-system-security-plan-metadata-title"
-    );
+    const textFieldAfterEvent = screen.getByTestId("textField-system-security-plan-metadata-title");
 
     expect(textFieldAfterEvent.value).toEqual(textField.value);
   });
@@ -96,18 +85,14 @@ export default function testOSCALEditableTextField(
       })
       .click();
 
-    const textField = screen.getByTestId(
-      "textField-system-security-plan-metadata-title"
-    );
+    const textField = screen.getByTestId("textField-system-security-plan-metadata-title");
     fireEvent.change(textField, { target: { value: "New Test Title" } });
     fireEvent.keyPress(textField, {
       key: "Enter",
       keyCode: 13,
     });
 
-    const textFieldAfterEvent = screen.getByTestId(
-      "textField-system-security-plan-metadata-title"
-    );
+    const textFieldAfterEvent = screen.getByTestId("textField-system-security-plan-metadata-title");
     expect(textFieldAfterEvent.value).toEqual("New Test Title");
   });
 }

--- a/packages/oscal-react-library/src/components/OSCALJsonEditor.js
+++ b/packages/oscal-react-library/src/components/OSCALJsonEditor.js
@@ -52,12 +52,7 @@ export default function OSCALJsonEditor(props) {
         />
       </Grid>
       <Grid item>
-        <ButtonGrid
-          container
-          spacing={2}
-          justifyContent="flex-end"
-          data-testid="button-grid"
-        >
+        <ButtonGrid container spacing={2} justifyContent="flex-end" data-testid="button-grid">
           <Grid item>
             <Button
               onClick={() => {

--- a/packages/oscal-react-library/src/components/OSCALJsonEditor.test.js
+++ b/packages/oscal-react-library/src/components/OSCALJsonEditor.test.js
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  render,
-  screen,
-  waitFor,
-  fireEvent,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import OSCALJsonEditor from "./OSCALJsonEditor";
 
 const oscalData = {
@@ -32,11 +26,7 @@ jest.mock(
   () =>
     function Editor(props) {
       const fragment = (
-        <textarea
-          data-testid="mocked-editor"
-          onChange={jest.fn()}
-          value={props.value}
-        />
+        <textarea data-testid="mocked-editor" onChange={jest.fn()} value={props.value} />
       );
       return fragment;
     }
@@ -119,8 +109,6 @@ describe("OSCALJsonEditor", () => {
     await waitFor(() => {
       expect(mockEditorRef.setValue).toBeCalledTimes(1);
     });
-    expect(mockEditorRef.setValue).toHaveBeenLastCalledWith(
-      oscalData.oscalSource
-    );
+    expect(mockEditorRef.setValue).toHaveBeenLastCalledWith(oscalData.oscalSource);
   });
 });

--- a/packages/oscal-react-library/src/components/OSCALLoader.js
+++ b/packages/oscal-react-library/src/components/OSCALLoader.js
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useCallback,
-  useEffect,
-  useRef,
-  useLayoutEffect,
-} from "react";
+import React, { useState, useCallback, useEffect, useRef, useLayoutEffect } from "react";
 import { useParams } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import { styled } from "@mui/material/styles";
@@ -73,11 +67,9 @@ export default function OSCALLoader(props) {
   // an error and to ensure.
   const [reloadCount, setReloadCount] = useState(0);
   const oscalObjectUuid = useParams()?.id ?? "";
-  const buildOscalUrl = (uuid) =>
-    `${props.backendUrl}/${props.oscalObjectType.restPath}/${uuid}`;
+  const buildOscalUrl = (uuid) => `${props.backendUrl}/${props.oscalObjectType.restPath}/${uuid}`;
   const determineDefaultOscalUrl = () =>
-    (props.isRestMode ? null : getRequestedUrl()) ||
-    props.oscalObjectType.defaultUrl;
+    (props.isRestMode ? null : getRequestedUrl()) || props.oscalObjectType.defaultUrl;
 
   const [oscalUrl, setOscalUrl] = useState(determineDefaultOscalUrl());
 
@@ -112,11 +104,7 @@ export default function OSCALLoader(props) {
     restUrlPath,
     oscalObjectType
   ) => {
-    const requestUrl = restUtils.buildRequestUrl(
-      partialRestData,
-      restUrlPath,
-      oscalObjectType
-    );
+    const requestUrl = restUtils.buildRequestUrl(partialRestData, restUrlPath, oscalObjectType);
 
     if (newValue) {
       restUtils.populatePartialRestData(
@@ -177,9 +165,7 @@ export default function OSCALLoader(props) {
 
   const handleFragment = useCallback(() => {
     // Ensure fragment exists and determine if a control grouping tab is found
-    const controlGroupingFragment = determineControlGroupFromFragment(
-      props.urlFragment
-    );
+    const controlGroupingFragment = determineControlGroupFromFragment(props.urlFragment);
     // Scroll to Element if not within a control grouping
     // NOTE: Control found in control grouping tabs are handled in Catalog Groups
     if (!controlGroupingFragment) {
@@ -305,10 +291,7 @@ export default function OSCALLoader(props) {
           sizes={editorIsVisible ? [34, 66] : [0, 100]}
         >
           <Box display={editorIsVisible ? "block" : "none"}>
-            <OSCALJsonEditor
-              value={oscalData.oscalSource}
-              onSave={handleRestPut}
-            />
+            <OSCALJsonEditor value={oscalData.oscalSource} onSave={handleRestPut} />
           </Box>
           <Box>
             {props.renderer(

--- a/packages/oscal-react-library/src/components/OSCALMarkupProse.js
+++ b/packages/oscal-react-library/src/components/OSCALMarkupProse.js
@@ -34,10 +34,5 @@ export function OSCALMarkupMultiLine(props) {
 }
 
 export function OSCALMarkupLine(props) {
-  return (
-    <ReactMarkdown
-      {...props}
-      components={{ ...baseComponents, p: React.Fragment }}
-    />
-  );
+  return <ReactMarkdown {...props} components={{ ...baseComponents, p: React.Fragment }} />;
 }

--- a/packages/oscal-react-library/src/components/OSCALMarkupProse.test.js
+++ b/packages/oscal-react-library/src/components/OSCALMarkupProse.test.js
@@ -10,20 +10,12 @@ test(`OSCALMarkupLine converts plaintext to HTML`, () => {
 });
 
 test(`OSCALMarkupLine converts Italics, Bold and Plaintext`, () => {
-  const html = asHtml(
-    <OSCALMarkupLine>*Hello*, **world** I am in markdown</OSCALMarkupLine>
-  );
-  expect(html).toEqual(
-    "<em>Hello</em>, <strong>world</strong> I am in markdown"
-  );
+  const html = asHtml(<OSCALMarkupLine>*Hello*, **world** I am in markdown</OSCALMarkupLine>);
+  expect(html).toEqual("<em>Hello</em>, <strong>world</strong> I am in markdown");
 });
 
 test(`OSCALMarkupLine converts hyperlinks to HTML`, () => {
-  render(
-    <OSCALMarkupLine>
-      [Link to EasyDynamics](https://www.easydynamics.com)]
-    </OSCALMarkupLine>
-  );
+  render(<OSCALMarkupLine>[Link to EasyDynamics](https://www.easydynamics.com)]</OSCALMarkupLine>);
   const a = screen.getByText("Link to EasyDynamics");
 
   expect(a.href).toEqual("https://www.easydynamics.com/");
@@ -36,9 +28,7 @@ test(`OSCALMarkupLine converts images to HTML`, () => {
 });
 
 test(`OSCALMarkupLine converts code to HTML`, () => {
-  const html = asHtml(
-    <OSCALMarkupLine>`Inserting Tester Code`</OSCALMarkupLine>
-  );
+  const html = asHtml(<OSCALMarkupLine>`Inserting Tester Code`</OSCALMarkupLine>);
   expect(html).toEqual("<code>Inserting Tester Code</code>");
 });
 
@@ -71,9 +61,7 @@ test(`OSCALMarkupMultiLine converts a multiline string to HTML`, () => {
 <h3>h3 Heading</h3>
 <p>This is in heading 3</p>
 <h4><strong>h4 Heading</strong></h4>`;
-  const html = asHtml(
-    <OSCALMarkupMultiLine>{multilineMarkdown}</OSCALMarkupMultiLine>
-  );
+  const html = asHtml(<OSCALMarkupMultiLine>{multilineMarkdown}</OSCALMarkupMultiLine>);
   expect(html).toEqual(multilineAsHTML);
 });
 

--- a/packages/oscal-react-library/src/components/OSCALMetadata.js
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.js
@@ -119,12 +119,8 @@ function TextWithIcon(props) {
 export function OSCALMetadataAddress(props) {
   const tryFormatAddress = (address) => {
     const lines = address["addr-lines"] ?? [];
-    const cityAndState = [address.city, address.state]
-      .filter((it) => it)
-      .join(", ");
-    const line = [cityAndState, address["postal-code"]]
-      .filter((it) => it)
-      .join(" ");
+    const cityAndState = [address.city, address.state].filter((it) => it).join(", ");
+    const line = [cityAndState, address["postal-code"]].filter((it) => it).join(" ");
     const allLines = [...lines, line, address.country].filter((it) => it);
     return allLines;
   };
@@ -203,11 +199,7 @@ function MetadataAvatar(props) {
       .substring(0, 2)
       .toUpperCase();
 
-  return (
-    <Avatar sx={{ bgcolor: avatarColor(id) }}>
-      {avatarValue(text) ?? fallbackIcon}
-    </Avatar>
-  );
+  return <Avatar sx={{ bgcolor: avatarColor(id) }}>{avatarValue(text) ?? fallbackIcon}</Avatar>;
 }
 
 const MetadataInfoTypes = {
@@ -222,33 +214,22 @@ const TYPE_MAPPING = (infoProps) => ({
   email: <OSCALMetadataEmail email={infoProps} />,
 });
 
-const getMetadataInfoList = (
-  list,
-  infoType,
-  emptyMessage = "No information provided"
-) => {
+const getMetadataInfoList = (list, infoType, emptyMessage = "No information provided") => {
   if (!list?.length) {
     return <Typography> {emptyMessage} </Typography>;
   }
 
   return list.map((item) => (
-    <ListItem
-      key={infoType === "email" ? item : `${item?.type}--${item?.name}`}
-    >
+    <ListItem key={infoType === "email" ? item : `${item?.type}--${item?.name}`}>
       {TYPE_MAPPING(item)[infoType]}
     </ListItem>
   ));
 };
 
 export function OSCALMetadataParty(props) {
-  const fallbackIcon =
-    props.party?.type === "organziation" ? <GroupIcon /> : <PersonIcon />;
+  const fallbackIcon = props.party?.type === "organziation" ? <GroupIcon /> : <PersonIcon />;
   const avatar = (
-    <MetadataAvatar
-      id={props.party.uuid}
-      text={props.party.name}
-      fallbackIcon={fallbackIcon}
-    />
+    <MetadataAvatar id={props.party.uuid} text={props.party.name} fallbackIcon={fallbackIcon} />
   );
 
   return (
@@ -271,10 +252,7 @@ export function OSCALMetadataParty(props) {
       <DialogContent dividers>
         <Grid container spacing={1}>
           <Grid item xs={4}>
-            <OSCALMetadataContactTypeHeader
-              icon={<MapIcon fontSize="small" />}
-              title="Address"
-            />
+            <OSCALMetadataContactTypeHeader icon={<MapIcon fontSize="small" />} title="Address" />
             <List>
               {getMetadataInfoList(
                 props.party.addresses,
@@ -284,10 +262,7 @@ export function OSCALMetadataParty(props) {
             </List>
           </Grid>
           <Grid item xs={4}>
-            <OSCALMetadataContactTypeHeader
-              icon={<PhoneIcon fontSize="small" />}
-              title="Phone"
-            />
+            <OSCALMetadataContactTypeHeader icon={<PhoneIcon fontSize="small" />} title="Phone" />
             <List>
               {getMetadataInfoList(
                 props.party["telephone-numbers"],
@@ -297,10 +272,7 @@ export function OSCALMetadataParty(props) {
             </List>
           </Grid>
           <Grid item xs={4}>
-            <OSCALMetadataContactTypeHeader
-              icon={<EmailIcon fontSize="small" />}
-              title="Email"
-            />
+            <OSCALMetadataContactTypeHeader icon={<EmailIcon fontSize="small" />} title="Email" />
             <List>
               {getMetadataInfoList(
                 props.party["email-addresses"],
@@ -318,13 +290,7 @@ export function OSCALMetadataParty(props) {
 export function OSCALMetadataRole(props) {
   const { role } = props;
 
-  const avatar = (
-    <MetadataAvatar
-      id={role.id}
-      text={role.title}
-      fallbackIcon={<WorkIcon />}
-    />
-  );
+  const avatar = <MetadataAvatar id={role.id} text={role.title} fallbackIcon={<WorkIcon />} />;
 
   return (
     <OSCALMetadataCard
@@ -357,9 +323,7 @@ function OSCALMetadataCard(props) {
   const cardTitle = title ? (
     <OSCALMarkupLine>{title}</OSCALMarkupLine>
   ) : (
-    <OSCALMetadataCardTitleFallbackText>
-      Not Specified
-    </OSCALMetadataCardTitleFallbackText>
+    <OSCALMetadataCardTitleFallbackText>Not Specified</OSCALMetadataCardTitleFallbackText>
   );
 
   return (
@@ -409,17 +373,11 @@ function OSCALMetadataBasicData(props) {
   return (
     <Stack direction="row" spacing={4}>
       <Stack direction="row" spacing={1}>
-        <OSCALMetadataLabel variant="body2">
-          Document Version:
-        </OSCALMetadataLabel>
+        <OSCALMetadataLabel variant="body2">Document Version:</OSCALMetadataLabel>
         <OSCALEditableTextField
           fieldName="Version"
           canEdit={isEditable}
-          editedField={
-            isEditable
-              ? [Object.keys(partialRestData)[0], "metadata", "version"]
-              : null
-          }
+          editedField={isEditable ? [Object.keys(partialRestData)[0], "metadata", "version"] : null}
           onFieldSave={onFieldSave}
           partialRestData={
             isEditable
@@ -439,10 +397,7 @@ function OSCALMetadataBasicData(props) {
           value={metadata.version}
         />
       </Stack>
-      <OSCALMetadataBasicDataItem
-        title="OSCAL Version:"
-        data={metadata["oscal-version"]}
-      />
+      <OSCALMetadataBasicDataItem title="OSCAL Version:" data={metadata["oscal-version"]} />
       <OSCALMetadataBasicDataItem
         title="Last Modified:"
         data={formatDate(metadata["last-modified"])}
@@ -473,24 +428,18 @@ function OSCALMetadataRoles(props) {
 function OSCALMetadataParties(props) {
   const { parties, urlFragment } = props;
 
-  const getRoleLabel = (roleId) =>
-    props.metadata.roles.find((role) => role.id === roleId);
+  const getRoleLabel = (roleId) => props.metadata.roles.find((role) => role.id === roleId);
 
   const getPartyRolesText = (party) =>
     props.metadata["responsible-parties"]
-      ?.filter((responsibleParty) =>
-        responsibleParty["party-uuids"]?.includes(party.uuid)
-      )
+      ?.filter((responsibleParty) => responsibleParty["party-uuids"]?.includes(party.uuid))
       .map((item) => item["role-id"])
       .map(getRoleLabel)
       .filter((item) => item);
 
   const cards = parties?.map((party) => (
     <Grid item xs={12} md={4} key={party.uuid} component={Card}>
-      <OSCALMetadataParty
-        party={party}
-        partyRolesText={getPartyRolesText(party)}
-      />
+      <OSCALMetadataParty party={party} partyRolesText={getPartyRolesText(party)} />
     </Grid>
   ));
 
@@ -544,17 +493,11 @@ export function OSCALMetadataLocationContent(props) {
     <Stack spacing={2}>
       <Grid container>
         <Grid item xs={4}>
-          <OSCALMetadataContactTypeHeader
-            icon={<MapIcon fontSize="small" />}
-            title="Address"
-          />
+          <OSCALMetadataContactTypeHeader icon={<MapIcon fontSize="small" />} title="Address" />
           <OSCALMetadataAddress address={location.address} />
         </Grid>
         <Grid item xs={4}>
-          <OSCALMetadataContactTypeHeader
-            icon={<PhoneIcon fontSize="small" />}
-            title="Phone"
-          />
+          <OSCALMetadataContactTypeHeader icon={<PhoneIcon fontSize="small" />} title="Phone" />
           <List>
             {getMetadataInfoList(
               location["telephone-numbers"],
@@ -564,10 +507,7 @@ export function OSCALMetadataLocationContent(props) {
           </List>
         </Grid>
         <Grid item xs={4}>
-          <OSCALMetadataContactTypeHeader
-            icon={<EmailIcon fontSize="small" />}
-            title="Email"
-          />
+          <OSCALMetadataContactTypeHeader icon={<EmailIcon fontSize="small" />} title="Email" />
           <List>
             {getMetadataInfoList(
               location["email-addresses"],
@@ -586,11 +526,7 @@ export function OSCALMetadataLocation(props) {
   const { location } = props;
 
   const avatar = (
-    <MetadataAvatar
-      id={location.uuid}
-      text={location.title}
-      fallbackIcon={<PlaceIcon />}
-    />
+    <MetadataAvatar id={location.uuid} text={location.title} fallbackIcon={<PlaceIcon />} />
   );
 
   return (
@@ -675,18 +611,14 @@ export default function OSCALMetadata(props) {
             fieldName="Title"
             canEdit={props.isEditable}
             editedField={
-              props.isEditable
-                ? [Object.keys(props.partialRestData)[0], "metadata", "title"]
-                : null
+              props.isEditable ? [Object.keys(props.partialRestData)[0], "metadata", "title"] : null
             }
             onFieldSave={props.onFieldSave}
             partialRestData={
               props.isEditable
                 ? {
                     [Object.keys(props.partialRestData)[0]]: {
-                      uuid: props.partialRestData[
-                        Object.keys(props.partialRestData)[0]
-                      ].uuid,
+                      uuid: props.partialRestData[Object.keys(props.partialRestData)[0]].uuid,
                       metadata: {
                         title: props.metadata.title,
                       },
@@ -712,9 +644,7 @@ export default function OSCALMetadata(props) {
                 onFieldSave={props.onFieldSave}
               />
             </OSCALMetadataSection>
-            <OSCALMarkupMultiLine>
-              {props.metadata.remarks}
-            </OSCALMarkupMultiLine>
+            <OSCALMarkupMultiLine>{props.metadata.remarks}</OSCALMarkupMultiLine>
             <OSCALMetadataKeywords
               keywords={propWithName(props.metadata.props, "keywords")?.value}
               urlFragment={props.urlFragment}
@@ -724,10 +654,7 @@ export default function OSCALMetadata(props) {
               metadata={props.metadata}
               urlFragment={props.urlFragment}
             />
-            <OSCALMetadataRoles
-              roles={props.metadata?.roles}
-              urlFragment={props.urlFragment}
-            />
+            <OSCALMetadataRoles roles={props.metadata?.roles} urlFragment={props.urlFragment} />
             <OSCALMetadataLocations
               locations={props.metadata?.locations}
               urlFragment={props.urlFragment}

--- a/packages/oscal-react-library/src/components/OSCALMetadata.test.js
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.test.js
@@ -60,9 +60,7 @@ describe("OSCAL metadata parties", () => {
     button.click();
 
     expect(screen.getByText("Email")).toBeVisible();
-    expect(
-      screen.getByRole("link", { name: /owners@email\.org/i })
-    ).toBeVisible();
+    expect(screen.getByRole("link", { name: /owners@email\.org/i })).toBeVisible();
   });
 
   test(`displays telephone mobile number info`, () => {
@@ -265,9 +263,7 @@ describe("OSCAL metadata locations", () => {
     button.click();
 
     expect(screen.getByText("Email")).toBeVisible();
-    expect(
-      screen.getByRole("link", { name: /owners@email\.org/i })
-    ).toBeVisible();
+    expect(screen.getByRole("link", { name: /owners@email\.org/i })).toBeVisible();
   });
 
   test(`display url list`, () => {
@@ -282,9 +278,7 @@ describe("OSCAL metadata locations", () => {
     button.click();
 
     expect(screen.getByText("URLs")).toBeVisible();
-    expect(
-      screen.getByRole("link", { name: /www\.website\.com/i })
-    ).toBeVisible();
+    expect(screen.getByRole("link", { name: /www\.website\.com/i })).toBeVisible();
   });
 });
 

--- a/packages/oscal-react-library/src/components/OSCALProfile.js
+++ b/packages/oscal-react-library/src/components/OSCALProfile.js
@@ -22,8 +22,7 @@ import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
  */
 export default function OSCALProfile(props) {
   const [error, setError] = useState(null);
-  const [inheritedProfilesAndCatalogs, setInheritedProfilesAndCatalogs] =
-    useState({});
+  const [inheritedProfilesAndCatalogs, setInheritedProfilesAndCatalogs] = useState({});
   const [isLoaded, setIsLoaded] = useState(false);
   const unmounted = useRef(false);
 
@@ -80,11 +79,7 @@ export default function OSCALProfile(props) {
       subheader={
         <Grid container spacing={2}>
           <Grid item xs={6}>
-            <ListSubheader
-              component="div"
-              id="oscal-profile-importedControls"
-              disableSticky
-            >
+            <ListSubheader component="div" id="oscal-profile-importedControls" disableSticky>
               <OSCALAnchorLinkHeader>Imported Controls</OSCALAnchorLinkHeader>
             </ListSubheader>
           </Grid>
@@ -114,10 +109,7 @@ export default function OSCALProfile(props) {
         ))
       ) : (
         <CardContent key="skeleton-card">
-          <span
-            style={{ marginTop: 5, display: "flex", gap: "1em" }}
-            key="controls load 0"
-          >
+          <span style={{ marginTop: 5, display: "flex", gap: "1em" }} key="controls load 0">
             <Skeleton variant="text" width="25em" height="3em" />
             <Skeleton variant="circular" width="3em" height="3em" />
           </span>
@@ -139,14 +131,9 @@ export default function OSCALProfile(props) {
         partialRestData={partialRestData}
         urlFragment={props.urlFragment}
       />
-      <OSCALProfileCatalogInheritance
-        inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs}
-      />
+      <OSCALProfileCatalogInheritance inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs} />
       {profileImports}
-      <OSCALBackMatter
-        backMatter={props.profile["back-matter"]}
-        parentUrl={props.parentUrl}
-      />
+      <OSCALBackMatter backMatter={props.profile["back-matter"]} parentUrl={props.parentUrl} />
     </OSCALDocumentRoot>
   );
 }

--- a/packages/oscal-react-library/src/components/OSCALProfile.test.js
+++ b/packages/oscal-react-library/src/components/OSCALProfile.test.js
@@ -32,10 +32,9 @@ function testOSCALProfile(parentElementName, renderer) {
 
   test(`${parentElementName} displays parameter constraints`, async () => {
     renderer();
-    const result = await screen.findAllByText(
-      "< organization-defined frequency >",
-      { timeout: 5000 }
-    );
+    const result = await screen.findAllByText("< organization-defined frequency >", {
+      timeout: 5000,
+    });
     fireEvent.mouseOver(result[0]);
     expect(await screen.findByText("at least every 3 years")).toBeVisible();
   });

--- a/packages/oscal-react-library/src/components/OSCALProfileCatalogInheritance.js
+++ b/packages/oscal-react-library/src/components/OSCALProfileCatalogInheritance.js
@@ -28,18 +28,14 @@ export default function OSCALProfileCatalogInheritance(props) {
       <Card>
         <CardContent>
           <OSCALAnchorLinkHeader value="profile-catalog-inheritance">
-            <OSCALSectionHeader>
-              Profiles/Catalog Inheritance
-            </OSCALSectionHeader>
+            <OSCALSectionHeader>Profiles/Catalog Inheritance</OSCALSectionHeader>
           </OSCALAnchorLinkHeader>
           <TreeView
             defaultCollapseIcon={<ExpandMoreIcon />}
             defaultExpandIcon={<ChevronRightIcon />}
             multiSelect
           >
-            {props.inheritedProfilesAndCatalogs.inherited?.map((item) =>
-              inheritedListItem(item)
-            )}
+            {props.inheritedProfilesAndCatalogs.inherited?.map((item) => inheritedListItem(item))}
           </TreeView>
         </CardContent>
       </Card>

--- a/packages/oscal-react-library/src/components/OSCALResponsibleRoles.js
+++ b/packages/oscal-react-library/src/components/OSCALResponsibleRoles.js
@@ -31,9 +31,7 @@ export default function OSCALResponsibleRoles(props) {
                 </TableCell>
                 <TableCell align="right">
                   {role["party-uuids"] &&
-                    role["party-uuids"].map((partyUuid) =>
-                      getPartyName(partyUuid)
-                    )}
+                    role["party-uuids"].map((partyUuid) => getPartyName(partyUuid))}
                 </TableCell>
               </TableRow>
             ))}

--- a/packages/oscal-react-library/src/components/OSCALResponsibleRoles.test.js
+++ b/packages/oscal-react-library/src/components/OSCALResponsibleRoles.test.js
@@ -1,10 +1,7 @@
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import OSCALResponsibleRoles from "./OSCALResponsibleRoles";
-import {
-  metadataTestData,
-  responsibleRolesTestData,
-} from "../test-data/CommonData";
+import { metadataTestData, responsibleRolesTestData } from "../test-data/CommonData";
 
 describe("OSCALResponsibleRoles", () => {
   test(`shows component roles`, () => {
@@ -20,9 +17,7 @@ describe("OSCALResponsibleRoles", () => {
     const rowHeader = within(responsibleRolesRow).getByRole("rowheader");
     expect(rowHeader).toHaveTextContent("provider");
 
-    const rowData = within(responsibleRolesRow).getByText(
-      "Some group of people"
-    );
+    const rowData = within(responsibleRolesRow).getByText("Some group of people");
     expect(rowData).toBeVisible();
   });
 });

--- a/packages/oscal-react-library/src/components/OSCALSsp.js
+++ b/packages/oscal-react-library/src/components/OSCALSsp.js
@@ -10,8 +10,7 @@ import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 
 export default function OSCALSsp(props) {
   const [error, setError] = useState(null);
-  const [inheritedProfilesAndCatalogs, setInheritedProfilesAndCatalogs] =
-    useState({});
+  const [inheritedProfilesAndCatalogs, setInheritedProfilesAndCatalogs] = useState({});
   const [isLoaded, setIsLoaded] = useState(false);
   const unmounted = useRef(false);
 
@@ -80,9 +79,7 @@ export default function OSCALSsp(props) {
         partialRestData={partialRestData}
         urlFragment={props.urlFragment}
       />
-      <OSCALProfileCatalogInheritance
-        inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs}
-      />
+      <OSCALProfileCatalogInheritance inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs} />
       <OSCALSystemCharacteristics
         systemCharacteristics={ssp["system-characteristics"]}
         backMatter={ssp["back-matter"]}
@@ -94,10 +91,7 @@ export default function OSCALSsp(props) {
         components={ssp["system-implementation"].components}
       />
       {controlImpl}
-      <OSCALBackMatter
-        backMatter={ssp["back-matter"]}
-        parentUrl={props.parentUrl}
-      />
+      <OSCALBackMatter backMatter={ssp["back-matter"]} parentUrl={props.parentUrl} />
     </OSCALDocumentRoot>
   );
 }

--- a/packages/oscal-react-library/src/components/OSCALSsp.test.js
+++ b/packages/oscal-react-library/src/components/OSCALSsp.test.js
@@ -18,12 +18,7 @@ function sspRenderer() {
 
 function sspRendererRestMode() {
   render(
-    <OSCALSsp
-      system-security-plan={sspTestData}
-      isEditable
-      parentUrl="./"
-      onFieldSave={() => {}}
-    />
+    <OSCALSsp system-security-plan={sspTestData} isEditable parentUrl="./" onFieldSave={() => {}} />
   );
 }
 

--- a/packages/oscal-react-library/src/components/OSCALSystemCharacteristics.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemCharacteristics.js
@@ -40,9 +40,7 @@ export default function OSCALSystemCharacteristics(props) {
               </Typography>
             </Grid>
             <Grid item xs={6}>
-              <Typography variant="body2">
-                {props.systemCharacteristics.description}
-              </Typography>
+              <Typography variant="body2">{props.systemCharacteristics.description}</Typography>
             </Grid>
             <Grid item xs={6}>
               <TableContainer>
@@ -78,9 +76,7 @@ export default function OSCALSystemCharacteristics(props) {
                 disabled
                 id="security-sensitivity-level"
                 label="sensitivity-level"
-                defaultValue={
-                  props.systemCharacteristics["security-sensitivity-level"]
-                }
+                defaultValue={props.systemCharacteristics["security-sensitivity-level"]}
                 variant="outlined"
                 margin="dense"
                 fullWidth
@@ -144,102 +140,83 @@ export default function OSCALSystemCharacteristics(props) {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {props.systemCharacteristics["system-information"][
-                      "information-types"
-                    ].map((informationType) => (
-                      <TableRow key={informationType.uuid}>
-                        <TableCell component="th" scope="row">
-                          <StyledTooltip title={informationType.description}>
-                            <Typography variant="body2">
-                              {informationType.title}
-                            </Typography>
-                          </StyledTooltip>
-                        </TableCell>
-                        <TableCell>
-                          {informationType.categorizations?.map(
-                            (categorization) =>
-                              categorization["information-type-ids"].map(
-                                (infoId) => (
-                                  <Chip
-                                    icon={
-                                      categorization.system.startsWith(
-                                        "http"
-                                      ) ? (
-                                        <OpenInNewIcon />
-                                      ) : null
-                                    }
-                                    label={infoId}
-                                    component="a"
-                                    href={categorization.system}
-                                    clickable
-                                    variant="outlined"
-                                    key={infoId}
-                                  />
-                                )
-                              )
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {informationType["confidentiality-impact"] &&
-                            informationType["confidentiality-impact"].base}
-                        </TableCell>
-                        <TableCell>
-                          {informationType["integrity-impact"] &&
-                            informationType["integrity-impact"].base}
-                        </TableCell>
-                        <TableCell>
-                          {informationType["availability-impact"] &&
-                            informationType["availability-impact"].base}
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                    {props.systemCharacteristics["system-information"]["information-types"].map(
+                      (informationType) => (
+                        <TableRow key={informationType.uuid}>
+                          <TableCell component="th" scope="row">
+                            <StyledTooltip title={informationType.description}>
+                              <Typography variant="body2">{informationType.title}</Typography>
+                            </StyledTooltip>
+                          </TableCell>
+                          <TableCell>
+                            {informationType.categorizations?.map((categorization) =>
+                              categorization["information-type-ids"].map((infoId) => (
+                                <Chip
+                                  icon={
+                                    categorization.system.startsWith("http") ? (
+                                      <OpenInNewIcon />
+                                    ) : null
+                                  }
+                                  label={infoId}
+                                  component="a"
+                                  href={categorization.system}
+                                  clickable
+                                  variant="outlined"
+                                  key={infoId}
+                                />
+                              ))
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {informationType["confidentiality-impact"] &&
+                              informationType["confidentiality-impact"].base}
+                          </TableCell>
+                          <TableCell>
+                            {informationType["integrity-impact"] &&
+                              informationType["integrity-impact"].base}
+                          </TableCell>
+                          <TableCell>
+                            {informationType["availability-impact"] &&
+                              informationType["availability-impact"].base}
+                          </TableCell>
+                        </TableRow>
+                      )
+                    )}
                   </TableBody>
                 </Table>
               </TableContainer>
             </Grid>
             <Grid item xs={12}>
               <Typography variant="subtitle1" gutterBottom component="div">
-                <OSCALAnchorLinkHeader>
-                  Authorization Boundary
-                </OSCALAnchorLinkHeader>
+                <OSCALAnchorLinkHeader>Authorization Boundary</OSCALAnchorLinkHeader>
               </Typography>
               <Typography variant="body2">
-                {
-                  props.systemCharacteristics?.["authorization-boundary"]
-                    ?.description
-                }
+                {props.systemCharacteristics?.["authorization-boundary"]?.description}
               </Typography>
               <Grid container spacing={2} justifyContent="center">
-                {props.systemCharacteristics?.[
-                  "authorization-boundary"
-                ]?.diagrams?.map((diagram) => (
-                  <Grid item xs={6} key={diagram.uuid}>
-                    <OSCALDiagram
-                      diagram={diagram}
-                      backMatter={props.backMatter}
-                      parentUrl={props.parentUrl}
-                      mediaTypeRegex={/^image\//}
-                    />
-                  </Grid>
-                ))}
+                {props.systemCharacteristics?.["authorization-boundary"]?.diagrams?.map(
+                  (diagram) => (
+                    <Grid item xs={6} key={diagram.uuid}>
+                      <OSCALDiagram
+                        diagram={diagram}
+                        backMatter={props.backMatter}
+                        parentUrl={props.parentUrl}
+                        mediaTypeRegex={/^image\//}
+                      />
+                    </Grid>
+                  )
+                )}
               </Grid>
             </Grid>
             <Grid item xs={12}>
               <Typography variant="subtitle1" gutterBottom component="div">
-                <OSCALAnchorLinkHeader>
-                  Network Architecture
-                </OSCALAnchorLinkHeader>
+                <OSCALAnchorLinkHeader>Network Architecture</OSCALAnchorLinkHeader>
               </Typography>
               <Typography variant="body2">
-                {
-                  props.systemCharacteristics?.["network-architecture"]
-                    ?.description
-                }
+                {props.systemCharacteristics?.["network-architecture"]?.description}
               </Typography>
               <Grid container spacing={2} justifyContent="center">
-                {props.systemCharacteristics?.[
-                  "network-architecture"
-                ]?.diagrams?.map((diagram) => (
+                {props.systemCharacteristics?.["network-architecture"]?.diagrams?.map((diagram) => (
                   <Grid item xs={6} key={diagram.uuid}>
                     <OSCALDiagram
                       diagram={diagram}
@@ -259,18 +236,16 @@ export default function OSCALSystemCharacteristics(props) {
                 {props.systemCharacteristics?.["data-flow"]?.description}
               </Typography>
               <Grid container spacing={2} justifyContent="center">
-                {props.systemCharacteristics?.["data-flow"]?.diagrams?.map(
-                  (diagram) => (
-                    <Grid item xs={6} key={diagram.uuid}>
-                      <OSCALDiagram
-                        diagram={diagram}
-                        backMatter={props.backMatter}
-                        parentUrl={props.parentUrl}
-                        mediaTypeRegex={/^image\//}
-                      />
-                    </Grid>
-                  )
-                )}
+                {props.systemCharacteristics?.["data-flow"]?.diagrams?.map((diagram) => (
+                  <Grid item xs={6} key={diagram.uuid}>
+                    <OSCALDiagram
+                      diagram={diagram}
+                      backMatter={props.backMatter}
+                      parentUrl={props.parentUrl}
+                      mediaTypeRegex={/^image\//}
+                    />
+                  </Grid>
+                ))}
               </Grid>
             </Grid>
           </Grid>

--- a/packages/oscal-react-library/src/components/OSCALSystemCharacteristics.test.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemCharacteristics.test.js
@@ -13,10 +13,7 @@ function systemCharacteristicsRenderer() {
   );
 }
 
-export default function testOSCALSystemCharacteristics(
-  parentElementName,
-  renderer
-) {
+export default function testOSCALSystemCharacteristics(parentElementName, renderer) {
   test(`${parentElementName} shows system name`, () => {
     renderer();
     const result = screen.getByRole("heading", { name: "Example System Name" });
@@ -55,8 +52,5 @@ export default function testOSCALSystemCharacteristics(
   });
 }
 if (!require.main) {
-  testOSCALSystemCharacteristics(
-    "OSCALSystemCharacteristics",
-    systemCharacteristicsRenderer
-  );
+  testOSCALSystemCharacteristics("OSCALSystemCharacteristics", systemCharacteristicsRenderer);
 }

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementation.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementation.js
@@ -31,9 +31,7 @@ export default function OSCALSystemImplementation(props) {
               </OSCALMarkupMultiLine>
             </Grid>
             <Grid item xs={12}>
-              <OSCALSystemImplementationUsers
-                users={props.systemImplementation.users}
-              />
+              <OSCALSystemImplementationUsers users={props.systemImplementation.users} />
             </Grid>
             <Grid item xs={12}>
               <OSCALSystemImplementationComponents

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationComponents.test.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationComponents.test.js
@@ -36,9 +36,7 @@ describe("OSCALSystemImplementationComponents", () => {
       />
     );
     await userEvent.hover(screen.getByText("Example Component"));
-    expect(
-      await screen.findByText("An example component.")
-    ).toBeInTheDocument();
+    expect(await screen.findByText("An example component.")).toBeInTheDocument();
   });
 
   test(`shows component status`, () => {
@@ -51,14 +49,10 @@ describe("OSCALSystemImplementationComponents", () => {
     // Grab example party row beneath heading row
     const exampleResponsiblePartiesRow = screen.getAllByRole("row")[1];
 
-    const component = within(exampleResponsiblePartiesRow).getByText(
-      "Example Component"
-    );
+    const component = within(exampleResponsiblePartiesRow).getByText("Example Component");
     expect(component).toBeVisible();
 
-    const result = within(exampleResponsiblePartiesRow).getByText(
-      "operational"
-    );
+    const result = within(exampleResponsiblePartiesRow).getByText("operational");
     expect(result).toBeVisible();
   });
 
@@ -72,9 +66,7 @@ describe("OSCALSystemImplementationComponents", () => {
     // Grab example party row beneath heading row
     const exampleResponsiblePartiesRow = screen.getAllByRole("row")[1];
 
-    const component = within(exampleResponsiblePartiesRow).getByText(
-      "Example Component"
-    );
+    const component = within(exampleResponsiblePartiesRow).getByText("Example Component");
     expect(component).toBeVisible();
 
     const result = within(exampleResponsiblePartiesRow).getByText("software");
@@ -91,18 +83,12 @@ describe("OSCALSystemImplementationComponents", () => {
     // Grab example party row beneath heading row
     const exampleResponsiblePartiesRow = screen.getAllByRole("row")[1];
 
-    const component = within(exampleResponsiblePartiesRow).getByText(
-      "Example Component"
-    );
+    const component = within(exampleResponsiblePartiesRow).getByText("Example Component");
     expect(component).toBeVisible();
 
-    const propNameResult = within(exampleResponsiblePartiesRow).getByText(
-      "version"
-    );
+    const propNameResult = within(exampleResponsiblePartiesRow).getByText("version");
     expect(propNameResult).toBeVisible();
-    const propValueResult = within(exampleResponsiblePartiesRow).getByText(
-      "1.1"
-    );
+    const propValueResult = within(exampleResponsiblePartiesRow).getByText("1.1");
     expect(propValueResult).toBeVisible();
   });
 });

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationInventoryItems.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationInventoryItems.js
@@ -26,9 +26,7 @@ function OSCALResponsibleParties(props) {
               <TableCell component="th" scope="row">
                 {party["role-id"]}
               </TableCell>
-              <TableCell align="right">
-                {party["party-uuids"]?.map(getPartyName)}
-              </TableCell>
+              <TableCell align="right">{party["party-uuids"]?.map(getPartyName)}</TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -71,9 +69,7 @@ function ImplementedComponents(props) {
   );
 }
 
-export default function OSCALOSCALSystemImplementationTableTitleInventoryItems(
-  props
-) {
+export default function OSCALOSCALSystemImplementationTableTitleInventoryItems(props) {
   if (!props.inventoryItems) {
     return null;
   }
@@ -91,9 +87,7 @@ export default function OSCALOSCALSystemImplementationTableTitleInventoryItems(
               <StyledHeaderTableCell>Item</StyledHeaderTableCell>
               <StyledHeaderTableCell>Properties</StyledHeaderTableCell>
               <StyledHeaderTableCell>Responsible Parties</StyledHeaderTableCell>
-              <StyledHeaderTableCell>
-                Implemented Components
-              </StyledHeaderTableCell>
+              <StyledHeaderTableCell>Implemented Components</StyledHeaderTableCell>
               <StyledHeaderTableCell>Remarks</StyledHeaderTableCell>
             </TableRow>
           </StyledTableHead>
@@ -112,9 +106,7 @@ export default function OSCALOSCALSystemImplementationTableTitleInventoryItems(
                 </TableCell>
                 <TableCell>
                   <ImplementedComponents
-                    implementedComponents={
-                      inventoryItem["implemented-components"]
-                    }
+                    implementedComponents={inventoryItem["implemented-components"]}
                     components={props.components}
                   />
                 </TableCell>

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationInventoryItems.test.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationInventoryItems.test.js
@@ -1,10 +1,7 @@
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import { responsiblePartiesTestData } from "../test-data/CommonData";
-import {
-  inventoryItemsTestData,
-  componentsTestData,
-} from "../test-data/SystemData";
+import { inventoryItemsTestData, componentsTestData } from "../test-data/SystemData";
 import OSCALSystemImplementationInventoryItems from "./OSCALSystemImplementationInventoryItems";
 
 const setup = () => {
@@ -60,14 +57,10 @@ describe("OSCALSystemImplementationInventoryItems", () => {
     // Grab example party row beneath heading row
     const exampleResponsiblePartiesRow = screen.getAllByRole("row")[1];
 
-    const component = within(exampleResponsiblePartiesRow).getByText(
-      "Example Component"
-    );
+    const component = within(exampleResponsiblePartiesRow).getByText("Example Component");
     expect(component).toBeVisible();
 
-    const propNameResult = within(exampleResponsiblePartiesRow).getByText(
-      "software"
-    );
+    const propNameResult = within(exampleResponsiblePartiesRow).getByText("software");
     expect(propNameResult).toBeVisible();
   });
 });

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.js
@@ -44,9 +44,7 @@ function AuthorizedPrivilegesTable(props) {
                 </StyledTooltip>
               </TableCell>
               <TableCell>
-                <FunctionsPreformedTable
-                  functions={privilege["functions-performed"]}
-                />
+                <FunctionsPreformedTable functions={privilege["functions-performed"]} />
               </TableCell>
             </TableRow>
           ))}
@@ -86,9 +84,7 @@ export default function OSCALSystemImplementationUsers(props) {
               <StyledHeaderTableCell>Short Name</StyledHeaderTableCell>
               <StyledHeaderTableCell>Properties</StyledHeaderTableCell>
               <StyledHeaderTableCell>Role IDs</StyledHeaderTableCell>
-              <StyledHeaderTableCell>
-                Authorized Privileges
-              </StyledHeaderTableCell>
+              <StyledHeaderTableCell>Authorized Privileges</StyledHeaderTableCell>
             </TableRow>
           </StyledTableHead>
           <TableBody>
@@ -107,9 +103,7 @@ export default function OSCALSystemImplementationUsers(props) {
                   <RoleIdTable roleIds={user["role-ids"]} />
                 </TableCell>
                 <TableCell>
-                  <AuthorizedPrivilegesTable
-                    authorizedPrivileges={user["authorized-privileges"]}
-                  />
+                  <AuthorizedPrivilegesTable authorizedPrivileges={user["authorized-privileges"]} />
                 </TableCell>
               </StyledTableRow>
             ))}

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.test.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.test.js
@@ -44,9 +44,7 @@ describe("OSCALSystemImplementationUsers", () => {
   test("shows 'Authorized Privileges' description", async () => {
     render(<OSCALSystemImplementationUsers users={usersTestData} />);
     await userEvent.hover(screen.getByText("privilege title"));
-    expect(
-      await screen.findByText("privilege description")
-    ).toBeInTheDocument();
+    expect(await screen.findByText("privilege description")).toBeInTheDocument();
   });
 
   test("shows read function preformed", () => {

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALBackMatterUtils.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALBackMatterUtils.js
@@ -17,9 +17,7 @@ export default class BackMatterLookup {
    * @returns ResolvedUri {string} or undefined
    */
   resolveUuid(uuid, mediaType) {
-    const resource = this.#backMatter.resources.find(
-      (item) => item.uuid === uuid
-    );
+    const resource = this.#backMatter.resources.find((item) => item.uuid === uuid);
 
     if (!this.#preferBase64) {
       const rlink = resource?.rlinks?.find((item) => {
@@ -55,10 +53,7 @@ export default class BackMatterLookup {
     }
 
     return {
-      uri: `data:${base64["media-type"]};base64,${base64.value.replace(
-        "\n",
-        ""
-      )}`,
+      uri: `data:${base64["media-type"]};base64,${base64.value.replace("\n", "")}`,
       mediaType: base64["media-type"],
     };
   }

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALBackMatterUtils.test.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALBackMatterUtils.test.js
@@ -117,10 +117,7 @@ describe("BackMatterLookup", () => {
   test("handles base64 resource without mediaType", () => {
     const lookup = new BackMatterLookup(backMatter);
 
-    const resource = lookup.resolve(
-      base64ResourceNoMediaType.uri,
-      mediaTypeRegex
-    );
+    const resource = lookup.resolve(base64ResourceNoMediaType.uri, mediaTypeRegex);
 
     expect(resource).toBeUndefined();
   });
@@ -136,10 +133,7 @@ describe("BackMatterLookup", () => {
   test("handles base64 resource with wrong media type", () => {
     const lookup = new BackMatterLookup(backMatter);
 
-    const resource = lookup.resolve(
-      base64ResourceWrongMediaType.uri,
-      mediaTypeRegex
-    );
+    const resource = lookup.resolve(base64ResourceWrongMediaType.uri, mediaTypeRegex);
 
     expect(resource).toBeUndefined();
   });

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALControlResolver.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALControlResolver.js
@@ -41,11 +41,7 @@ export default function getControlOrSubControl(resolvedControls, controlId) {
  * @param {string} componentId Id of a component
  * @returns Returns the by-component object when a statement is found
  */
-export function getStatementByComponent(
-  implReqStatements,
-  statementId,
-  componentId
-) {
+export function getStatementByComponent(implReqStatements, statementId, componentId) {
   const foundStatement = implReqStatements?.find(
     (statement) => statement["statement-id"] === statementId
   );

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.js
@@ -70,15 +70,10 @@ export function determineControlGroupFromFragment(fragment) {
     return null;
   }
   // Create array from all tab control grouping elements
-  const controlGroupList = Array.from(
-    document.querySelectorAll('[id^="vertical-tab-"]')
-  );
+  const controlGroupList = Array.from(document.querySelectorAll('[id^="vertical-tab-"]'));
   // Grab group id if found
   return controlGroupList
-    ?.find(
-      (group) =>
-        fragment.split("/")?.[0] === group.id.split("vertical-tab-").pop()
-    )
+    ?.find((group) => fragment.split("/")?.[0] === group.id.split("vertical-tab-").pop())
     ?.id?.split("vertical-tab-")
     ?.pop();
 }
@@ -101,9 +96,7 @@ export function appendToFragmentPrefix(fragmentPrefix, controlId) {
  * @returns {string} fragmentSuffix with a removed control
  */
 export function shiftFragmentSuffix(fragmentSuffix) {
-  return fragmentSuffix
-    ? `${fragmentSuffix.substring(fragmentSuffix.indexOf("/") + 1)}`
-    : null;
+  return fragmentSuffix ? `${fragmentSuffix.substring(fragmentSuffix.indexOf("/") + 1)}` : null;
 }
 
 /**

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.test.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.test.js
@@ -2,23 +2,17 @@ import { guessExtensionFromHref } from "./OSCALLinkUtils";
 
 describe("guessExtensionFromHref", () => {
   it("gets favicon", async () => {
-    expect(
-      guessExtensionFromHref("https://easydynamics.com/favicon.ico")
-    ).toEqual("ICO");
+    expect(guessExtensionFromHref("https://easydynamics.com/favicon.ico")).toEqual("ICO");
   });
 
   it("gets png", async () => {
-    expect(
-      guessExtensionFromHref(`https://easydynamics.com/diagram.png`)
-    ).toEqual("PNG");
+    expect(guessExtensionFromHref(`https://easydynamics.com/diagram.png`)).toEqual("PNG");
   });
 
   it("gets unknown", async () => {
-    expect(
-      guessExtensionFromHref(
-        `https://easydynamics.com/unknown/unknown-filetype`
-      )
-    ).toEqual("Unknown");
+    expect(guessExtensionFromHref(`https://easydynamics.com/unknown/unknown-filetype`)).toEqual(
+      "Unknown"
+    );
   });
 
   it("gets OSCAL React Library README.md", async () => {
@@ -31,16 +25,12 @@ describe("guessExtensionFromHref", () => {
 
   it("gets OSCAL React Library PR#574", async () => {
     expect(
-      guessExtensionFromHref(
-        "https://github.com/EasyDynamics/oscal-react-library/pull/574/files"
-      )
+      guessExtensionFromHref("https://github.com/EasyDynamics/oscal-react-library/pull/574/files")
     ).toEqual("Unknown");
   });
 
   it("gets NIST SP.800-97 Publication", async () => {
-    expect(
-      guessExtensionFromHref(`"https://doi.org/10.6028/NIST.SP.800-97"`)
-    ).toEqual("Unknown");
+    expect(guessExtensionFromHref(`"https://doi.org/10.6028/NIST.SP.800-97"`)).toEqual("Unknown");
   });
 
   it("gets US government configuration baseline", async () => {
@@ -68,8 +58,6 @@ describe("guessExtensionFromHref", () => {
   });
 
   it("gets bad diagram link", async () => {
-    expect(
-      guessExtensionFromHref("https://easydynamics.com/diagram.png/")
-    ).toEqual("Unknown");
+    expect(guessExtensionFromHref("https://easydynamics.com/diagram.png/")).toEqual("Unknown");
   });
 });

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALProfileResolver.js
@@ -129,13 +129,7 @@ export function OSCALResolveProfile(profile, parentUrl, onSuccess, onError) {
     OSCALResolveProfileOrCatalogUrlControls(
       profile.resolvedControls,
       profile.modifications,
-      resolveLinkHref(
-        profile?.["back-matter"] ?? [],
-        imp.href,
-        parentUrl,
-        OSCAL_MEDIA_TYPE,
-        false
-      ),
+      resolveLinkHref(profile?.["back-matter"] ?? [], imp.href, parentUrl, OSCAL_MEDIA_TYPE, false),
       parentUrl,
       profile?.["back-matter"] ?? [],
       inheritedProfilesAndCatalogs.inherited,

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALProfileUtils.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALProfileUtils.js
@@ -19,11 +19,7 @@ export function fixProfileUrl(sourceUrl, parentUrl) {
  * @param {string} parentUrl parent url to fix sourceUrl
  * @param {function} setModifications set method for modifications
  */
-export async function fetchProfileModifications(
-  sourceUrl,
-  parentUrl,
-  setModifications
-) {
+export async function fetchProfileModifications(sourceUrl, parentUrl, setModifications) {
   const profileUrl = fixProfileUrl(sourceUrl, parentUrl);
 
   fetch(profileUrl)

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALRestUtils.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALRestUtils.js
@@ -53,11 +53,7 @@ export const oscalObjectTypes = {
  * @param {Object} oscalObjectType Object that contains information on an oscalObject
  * @param {(any) => void} handleResult Function to map a fetched result to the json root name of an oscal object
  */
-export function fetchAllResourcesOfType(
-  backendUrl,
-  oscalObjectType,
-  handleResult
-) {
+export function fetchAllResourcesOfType(backendUrl, oscalObjectType, handleResult) {
   fetch(`${backendUrl}/${oscalObjectType.restPath}`)
     .then((response) => {
       if (!response.ok) throw new Error(response.status);
@@ -67,9 +63,7 @@ export function fetchAllResourcesOfType(
 }
 
 export function getOscalObjectTypeFromJsonRootName(jsonRootName) {
-  return Object.keys(oscalObjectTypes).find(
-    (element) => element.jsonRootName === jsonRootName
-  );
+  return Object.keys(oscalObjectTypes).find((element) => element.jsonRootName === jsonRootName);
 }
 
 export function deepClone(obj) {
@@ -243,18 +237,13 @@ export function createOrUpdateSspControlImplementationImplementedRequirementStat
     implementationSetParameters
       .filter((element) => !!element)
       .forEach((implementationSetParameter) => {
-        const foundExistingSetParam = statementByComponent[
-          "set-parameters"
-        ].find(
-          (element) =>
-            element["param-id"] === implementationSetParameter["param-id"]
+        const foundExistingSetParam = statementByComponent["set-parameters"].find(
+          (element) => element["param-id"] === implementationSetParameter["param-id"]
         );
         if (foundExistingSetParam) {
           foundExistingSetParam.values = implementationSetParameter.values;
         } else {
-          statementByComponent["set-parameters"].push(
-            implementationSetParameter
-          );
+          statementByComponent["set-parameters"].push(implementationSetParameter);
         }
       });
   }

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALSspResolver.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALSspResolver.js
@@ -4,12 +4,7 @@ import OSCALResolveProfileOrCatalogUrlControls from "./OSCALProfileResolver";
  *
  * @see {@link https://pages.nist.gov/OSCAL/documentation/schema/implementation-layer/ssp/xml-schema/#global_import-profile}
  */
-export default function OSCALSspResolveProfile(
-  ssp,
-  parentUrl,
-  onSuccess,
-  onError
-) {
+export default function OSCALSspResolveProfile(ssp, parentUrl, onSuccess, onError) {
   if (!ssp["import-profile"]) {
     return;
   }

--- a/packages/oscal-react-library/src/components/oscal-utils/TestUtils.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/TestUtils.js
@@ -3,12 +3,9 @@ import { screen } from "@testing-library/react";
 function getByTextIncludingChildren(textMatch) {
   return screen.getByText((content, node) => {
     const hasText = (testNode) =>
-      testNode.textContent === textMatch ||
-      testNode.textContent.match(textMatch);
+      testNode.textContent === textMatch || testNode.textContent.match(textMatch);
     const nodeHasText = hasText(node);
-    const childrenDontHaveText = Array.from(node?.children || []).every(
-      (child) => !hasText(child)
-    );
+    const childrenDontHaveText = Array.from(node?.children || []).every((child) => !hasText(child));
     return nodeHasText && childrenDontHaveText;
   });
 }

--- a/packages/oscal-react-library/src/stories/OSCALEditableTextField.stories.js
+++ b/packages/oscal-react-library/src/stories/OSCALEditableTextField.stories.js
@@ -1,9 +1,6 @@
 import React from "react";
 import OSCALEditableTextField from "../components/OSCALEditableTextField";
-import {
-  testModifiableMetadata,
-  textFieldEditModeMetadata,
-} from "../test-data/MetadataData";
+import { testModifiableMetadata, textFieldEditModeMetadata } from "../test-data/MetadataData";
 
 export default {
   title: "Components/Editable Text Field",

--- a/packages/oscal-react-library/src/stories/OSCALMetadata.stories.js
+++ b/packages/oscal-react-library/src/stories/OSCALMetadata.stories.js
@@ -1,9 +1,6 @@
 import React from "react";
 import OSCALMetadata from "../components/OSCALMetadata";
-import {
-  exampleMetadata,
-  exampleMetadataWithPartiesAndRoles,
-} from "../test-data/MetadataData";
+import { exampleMetadata, exampleMetadataWithPartiesAndRoles } from "../test-data/MetadataData";
 
 export default {
   title: "Components/Metadata",

--- a/packages/oscal-react-library/src/stories/OSCALResponsibleRoles.stories.js
+++ b/packages/oscal-react-library/src/stories/OSCALResponsibleRoles.stories.js
@@ -1,9 +1,6 @@
 import React from "react";
 import OSCALResponsibleRoles from "../components/OSCALResponsibleRoles";
-import {
-  exampleParties,
-  responsibleRolesTestData,
-} from "../test-data/CommonData";
+import { exampleParties, responsibleRolesTestData } from "../test-data/CommonData";
 
 export default {
   title: "Components/Responsible Roles",

--- a/packages/oscal-react-library/src/stories/OSCALSystemImplementation.stories.js
+++ b/packages/oscal-react-library/src/stories/OSCALSystemImplementation.stories.js
@@ -1,9 +1,6 @@
 import React from "react";
 import OSCALSystemImplementation from "../components/OSCALSystemImplementation";
-import {
-  systemImplementationTestData,
-  componentsTestData,
-} from "../test-data/SystemData";
+import { systemImplementationTestData, componentsTestData } from "../test-data/SystemData";
 import { exampleParties } from "../test-data/CommonData";
 
 export default {

--- a/packages/oscal-react-library/src/stories/OSCALSystemImplementationInventoryItems.stories.js
+++ b/packages/oscal-react-library/src/stories/OSCALSystemImplementationInventoryItems.stories.js
@@ -1,8 +1,5 @@
 import React from "react";
-import {
-  systemImplementationTestData,
-  componentsTestData,
-} from "../test-data/SystemData";
+import { systemImplementationTestData, componentsTestData } from "../test-data/SystemData";
 import { exampleParties } from "../test-data/CommonData";
 import OSCALSystemImplementationInventoryItems from "../components/OSCALSystemImplementationInventoryItems";
 

--- a/packages/oscal-react-library/src/test-data/ComponentsData.js
+++ b/packages/oscal-react-library/src/test-data/ComponentsData.js
@@ -72,8 +72,7 @@ export const componentDefinitionTestData = {
         {
           uuid: "control-implementation-1",
           source: revFourCatalog,
-          description:
-            "This is an example description for control implementations",
+          description: "This is an example description for control implementations",
           "implemented-requirements": [
             {
               uuid: "implemented-requirements-1",
@@ -92,8 +91,7 @@ export const exampleComponentStories = [
     uuid: "b036a6ac-6cff-4066-92bc-74ddfd9ad6fa",
     type: "software",
     title: "test component 1",
-    description:
-      "This is a software component that implements basic authentication mechanisms.",
+    description: "This is a software component that implements basic authentication mechanisms.",
     "responsible-roles": [
       {
         "role-id": "supplier",
@@ -121,8 +119,7 @@ export const exampleComponentDefinitionComponent = {
   uuid: "b036a6ac-6cff-4066-92bc-74ddfd9ad6fa",
   type: "software",
   title: "test component 1",
-  description:
-    "This is a software component that implements basic authentication mechanisms.",
+  description: "This is a software component that implements basic authentication mechanisms.",
   "responsible-roles": [
     {
       "role-id": "supplier",

--- a/packages/oscal-react-library/src/test-data/ControlsData.js
+++ b/packages/oscal-react-library/src/test-data/ControlsData.js
@@ -215,8 +215,7 @@ export const controlImplWithDecSmtTestData = {
             {
               "component-uuid": "component-1.1",
               uuid: "a74681b2-fbcb-46eb-90fd-0d55aa74ac7b",
-              description:
-                "Component 1.1 description of implementing control 1",
+              description: "Component 1.1 description of implementing control 1",
               "set-parameters": [
                 {
                   "param-id": "control-1.1_prm_1",

--- a/packages/oscal-react-library/src/test-data/SystemData.js
+++ b/packages/oscal-react-library/src/test-data/SystemData.js
@@ -1,8 +1,5 @@
 import { metadataTestData, responsibleRolesTestData } from "./CommonData";
-import {
-  systemCharacteristicsDescriptionUrl,
-  systemCharacteristicsInformationUrl,
-} from "./Urls";
+import { systemCharacteristicsDescriptionUrl, systemCharacteristicsInformationUrl } from "./Urls";
 import { localReferenceDiagram } from "./DiagramData";
 import { backMatterTestData } from "./BackMatterData";
 
@@ -136,8 +133,7 @@ export const systemCharacteristicsTestData = {
   },
   status: {
     state: "other",
-    remarks:
-      "This is an example, and is not intended to be implemented as a system",
+    remarks: "This is an example, and is not intended to be implemented as a system",
   },
   props: [
     {

--- a/packages/oscal-react-library/src/test-data/Urls.js
+++ b/packages/oscal-react-library/src/test-data/Urls.js
@@ -17,10 +17,8 @@ export const rev4LowBaselineProfileJson =
 export const sspTestExampleUrl =
   "https://raw.githubusercontent.com/usnistgov/oscal-content/master/examples/ssp/json/oscal_leveraged-example_ssp.json";
 
-export const systemCharacteristicsDescriptionUrl =
-  "https://ietf.org/rfc/rfc4122";
+export const systemCharacteristicsDescriptionUrl = "https://ietf.org/rfc/rfc4122";
 
-export const systemCharacteristicsInformationUrl =
-  "https://doi.org/10.6028/NIST.SP.800-60v2r1";
+export const systemCharacteristicsInformationUrl = "https://doi.org/10.6028/NIST.SP.800-60v2r1";
 
 export const urlParameterTestUrl = "https://www.easydynamics.com/";

--- a/packages/oscal-viewer/package.json
+++ b/packages/oscal-viewer/package.json
@@ -14,7 +14,7 @@
     "watch": "craco start",
     "test": "craco test --watchAll=false",
     "eject": "craco eject",
-    "lint": "eslint --ext .js,.jsx,.tsx,.ts,.json",
+    "lint": "eslint --ext .js,.jsx,.tsx,.ts,.json -c .eslintrc.json .",
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {

--- a/packages/oscal-viewer/src/App.js
+++ b/packages/oscal-viewer/src/App.js
@@ -1,10 +1,5 @@
 import "./App.css";
-import {
-  styled,
-  createTheme,
-  ThemeProvider,
-  StyledEngineProvider,
-} from "@mui/material/styles";
+import { styled, createTheme, ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
 import React, { createElement, useEffect, useState } from "react";
 import Typography from "@mui/material/Typography";
 import Container from "@mui/material/Container";
@@ -18,12 +13,7 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import CssBaseline from "@mui/material/CssBaseline";
 import ReactGA from "react-ga4";
-import {
-  Route,
-  Routes,
-  Link as RouterLink,
-  useLocation,
-} from "react-router-dom";
+import { Route, Routes, Link as RouterLink, useLocation } from "react-router-dom";
 import Grid from "@mui/material/Grid";
 import Switch from "@mui/material/Switch";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -44,9 +34,7 @@ const appTheme = createTheme({
   },
 });
 
-const OpenNavButton = styled(IconButton)(
-  ({ theme }) => `margin-right: ${theme.spacing(2)}`
-);
+const OpenNavButton = styled(IconButton)(({ theme }) => `margin-right: ${theme.spacing(2)}`);
 const LogoImage = styled("img")`
   width: 150px;
   margin-right: 1em;
@@ -82,9 +70,7 @@ function App() {
     // be different).
     !!process.env.REACT_APP_REST_BASE_URL
   );
-  const [backendUrl] = useState(
-    getBackEndUrl(process.env.REACT_APP_REST_BASE_URL)
-  );
+  const [backendUrl] = useState(getBackEndUrl(process.env.REACT_APP_REST_BASE_URL));
   const [hasDefaultUrl, setHasDefaultUrl] = useState(false);
   const [urlFragment, setUrlFragment] = useState(null);
 
@@ -93,18 +79,12 @@ function App() {
     // Open the drawer when in REST mode and no uuid is present.
     // Note: The lowest subdirectory of the url is extracted to see if
     // it contains a uuid.
-    if (
-      isRestMode &&
-      currentUrl.substring(currentUrl.lastIndexOf("/") + 1) === ""
-    ) {
+    if (isRestMode && currentUrl.substring(currentUrl.lastIndexOf("/") + 1) === "") {
       setIsDrawerOpen(true);
     }
   }, [isRestMode]);
 
-  const appType = React.useMemo(
-    () => (isRestMode ? "Editor" : "Viewer"),
-    [isRestMode]
-  );
+  const appType = React.useMemo(() => (isRestMode ? "Editor" : "Viewer"), [isRestMode]);
   useEffect(() => {
     document.title = `OSCAL ${appType}`;
   }, [appType]);
@@ -195,10 +175,7 @@ function App() {
       {/* Default index will open up the Catalog */}
       <Route
         index
-        element={createElement(
-          oscalObjectTypes[0].loaderElement,
-          oscalObjectLoaderProps
-        )}
+        element={createElement(oscalObjectTypes[0].loaderElement, oscalObjectLoaderProps)}
       />
       {oscalObjectTypes.map((oscalObjectType) => (
         <Route path={oscalObjectType.pathName} key={oscalObjectType.pathName}>
@@ -206,10 +183,7 @@ function App() {
             <Route
               path={path}
               key={path}
-              element={createElement(
-                oscalObjectType.loaderElement,
-                oscalObjectLoaderProps
-              )}
+              element={createElement(oscalObjectType.loaderElement, oscalObjectLoaderProps)}
             />
           ))}
         </Route>
@@ -232,32 +206,16 @@ function App() {
       open={Boolean(anchorEl)}
       onClose={handleAppNavClose}
     >
-      <MenuItem
-        onClick={handleAppNavClose}
-        component={RouterLink}
-        to="/catalog/"
-      >
+      <MenuItem onClick={handleAppNavClose} component={RouterLink} to="/catalog/">
         {`Catalog ${appType}`}
       </MenuItem>
-      <MenuItem
-        onClick={handleAppNavClose}
-        component={RouterLink}
-        to="/profile/"
-      >
+      <MenuItem onClick={handleAppNavClose} component={RouterLink} to="/profile/">
         {`Profile ${appType}`}
       </MenuItem>
-      <MenuItem
-        onClick={handleAppNavClose}
-        component={RouterLink}
-        to="/component-definition/"
-      >
+      <MenuItem onClick={handleAppNavClose} component={RouterLink} to="/component-definition/">
         {`Component ${appType}`}
       </MenuItem>
-      <MenuItem
-        onClick={handleAppNavClose}
-        component={RouterLink}
-        to="/system-security-plan/"
-      >
+      <MenuItem onClick={handleAppNavClose} component={RouterLink} to="/system-security-plan/">
         {`System Security Plan ${appType}`}
       </MenuItem>
     </Menu>
@@ -300,10 +258,7 @@ function App() {
                 <Grid item md={4}>
                   <Grid container alignItems="center" justifyContent="center">
                     <Grid item align="center">
-                      <Typography
-                        variant="body2"
-                        sx={{ color: "white", fontStyle: "italic" }}
-                      >
+                      <Typography variant="body2" sx={{ color: "white", fontStyle: "italic" }}>
                         Powered by
                       </Typography>
                     </Grid>


### PR DESCRIPTION
This is a pretty trivial linter change but with the addition of TypeScript, lines for function definitions and elsewhere are going to get a bit longer. This gives us some more room on each line before they get split unnecessarily early.

The true changes here are:

 - updating `.prettierrc` for the new line length
 - updating `packages/oscal-viewer/package.json` to properly reference the config file

The remaining changes are just the result of `npm run lint:fix`.

After this is merged and we have the commit hash, I will update `.git-blame-ignore-revs`[^1] with that to clean up `git-blame(1)` output in the future.

[^1]: While https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/ isn't the formal documentation for this feature, it covers the intent of the file. The same file is supported by the `git` tool locally.