### PR TITLE
chore: fix storybook build after type integration

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,6 +33,8 @@ jobs:
         run: npm install -g npm@latest
       - name: Install dependencies
         run: npm ci
+      - name: Build library's dependencies
+        run: npx lerna exec --include-dependencies --scope '@easydynamics/oscal-react-library' -- npm run build
       - name: Build Storybook
         run: npm run build-storybook
         working-directory: packages/oscal-react-library


### PR DESCRIPTION
This breakage happened because the library now has dependencies.
Additionally, we didn't detect this earlier because we don't run the
storybook build on PRs.
