### PR TITLE
chore(workflows): fix failing types workflow

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: schema
-          path: 
+          path: |
             oscal_complete_schema.json
             VERSION.txt
 


### PR DESCRIPTION
The workflow to update types is failing because the paths being provided
don't match any files. This is because we missed the `|` to indicate
that newlines should be preserved.
