### PR TITLE
fix: CDef, Profile, & SSP metadata anchor links

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALLoader.js
+++ b/packages/oscal-react-library/src/components/OSCALLoader.js
@@ -408,6 +408,7 @@ export function OSCALSSPLoader(props) {
       system-security-plan={oscalData[oscalObjectType.jsonRootName]}
       isEditable={isRestMode}
       parentUrl={oscalUrl}
+      urlFragment={props.urlFragment}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(
         appendToLastFieldInPath,
@@ -459,6 +460,7 @@ export function OSCALComponentLoader(props) {
       componentDefinition={oscalData[oscalObjectType.jsonRootName]}
       isEditable={isRestMode}
       parentUrl={oscalUrl}
+      urlFragment={props.urlFragment}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(
         appendToLastFieldInPath,
@@ -509,6 +511,7 @@ export function OSCALProfileLoader(props) {
       profile={oscalData[oscalObjectType.jsonRootName]}
       isEditable={isRestMode}
       parentUrl={oscalUrl}
+      urlFragment={props.urlFragment}
       onResolutionComplete={onResolutionComplete}
       onFieldSave={(
         appendToLastFieldInPath,


### PR DESCRIPTION
Exposed by Cypress tests, the metadata links
for some models were not opening after
scrolling. This is a result of the `urlFragment`
not being passed properly to some of the
models.

Relates to https://github.com/EasyDynamics/oscal-react-library/issues/176