### PR TITLE
fix(app): header content alignment is unclear and distracting

### DIFF
--- a/packages/oscal-viewer/src/App.js
+++ b/packages/oscal-viewer/src/App.js
@@ -255,49 +255,49 @@ function App() {
                     </Grid>
                   </Grid>
                 </Grid>
-                <Grid item md={4}>
-                  <Grid container alignItems="center" justifyContent="center">
-                    <Grid item align="center">
-                      <Typography variant="body2" sx={{ color: "white", fontStyle: "italic" }}>
-                        Powered by
-                      </Typography>
-                    </Grid>
-                    <Grid item align="center">
-                      <Button
-                        href="https://www.easydynamics.com"
-                        target="_blank"
-                        sx={{ color: "white" }}
-                      >
-                        <LogoImage src={logo} alt="Easy Dynamics Logo" />
-                      </Button>
-                    </Grid>
-                    <Grid item align="center">
-                      <IconButton
-                        href="https://github.com/EasyDynamics/oscal-react-library"
-                        target="_blank"
-                        rel="noreferrer"
-                        size="large"
-                      >
-                        <GitHubIcon htmlColor="white" />
-                      </IconButton>
-                    </Grid>
+                <Grid item md={8}>
+                  <Grid container alignItems="center" justifyContent="right">
+                    <Typography variant="body2" sx={{ color: "white", fontStyle: "italic" }}>
+                      Powered by
+                    </Typography>
+                    <Button
+                      href="https://www.easydynamics.com"
+                      target="_blank"
+                      sx={{ color: "white" }}
+                    >
+                      <LogoImage src={logo} alt="Easy Dynamics Logo" />
+                    </Button>
+                    <IconButton
+                      href="https://github.com/EasyDynamics/oscal-react-library"
+                      target="_blank"
+                      rel="noreferrer"
+                      size="large"
+                    >
+                      <GitHubIcon htmlColor="white" />
+                    </IconButton>
+                    {backendUrl && (
+                      <>
+                        <Typography
+                          variant="body2"
+                          sx={{ color: "white", fontStyle: "italic", mx: 5 }}
+                        >
+                          |
+                        </Typography>
+                        <FormControlLabel
+                          control={
+                            <Switch
+                              checked={isRestMode}
+                              color="warning"
+                              onChange={onChangeRestMode}
+                              name="isRestMode"
+                            />
+                          }
+                          label="REST Mode"
+                        />
+                      </>
+                    )}
                   </Grid>
                 </Grid>
-                {backendUrl && (
-                  <Grid item md={4} align="right">
-                    <FormControlLabel
-                      control={
-                        <Switch
-                          checked={isRestMode}
-                          color="warning"
-                          onChange={onChangeRestMode}
-                          name="isRestMode"
-                        />
-                      }
-                      label="REST Mode"
-                    />
-                  </Grid>
-                )}
               </Grid>
             </Toolbar>
           </AppBar>

--- a/packages/oscal-viewer/src/App.js
+++ b/packages/oscal-viewer/src/App.js
@@ -234,7 +234,7 @@ function App() {
           <AppBar position="static">
             <Toolbar>
               <Grid container alignItems="center">
-                <Grid item md={4} align="left">
+                <Grid item md={6} align="left">
                   <Grid container alignItems="center">
                     <Grid item align="left">
                       <OpenNavButton
@@ -253,36 +253,8 @@ function App() {
                         <Routes>{appBarRoutes}</Routes>
                       </Typography>
                     </Grid>
-                  </Grid>
-                </Grid>
-                <Grid item md={8}>
-                  <Grid container alignItems="center" justifyContent="right">
-                    <Typography variant="body2" sx={{ color: "white", fontStyle: "italic" }}>
-                      Powered by
-                    </Typography>
-                    <Button
-                      href="https://www.easydynamics.com"
-                      target="_blank"
-                      sx={{ color: "white" }}
-                    >
-                      <LogoImage src={logo} alt="Easy Dynamics Logo" />
-                    </Button>
-                    <IconButton
-                      href="https://github.com/EasyDynamics/oscal-react-library"
-                      target="_blank"
-                      rel="noreferrer"
-                      size="large"
-                    >
-                      <GitHubIcon htmlColor="white" />
-                    </IconButton>
                     {backendUrl && (
-                      <>
-                        <Typography
-                          variant="body2"
-                          sx={{ color: "white", fontStyle: "italic", mx: 5 }}
-                        >
-                          |
-                        </Typography>
+                      <Grid item align="right" sx={{ mx: 4 }}>
                         <FormControlLabel
                           control={
                             <Switch
@@ -294,8 +266,33 @@ function App() {
                           }
                           label="REST Mode"
                         />
-                      </>
+                      </Grid>
                     )}
+                  </Grid>
+                </Grid>
+                <Grid item md={6}>
+                  <Grid container alignItems="center" justifyContent="right">
+                    <Typography variant="body2" sx={{ color: "white", fontStyle: "italic" }}>
+                      Powered by
+                    </Typography>
+                    <Button
+                      href="https://www.easydynamics.com"
+                      target="_blank"
+                      sx={{ color: "white" }}
+                    >
+                      <LogoImage src={logo} alt="Easy Dynamics Logo" />
+                    </Button>
+                    <Typography variant="body2" sx={{ color: "white", mx: 5 }}>
+                      |
+                    </Typography>
+                    <IconButton
+                      href="https://github.com/EasyDynamics/oscal-react-library"
+                      target="_blank"
+                      rel="noreferrer"
+                      size="large"
+                    >
+                      <GitHubIcon htmlColor="white" />
+                    </IconButton>
                   </Grid>
                 </Grid>
               </Grid>


### PR DESCRIPTION
The "Powered by Easy Dynamics" and GitHub icon is realigned back to the right side of the top navigation bar. When a backend is provided to support viewing capabilities, a vertical slash (`|`) is placed in between this content and the REST Mode switch.

Resolves https://github.com/EasyDynamics/oscal-react-library/issues/603