### PR TITLE
fix(profile): include-all and exclude directives are not resolved correctly

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALControl.js
+++ b/packages/oscal-react-library/src/components/OSCALControl.js
@@ -95,7 +95,6 @@ export default function OSCALControl(props) {
     modificationAlters,
     showInList,
     childLevel,
-    includeAll,
     excludeControlIds,
   } = props;
 
@@ -111,7 +110,7 @@ export default function OSCALControl(props) {
     elementWithFragment?.scrollIntoView?.({ behavior: "smooth" });
   }, [listItemOpened, isItemNavigatedTo, urlFragment]);
 
-  if (!includeAll && (!control || (includeControlIds && !includeControlIds.includes(control.id)))) {
+  if (!control || (includeControlIds && !includeControlIds.includes(control.id))) {
     return null;
   }
   if (!control || (excludeControlIds && excludeControlIds.includes(control.id))) {

--- a/packages/oscal-react-library/src/components/OSCALProfile.js
+++ b/packages/oscal-react-library/src/components/OSCALProfile.js
@@ -63,14 +63,31 @@ export default function OSCALProfile(props) {
     .filter((include) => include);
 
   const includeAll = includeAllControls.length > 0;
-  // Flatten controls and IDs into single key, value structure
-  const includeControlIds = props.profile.imports
-    .flatMap((imp) => imp["include-controls"] ?? [])
-    .flatMap((includeControl) => includeControl["with-ids"] ?? []);
+
+  const subControlIds = props.profile.resolvedControls
+    ?.flatMap((resolved) => resolved.controls ?? [])
+    .flatMap((subControl) => subControl.id)
+    ?.filter((id) => id);
+  const controlIds = props.profile.resolvedControls?.flatMap((control) => control.id);
 
   const excludeControlIds = props.profile.imports
     .flatMap((imp) => imp["exclude-controls"] ?? [])
     .flatMap((excludeControl) => excludeControl["with-ids"] ?? []);
+
+  // Exclude all subcontrols that needed to be excluded.
+
+  const includedSubControlIds = subControlIds
+    ?.flatMap((subControl) => (!excludeControlIds?.includes(subControl) ? subControl : undefined))
+    ?.filter((id) => id);
+
+  const allControlIds = [...(controlIds ?? []), ...(includedSubControlIds ?? [])];
+
+  // Flatten controls and IDs into single key, value structure
+  const includeControlIds = includeAll
+    ? allControlIds
+    : props.profile.imports
+        .flatMap((imp) => imp["include-controls"] ?? [])
+        .flatMap((includeControl) => includeControl["with-ids"] ?? []);
 
   // Import resolved controls when loaded. When loading, display a basic skeleton placeholder
   // resembling the content.
@@ -92,7 +109,6 @@ export default function OSCALProfile(props) {
       {isLoaded ? (
         props.profile.resolvedControls.map((control) => (
           <OSCALControl
-            includeAll={includeAll}
             control={control}
             excludeControlIds={excludeControlIds}
             includeControlIds={includeControlIds}


### PR DESCRIPTION
Fixing include-all and exclude-control issues.

for testing you can use these profiles:
https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/test-content/profiles/NIST_SP-800-53_rev4ProfilewithIncludeAllandExcludeControl.json
and
https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/test-content/profiles/NIST_SP-800-53_rev4ProfilewithIncludeAll.json
