### PR TITLE
feat(metadata): Support viewing revisions

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALMetadata.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.test.tsx
@@ -284,9 +284,7 @@ describe("OSCAL metadata locations", () => {
 
 describe("OSCAL metadata keywords", () => {
   test("display keyword chips", () => {
-    metadataTestData.props = keywordValuesList.basic;
-
-    render(<OSCALMetadata metadata={metadataTestData} />);
+    render(<OSCALMetadata metadata={{ ...metadataTestData, props: keywordValuesList.basic }} />);
 
     const expand = screen.getByText("Keywords");
     fireEvent.click(expand);
@@ -303,9 +301,9 @@ describe("OSCAL metadata keywords", () => {
   });
 
   test("displays one keyword", () => {
-    metadataTestData.props = keywordValuesList.oneKeyWord;
-
-    render(<OSCALMetadata metadata={metadataTestData} />);
+    render(
+      <OSCALMetadata metadata={{ ...metadataTestData, props: keywordValuesList.oneKeyWord }} />
+    );
 
     const expand = screen.getByText("Keywords");
     fireEvent.click(expand);
@@ -318,9 +316,9 @@ describe("OSCAL metadata keywords", () => {
   });
 
   test("displays no keywords with empty props", () => {
-    metadataTestData.props = keywordValuesList.emptyProps;
-
-    render(<OSCALMetadata metadata={metadataTestData} />);
+    render(
+      <OSCALMetadata metadata={{ ...metadataTestData, props: keywordValuesList.emptyProps }} />
+    );
 
     const expand = screen.getByText("Keywords");
     fireEvent.click(expand);
@@ -331,9 +329,9 @@ describe("OSCAL metadata keywords", () => {
   });
 
   test("displays no keywords with empty value", () => {
-    metadataTestData.props = keywordValuesList.emptyValue;
-
-    render(<OSCALMetadata metadata={metadataTestData} />);
+    render(
+      <OSCALMetadata metadata={{ ...metadataTestData, props: keywordValuesList.emptyValue }} />
+    );
 
     const expand = screen.getByText("Keywords");
     fireEvent.click(expand);
@@ -344,9 +342,7 @@ describe("OSCAL metadata keywords", () => {
   });
 
   test("displays no keywords with different ns", () => {
-    metadataTestData.props = keywordValuesList.setns;
-
-    render(<OSCALMetadata metadata={metadataTestData} />);
+    render(<OSCALMetadata metadata={{ ...metadataTestData, props: keywordValuesList.setns }} />);
 
     const expand = screen.getByText("Keywords");
     fireEvent.click(expand);

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -33,30 +33,39 @@ import ListItem from "@mui/material/ListItem";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import React, { useEffect } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { OSCALSection } from "../styles/CommonPageStyles";
 import { propWithName } from "./oscal-utils/OSCALPropUtils";
-import OSCALEditableTextField from "./OSCALEditableTextField";
+import OSCALEditableTextField, { EditableFieldProps } from "./OSCALEditableTextField";
 import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
 import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
+import {
+  Address,
+  PublicationMetadata,
+  Location,
+  PartyOrganizationOrPerson,
+  Role,
+  PartyType,
+  TelephoneNumber,
+} from "@easydynamics/oscal-types";
 
 const OSCALMetadataSectionInfoHeader = styled(Typography)`
   display: flex;
   align-items: center;
-`;
+` as typeof Typography;
 
 const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
   textAlign: "right",
   color: theme.palette.text.secondary,
-}));
+})) as typeof Typography;
 
 const OSCALMetadataCardTitleFallbackText = styled(Typography)(({ theme }) => ({
   color: theme.palette.text.secondary,
-}));
+})) as typeof Typography;
 
 const OSCALMetadataTitle = styled(Grid)`
   height: 56px;
-`;
+` as typeof Grid;
 
 const OSCALMetadataSection = styled(Grid)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
@@ -67,13 +76,10 @@ const OSCALMetadataSection = styled(Grid)(({ theme }) => ({
   paddingRight: ".5em",
   paddingTop: ".5em",
   display: "flex",
-}));
+})) as typeof Grid;
 
 // Returns a string with a locality-sensitive representation of this date
-function formatDate(isoDate) {
-  if (!isoDate) {
-    return isoDate;
-  }
+function formatDate(isoDate: string | number | Date): string {
   return new Date(isoDate).toLocaleString();
 }
 
@@ -90,22 +96,36 @@ const ADDRESS_ICON_MAPPING = {
 
 const UNKNOWN_TYPE_ICON = <HelpOutlineIcon />;
 
-function getIconOfType(mapping, contactType) {
+function getIconOfType(
+  mapping: Record<string, ReactNode> | undefined,
+  contactType: string | undefined
+) {
   if (!mapping || !contactType) {
     return UNKNOWN_TYPE_ICON;
   }
   return mapping[contactType] ?? UNKNOWN_TYPE_ICON;
 }
 
-function getPhoneIcon(contactType) {
+function getPhoneIcon(contactType: string | undefined) {
   return getIconOfType(TELEPHONE_ICON_MAPPING, contactType);
 }
 
-function getAddressIcon(contactType) {
+function getAddressIcon(contactType: string | undefined) {
   return getIconOfType(ADDRESS_ICON_MAPPING, contactType);
 }
 
-function TextWithIcon(props) {
+interface TextWithIconProps {
+  /**
+   * icon to display to the left of text
+   */
+  icon: ReactNode;
+  /**
+   * React component for text
+   */
+  children: ReactNode;
+}
+
+const TextWithIcon: React.FC<TextWithIconProps> = (props) => {
   const { icon, children } = props;
 
   return (
@@ -114,10 +134,14 @@ function TextWithIcon(props) {
       <Typography>{children}</Typography>
     </Stack>
   );
+};
+
+export interface OSCALMetadataAddressProps {
+  address: Address;
 }
 
-export function OSCALMetadataAddress(props) {
-  const tryFormatAddress = (address) => {
+export const OSCALMetadataAddress: React.FC<OSCALMetadataAddressProps> = (props) => {
+  const tryFormatAddress = (address: Address) => {
     const lines = address["addr-lines"] ?? [];
     const cityAndState = [address.city, address.state].filter((it) => it).join(", ");
     const line = [cityAndState, address["postal-code"]].filter((it) => it).join(" ");
@@ -130,25 +154,31 @@ export function OSCALMetadataAddress(props) {
   const formatted = addr.flatMap((it, index) => [it, <br key={index} />]);
 
   return addr.length ? (
-    <TextWithIcon icon={getAddressIcon(address.type)} key={address}>
-      {formatted}
-    </TextWithIcon>
+    <TextWithIcon icon={getAddressIcon(address.type)}>{formatted}</TextWithIcon>
   ) : (
-    <TextWithIcon icon={<ErrorOutlineIcon />} key={address}>
+    <TextWithIcon icon={<ErrorOutlineIcon />}>
       <Typography variant="body2">Address cannot be formatted</Typography>
     </TextWithIcon>
   );
+};
+
+export interface OSCALMetadataEmailProps {
+  email: string;
 }
 
-export function OSCALMetadataEmail(props) {
+export const OSCALMetadataEmail: React.FC<OSCALMetadataEmailProps> = (props) => {
   return (
     <Typography>
       <Link href={`mailto:${props.email}`}>{props.email}</Link>
     </Typography>
   );
+};
+
+export interface OSCALMetadataTelephoneProps {
+  telephone: TelephoneNumber;
 }
 
-export function OSCALMetadataTelephone(props) {
+export const OSCALMetadataTelephone: React.FC<OSCALMetadataTelephoneProps> = (props) => {
   const { telephone } = props;
 
   return (
@@ -156,9 +186,20 @@ export function OSCALMetadataTelephone(props) {
       <Link href={`tel:${telephone.number}`}>{telephone.number}</Link>
     </TextWithIcon>
   );
+};
+
+interface OSCALMetadataContactTypeHeaderProps {
+  /**
+   * Contact info list title
+   */
+  title: string;
+  /**
+   * Optional icon to display
+   */
+  icon?: ReactNode;
 }
 
-function OSCALMetadataContactTypeHeader(props) {
+const OSCALMetadataContactTypeHeader: React.FC<OSCALMetadataContactTypeHeaderProps> = (props) => {
   return (
     <Stack direction="row" alignItems="center" gap={1}>
       {props.icon}
@@ -167,12 +208,27 @@ function OSCALMetadataContactTypeHeader(props) {
       </OSCALMetadataSectionInfoHeader>
     </Stack>
   );
+};
+
+interface MetadataAvatarProps {
+  /**
+   * String to create avatar color with
+   */
+  id: string;
+  /**
+   * Text to appear on avatar
+   */
+  text: string | undefined;
+  /**
+   * Icon to use if text is undefined
+   */
+  fallbackIcon: ReactNode;
 }
 
-function MetadataAvatar(props) {
+const MetadataAvatar: React.FC<MetadataAvatarProps> = (props) => {
   const { id, text, fallbackIcon } = props;
 
-  const avatarColor = (name) => {
+  const avatarColor = (name: string) => {
     // This implementation hashes the given string to create a
     // color string. This is based of the example algorithm given
     // in the MUI documentation and adapted to our use case.
@@ -191,7 +247,7 @@ function MetadataAvatar(props) {
     return color;
   };
 
-  const avatarValue = (name) =>
+  const avatarValue = (name: string | undefined) =>
     name
       ?.split(" ")
       .map((str) => str.substring(0, 1))
@@ -200,34 +256,71 @@ function MetadataAvatar(props) {
       .toUpperCase();
 
   return <Avatar sx={{ bgcolor: avatarColor(id) }}>{avatarValue(text) ?? fallbackIcon}</Avatar>;
-}
-
-const MetadataInfoTypes = {
-  address: "address",
-  telephone: "telephone",
-  email: "email",
 };
 
-const TYPE_MAPPING = (infoProps) => ({
-  address: <OSCALMetadataAddress address={infoProps} />,
-  telephone: <OSCALMetadataTelephone telephone={infoProps} />,
-  email: <OSCALMetadataEmail email={infoProps} />,
-});
+enum MetadataInfoType {
+  address = "address",
+  telephone = "telephone",
+  email = "email",
+}
 
-const getMetadataInfoList = (list, infoType, emptyMessage = "No information provided") => {
+/**
+ * Maps a contact list item to the correct component.
+ *
+ * @param infoProps Props to pass to the component
+ * @param type Contact info type to use for map
+ */
+const mapContactType = (infoProps: Address | TelephoneNumber | string, type: MetadataInfoType) => {
+  switch (type) {
+    case MetadataInfoType.email:
+      return <OSCALMetadataEmail email={infoProps as string} />;
+    case MetadataInfoType.address:
+      return <OSCALMetadataAddress address={infoProps as Address} />;
+    case MetadataInfoType.telephone:
+      return <OSCALMetadataTelephone telephone={infoProps as TelephoneNumber} />;
+  }
+};
+
+interface MetadataInfoListProps {
+  /**
+   * List of metadata contact info
+   */
+  list: Address[] | string[] | TelephoneNumber[] | undefined;
+  /**
+   * Type of metadata contact info
+   */
+  infoType: MetadataInfoType;
+  /**
+   * Message to display if list is empty
+   */
+  emptyMessage: string;
+}
+
+const MetadataInfoList: React.FC<MetadataInfoListProps> = (props) => {
+  const { list, infoType, emptyMessage } = props;
+
   if (!list?.length) {
     return <Typography> {emptyMessage} </Typography>;
   }
 
-  return list.map((item) => (
-    <ListItem key={infoType === "email" ? item : `${item?.type}--${item?.name}`}>
-      {TYPE_MAPPING(item)[infoType]}
-    </ListItem>
-  ));
+  return (
+    <>
+      {list.map((item, index) => {
+        return <ListItem key={index}>{mapContactType(item, infoType)}</ListItem>;
+      })}
+    </>
+  );
 };
 
-export function OSCALMetadataParty(props) {
-  const fallbackIcon = props.party?.type === "organziation" ? <GroupIcon /> : <PersonIcon />;
+export interface OSCALMetadataPartyProps {
+  party: PartyOrganizationOrPerson;
+  partyRolesText: Role[] | undefined;
+}
+
+export const OSCALMetadataParty: React.FC<OSCALMetadataPartyProps> = (props) => {
+  const fallbackIcon =
+    props.party?.type === PartyType.ORGANIZATION ? <GroupIcon /> : <PersonIcon />;
+
   const avatar = (
     <MetadataAvatar id={props.party.uuid} text={props.party.name} fallbackIcon={fallbackIcon} />
   );
@@ -235,7 +328,7 @@ export function OSCALMetadataParty(props) {
   return (
     <OSCALMetadataCard
       title={props.party.name}
-      subheader={props.partyRolesText?.map((role) => role.title).join(", ")}
+      subheader={props.partyRolesText?.map((role: Role) => role.title).join(", ")}
       avatar={avatar}
     >
       <DialogTitle id="scroll-dialog-title">
@@ -254,40 +347,44 @@ export function OSCALMetadataParty(props) {
           <Grid item xs={4}>
             <OSCALMetadataContactTypeHeader icon={<MapIcon fontSize="small" />} title="Address" />
             <List>
-              {getMetadataInfoList(
-                props.party.addresses,
-                MetadataInfoTypes.address,
-                "No address information provided"
-              )}
+              <MetadataInfoList
+                list={props.party.addresses}
+                infoType={MetadataInfoType.address}
+                emptyMessage="No address information provided"
+              />
             </List>
           </Grid>
           <Grid item xs={4}>
             <OSCALMetadataContactTypeHeader icon={<PhoneIcon fontSize="small" />} title="Phone" />
             <List>
-              {getMetadataInfoList(
-                props.party["telephone-numbers"],
-                MetadataInfoTypes.telephone,
-                "No telephone information provided"
-              )}
+              <MetadataInfoList
+                list={props.party["telephone-numbers"]}
+                infoType={MetadataInfoType.telephone}
+                emptyMessage="No telephone information provided"
+              />
             </List>
           </Grid>
           <Grid item xs={4}>
             <OSCALMetadataContactTypeHeader icon={<EmailIcon fontSize="small" />} title="Email" />
             <List>
-              {getMetadataInfoList(
-                props.party["email-addresses"],
-                MetadataInfoTypes.email,
-                "No email information provided"
-              )}
+              <MetadataInfoList
+                list={props.party["email-addresses"]}
+                infoType={MetadataInfoType.email}
+                emptyMessage="No email information provided"
+              />
             </List>
           </Grid>
         </Grid>
       </DialogContent>
     </OSCALMetadataCard>
   );
+};
+
+interface OSCALMetadataRoleProps {
+  role: Role;
 }
 
-export function OSCALMetadataRole(props) {
+export const OSCALMetadataRole: React.FC<OSCALMetadataRoleProps> = (props) => {
   const { role } = props;
 
   const avatar = <MetadataAvatar id={role.id} text={role.title} fallbackIcon={<WorkIcon />} />;
@@ -305,9 +402,32 @@ export function OSCALMetadataRole(props) {
       </DialogContent>
     </OSCALMetadataCard>
   );
+};
+
+interface OSCALMetadataCardProps {
+  /**
+   * Title of the card
+   */
+  title: string | undefined;
+  /**
+   * Optional subheader for the card
+   */
+  subheader?: string;
+  /**
+   * Avatar icon for the card
+   */
+  avatar: ReactNode;
+  /**
+   * True if modal button should be disabled
+   */
+  disabled?: boolean;
+  /**
+   * Dialog component's children
+   */
+  children: ReactNode;
 }
 
-function OSCALMetadataCard(props) {
+const OSCALMetadataCard: React.FC<OSCALMetadataCardProps> = (props) => {
   const { title, subheader, avatar, disabled, children } = props;
 
   const [open, setOpen] = React.useState(false);
@@ -354,9 +474,20 @@ function OSCALMetadataCard(props) {
       </CardActions>
     </>
   );
+};
+
+interface OSCALMetadataBasicDataItemProps {
+  /**
+   * Title to display
+   */
+  title: string;
+  /**
+   * Child data
+   */
+  data: string;
 }
 
-function OSCALMetadataBasicDataItem(props) {
+const OSCALMetadataBasicDataItem: React.FC<OSCALMetadataBasicDataItemProps> = (props) => {
   const { title, data } = props;
 
   return (
@@ -365,9 +496,13 @@ function OSCALMetadataBasicDataItem(props) {
       <Typography variant="body2">{data}</Typography>
     </Stack>
   );
+};
+
+interface OSCALMetadataBasicDataProps extends EditableFieldProps {
+  metadata: PublicationMetadata;
 }
 
-function OSCALMetadataBasicData(props) {
+const OSCALMetadataBasicData: React.FC<OSCALMetadataBasicDataProps> = (props) => {
   const { metadata, isEditable, partialRestData, onFieldSave } = props;
 
   return (
@@ -404,13 +539,18 @@ function OSCALMetadataBasicData(props) {
       />
       <OSCALMetadataBasicDataItem
         title="Published Date:"
-        data={formatDate(metadata.published) ?? "Not published"}
+        data={metadata.published ? formatDate(metadata.published) : "Not published"}
       />
     </Stack>
   );
+};
+
+interface OSCALMetadataRolesProps {
+  roles: Role[] | undefined;
+  urlFragment?: string;
 }
 
-function OSCALMetadataRoles(props) {
+const OSCALMetadataRoles: React.FC<OSCALMetadataRolesProps> = (props) => {
   const { roles, urlFragment } = props;
   const cards = roles?.map((role) => (
     <Grid item xs={12} md={4} key={role.id} component={Card}>
@@ -423,19 +563,26 @@ function OSCALMetadataRoles(props) {
       {cards}
     </OSCALMetadataFieldArea>
   );
+};
+
+interface OSCALMetadataPartiesProps {
+  metadata: PublicationMetadata;
+  parties: PartyOrganizationOrPerson[] | undefined;
+  urlFragment?: string;
 }
 
-function OSCALMetadataParties(props) {
+const OSCALMetadataParties: React.FC<OSCALMetadataPartiesProps> = (props) => {
   const { parties, urlFragment } = props;
 
-  const getRoleLabel = (roleId) => props.metadata.roles.find((role) => role.id === roleId);
+  const getRoleLabel = (roleId: string) =>
+    props.metadata?.roles?.find((role) => role.id === roleId);
 
-  const getPartyRolesText = (party) =>
+  const getPartyRolesText = (party: PartyOrganizationOrPerson) =>
     props.metadata["responsible-parties"]
       ?.filter((responsibleParty) => responsibleParty["party-uuids"]?.includes(party.uuid))
       .map((item) => item["role-id"])
       .map(getRoleLabel)
-      .filter((item) => item);
+      .filter((item): item is Role => !!item);
 
   const cards = parties?.map((party) => (
     <Grid item xs={12} md={4} key={party.uuid} component={Card}>
@@ -448,9 +595,14 @@ function OSCALMetadataParties(props) {
       {cards}
     </OSCALMetadataFieldArea>
   );
+};
+
+interface OSCALMetadataLocationsProps {
+  locations: Location[] | undefined;
+  urlFragment?: string | undefined;
 }
 
-function OSCALMetadataLocations(props) {
+const OSCALMetadataLocations: React.FC<OSCALMetadataLocationsProps> = (props) => {
   const { locations, urlFragment } = props;
 
   const cards = locations?.map((location) => (
@@ -464,9 +616,16 @@ function OSCALMetadataLocations(props) {
       {cards}
     </OSCALMetadataFieldArea>
   );
+};
+
+interface OSCALMetadataLocationUrlsProps {
+  /**
+   * List of urls for a given location.
+   */
+  urls: string[] | undefined;
 }
 
-function OSCALMetadataLocationUrls(props) {
+const OSCALMetadataLocationUrls: React.FC<OSCALMetadataLocationUrlsProps> = (props) => {
   const { urls } = props;
   return (
     <Stack>
@@ -484,9 +643,9 @@ function OSCALMetadataLocationUrls(props) {
       )}
     </Stack>
   );
-}
+};
 
-export function OSCALMetadataLocationContent(props) {
+export const OSCALMetadataLocationContent: React.FC<OSCALMetadataLocationProps> = (props) => {
   const { location } = props;
 
   return (
@@ -499,30 +658,34 @@ export function OSCALMetadataLocationContent(props) {
         <Grid item xs={4}>
           <OSCALMetadataContactTypeHeader icon={<PhoneIcon fontSize="small" />} title="Phone" />
           <List>
-            {getMetadataInfoList(
-              location["telephone-numbers"],
-              MetadataInfoTypes.telephone,
-              "No telephone information provided"
-            )}
+            <MetadataInfoList
+              list={location["telephone-numbers"]}
+              infoType={MetadataInfoType.telephone}
+              emptyMessage="No telephone information provided"
+            />
           </List>
         </Grid>
         <Grid item xs={4}>
           <OSCALMetadataContactTypeHeader icon={<EmailIcon fontSize="small" />} title="Email" />
           <List>
-            {getMetadataInfoList(
-              location["email-addresses"],
-              MetadataInfoTypes.email,
-              "No email information provided"
-            )}
+            <MetadataInfoList
+              list={location["email-addresses"]}
+              infoType={MetadataInfoType.email}
+              emptyMessage="No email information provided"
+            />
           </List>
         </Grid>
       </Grid>
       <OSCALMetadataLocationUrls urls={location?.urls} />
     </Stack>
   );
+};
+
+export interface OSCALMetadataLocationProps {
+  location: Location;
 }
 
-export function OSCALMetadataLocation(props) {
+export const OSCALMetadataLocation: React.FC<OSCALMetadataLocationProps> = (props) => {
   const { location } = props;
 
   const avatar = (
@@ -539,9 +702,25 @@ export function OSCALMetadataLocation(props) {
       </DialogContent>
     </OSCALMetadataCard>
   );
+};
+
+interface OSCALMetadataFieldAreaProps {
+  /**
+   * Title of the accordion.
+   */
+  title: string;
+  /**
+   * Inner component displayed on opening of accordion.
+   */
+  children: ReactNode;
+  /**
+   * Summary element near title.
+   */
+  summary?: ReactNode;
+  urlFragment?: string;
 }
 
-function OSCALMetadataFieldArea(props) {
+const OSCALMetadataFieldArea: React.FC<OSCALMetadataFieldAreaProps> = (props) => {
   const { title, children, summary, urlFragment } = props;
 
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -574,31 +753,57 @@ function OSCALMetadataFieldArea(props) {
       </AccordionDetails>
     </Accordion>
   );
+};
+
+export interface OSCALMetadataKeywordProps {
+  keyword: string;
 }
 
-export function OSCALMetadataKeyword(props) {
+export const OSCALMetadataKeyword: React.FC<OSCALMetadataKeywordProps> = (props) => {
   const { keyword } = props;
   const text = keyword.trim();
 
-  return text && <Chip label={text} size="small" role="chip" />;
+  return (
+    <>
+      text && <Chip label={text} size="small" role="chip" />
+    </>
+  );
+};
+
+export interface OSCALMetadataKeywordsProps {
+  /**
+   * Comma seperated list of keywords.
+   */
+  keywords: string | undefined;
+  urlFragment?: string;
 }
 
-export function OSCALMetadataKeywords(props) {
+export const OSCALMetadataKeywords: React.FC<OSCALMetadataKeywordsProps> = (props) => {
   const { keywords, urlFragment } = props;
 
-  const chips = (keywords ?? "")
-    .split(",")
-    .map((keyword) => keyword.trim())
-    .map((keyword) => <OSCALMetadataKeyword key={keyword} keyword={keyword} />);
+  const chips = !keywords
+    ? undefined
+    : keywords
+        ?.split(",")
+        .map((keyword) => keyword.trim())
+        .map((keyword) => <OSCALMetadataKeyword key={keyword} keyword={keyword} />);
 
   return (
     <OSCALMetadataFieldArea title="Keywords" urlFragment={urlFragment}>
       {chips}
     </OSCALMetadataFieldArea>
   );
+};
+
+interface OSCALMetadataProps extends EditableFieldProps {
+  /**
+   * The metadata of an OSCAL document.
+   */
+  metadata: PublicationMetadata;
+  urlFragment?: string;
 }
 
-export default function OSCALMetadata(props) {
+export const OSCALMetadata: React.FC<OSCALMetadataProps> = (props) => {
   if (!props.metadata) {
     return null;
   }
@@ -664,4 +869,6 @@ export default function OSCALMetadata(props) {
       </Card>
     </OSCALSection>
   );
-}
+};
+
+export default OSCALMetadata;

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -48,13 +48,14 @@ import {
   PartyType,
   TelephoneNumber,
 } from "@easydynamics/oscal-types";
+import { OSCALRevisionsButton } from "./OSCALRevision";
 
 const OSCALMetadataSectionInfoHeader = styled(Typography)`
   display: flex;
   align-items: center;
 ` as typeof Typography;
 
-const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
+export const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
   textAlign: "right",
   color: theme.palette.text.secondary,
 })) as typeof Typography;
@@ -506,7 +507,7 @@ const OSCALMetadataBasicData: React.FC<OSCALMetadataBasicDataProps> = (props) =>
   const { metadata, isEditable, partialRestData, onFieldSave } = props;
 
   return (
-    <Stack direction="row" spacing={4}>
+    <Stack direction="row" alignItems="center" spacing={4}>
       <Stack direction="row" spacing={1}>
         <OSCALMetadataLabel variant="body2">Document Version:</OSCALMetadataLabel>
         <OSCALEditableTextField
@@ -541,6 +542,7 @@ const OSCALMetadataBasicData: React.FC<OSCALMetadataBasicDataProps> = (props) =>
         title="Published Date:"
         data={metadata.published ? formatDate(metadata.published) : "Not published"}
       />
+      <OSCALRevisionsButton revisions={metadata.revisions} />
     </Stack>
   );
 };

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -49,16 +49,12 @@ import {
   TelephoneNumber,
 } from "@easydynamics/oscal-types";
 import { OSCALRevisionsButton } from "./OSCALRevision";
+import { OSCALMetadataLabel } from "./OSCALMetadataCommon";
 
 const OSCALMetadataSectionInfoHeader = styled(Typography)`
   display: flex;
   align-items: center;
 ` as typeof Typography;
-
-export const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
-  textAlign: "right",
-  color: theme.palette.text.secondary,
-})) as typeof Typography;
 
 const OSCALMetadataCardTitleFallbackText = styled(Typography)(({ theme }) => ({
   color: theme.palette.text.secondary,

--- a/packages/oscal-react-library/src/components/OSCALMetadataCommon.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadataCommon.tsx
@@ -1,0 +1,12 @@
+import { styled } from "@mui/material/styles";
+import { Typography } from "@mui/material";
+
+/**
+ * A collection of common components shared amongst
+ * OSCALMetadata child components.
+ */
+
+export const OSCALMetadataLabel = styled(Typography)(({ theme }) => ({
+  textAlign: "right",
+  color: theme.palette.text.secondary,
+})) as typeof Typography;

--- a/packages/oscal-react-library/src/components/OSCALRevision.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALRevision.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { exampleRevisions } from "../test-data/CommonData";
+import { OSCALRevisions, OSCALRevisionsButton } from "./OSCALRevision";
+
+describe("OSCAL Revisions Button", () => {
+  test("displays 0 when there are no revisions", () => {
+    render(<OSCALRevisionsButton revisions={undefined} />);
+
+    const button = screen.getByRole("button");
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent("0");
+  });
+
+  test("is disabled when there are no revisions", () => {
+    render(<OSCALRevisionsButton revisions={undefined} />);
+
+    const button = screen.getByRole("button");
+
+    expect(button).toBeDisabled();
+  });
+
+  test("displays 2 when there are 2 revisions", () => {
+    render(<OSCALRevisionsButton revisions={exampleRevisions} />);
+
+    const button = screen.getByRole("button");
+
+    expect(button).toHaveTextContent("2");
+  });
+
+  test("displays Revisions dialog headers", () => {
+    render(<OSCALRevisionsButton revisions={exampleRevisions} />);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    const header = screen.getByRole("heading", {
+      name: /revision history/i,
+    });
+    const titleHeader = screen.getByRole("columnheader", { name: /title/i });
+    const publishHeader = screen.getByRole("columnheader", { name: /published/i });
+
+    expect(header).toBeVisible();
+    expect(titleHeader).toBeVisible();
+    expect(publishHeader).toBeVisible();
+  });
+});
+
+describe("OSCALRevisions", () => {
+  test("Displays all title cells", () => {
+    render(<OSCALRevisions revisions={exampleRevisions} />);
+
+    const title1 = screen.getByRole("cell", { name: /title1/i });
+    const title2 = screen.getByRole("cell", { name: /title2/i });
+
+    expect(title1).toBeVisible();
+    expect(title2).toBeVisible();
+  });
+
+  test("Displays all version cells", () => {
+    render(<OSCALRevisions revisions={exampleRevisions} />);
+
+    const version1 = screen.getByRole("cell", { name: /v1/i });
+    const version2 = screen.getByRole("cell", { name: /v1/i });
+
+    expect(version1).toBeVisible();
+    expect(version2).toBeVisible();
+  });
+
+  test("Displays all revision cells", () => {
+    render(<OSCALRevisions revisions={exampleRevisions} />);
+
+    const revision1 = screen.getByRole("cell", { name: /1\.0\.4/i });
+    const revision2 = screen.getByRole("cell", { name: /1\.0\.3/i });
+
+    expect(revision1).toBeVisible();
+    expect(revision2).toBeVisible();
+  });
+});

--- a/packages/oscal-react-library/src/components/OSCALRevision.tsx
+++ b/packages/oscal-react-library/src/components/OSCALRevision.tsx
@@ -1,0 +1,95 @@
+import { RevisionHistoryEntry } from "@easydynamics/oscal-types";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import React from "react";
+import { OSCALMetadataLabel } from "./OSCALMetadata";
+import {
+  StyledHeaderTableCell,
+  StyledTableHead,
+  StyledTableRow,
+} from "./OSCALSystemImplementationTableStyles";
+
+export interface OSCALRevisionProps {
+  revision: RevisionHistoryEntry;
+}
+
+export const OSCALRevision: React.FC<OSCALRevisionProps> = (props) => {
+  const { revision } = props;
+  const NO_INFORMATION = "n/a";
+
+  return (
+    <StyledTableRow>
+      <TableCell>{revision.title ?? NO_INFORMATION}</TableCell>
+      <TableCell>{revision.published?.toString() ?? NO_INFORMATION}</TableCell>
+      <TableCell>{revision["last-modified"]?.toString() ?? NO_INFORMATION}</TableCell>
+      <TableCell>{revision.version}</TableCell>
+      <TableCell>{revision["oscal-version"] ?? NO_INFORMATION}</TableCell>
+    </StyledTableRow>
+  );
+};
+
+export interface OSCALRevisionsProps {
+  revisions: RevisionHistoryEntry[] | undefined;
+}
+
+export const OSCALRevisions: React.FC<OSCALRevisionsProps> = (props) => {
+  const { revisions } = props;
+
+  return (
+    <Table aria-label="Components" sx={{ height: "max-content" }}>
+      <StyledTableHead>
+        <TableRow>
+          <StyledHeaderTableCell>Title</StyledHeaderTableCell>
+          <StyledHeaderTableCell>Published</StyledHeaderTableCell>
+          <StyledHeaderTableCell>Last Modified</StyledHeaderTableCell>
+          <StyledHeaderTableCell>Version</StyledHeaderTableCell>
+          <StyledHeaderTableCell>OSCAL Version</StyledHeaderTableCell>
+        </TableRow>
+      </StyledTableHead>
+      <TableBody>
+        {revisions?.map((revision) => (
+          <OSCALRevision revision={revision} key={revision.version} />
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export const OSCALRevisionsButton: React.FC<OSCALRevisionsProps> = (props) => {
+  const { revisions } = props;
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={1}>
+      <OSCALMetadataLabel variant="body2">Revisions:</OSCALMetadataLabel>
+      <Button size="small" variant="outlined" onClick={handleOpen} disabled={!revisions}>
+        <Typography variant="body2">{revisions?.length ?? 0}</Typography>
+      </Button>
+      <Dialog open={open} onClose={handleClose} scroll="paper" maxWidth="md" fullWidth>
+        <DialogTitle>Revision History</DialogTitle>
+        <DialogContent dividers>
+          <OSCALRevisions revisions={revisions} />
+        </DialogContent>
+      </Dialog>
+    </Stack>
+  );
+};

--- a/packages/oscal-react-library/src/components/OSCALRevision.tsx
+++ b/packages/oscal-react-library/src/components/OSCALRevision.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from "@mui/material";
 import React from "react";
-import { OSCALMetadataLabel } from "./OSCALMetadata";
+import { OSCALMetadataLabel } from "./OSCALMetadataCommon";
 import {
   StyledHeaderTableCell,
   StyledTableHead,

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALPropUtils.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALPropUtils.ts
@@ -60,7 +60,7 @@ export interface PropertyFilter {
 export function propWithName(
   props: Property[] | undefined,
   name: string,
-  ns: string | undefined
+  ns?: string | undefined
 ): Property | undefined {
   return matchingProp(props, { name, ns, filter: () => true });
 }

--- a/packages/oscal-react-library/src/test-data/CommonData.ts
+++ b/packages/oscal-react-library/src/test-data/CommonData.ts
@@ -1,7 +1,15 @@
-export const exampleParties = [
+import {
+  Location,
+  PartyOrganizationOrPerson,
+  PartyType,
+  PublicationMetadata,
+  Role,
+} from "@easydynamics/oscal-types";
+
+export const exampleParties: PartyOrganizationOrPerson[] = [
   {
     uuid: "party-1",
-    type: "organization",
+    type: PartyType.ORGANIZATION,
     name: "Some group of people",
     "email-addresses": ["owners@email.org"],
     "telephone-numbers": [
@@ -49,7 +57,7 @@ export const exampleParties = [
   },
 ];
 
-export const exampleRoles = [
+export const exampleRoles: Role[] = [
   {
     id: "creator",
     title: "Document creator",
@@ -61,7 +69,7 @@ export const exampleRoles = [
   },
 ];
 
-export const exampleLocations = [
+export const exampleLocations: Location[] = [
   {
     uuid: "54e8923b-56d2-46f1-bb97-9c6f734d9d9e",
     title: "Example Location",
@@ -146,13 +154,15 @@ export const keywordValuesList = {
   ],
 };
 
-export const metadataTestData = {
+export const metadataTestData: PublicationMetadata = {
   title: "Test Title",
   parties: exampleParties,
   roles: exampleRoles,
   locations: exampleLocations,
   version: "Revision 5",
   remarks: "This is test data",
+  "last-modified": new Date("2019-09-28T23:20:50.52Z"),
+  "oscal-version": "1.0.4",
 };
 
 export const responsibleRolesTestData = [

--- a/packages/oscal-react-library/src/test-data/CommonData.ts
+++ b/packages/oscal-react-library/src/test-data/CommonData.ts
@@ -3,6 +3,7 @@ import {
   PartyOrganizationOrPerson,
   PartyType,
   PublicationMetadata,
+  RevisionHistoryEntry,
   Role,
 } from "@easydynamics/oscal-types";
 
@@ -153,6 +154,23 @@ export const keywordValuesList = {
     },
   ],
 };
+
+export const exampleRevisions: RevisionHistoryEntry[] = [
+  {
+    version: "V1",
+    title: "Title1",
+    published: new Date("2023-05-19T13:50:25+00:00"),
+    "last-modified": new Date("2023-04-19T13:50:25+00:00"),
+    "oscal-version": "1.0.4",
+  },
+  {
+    version: "V2",
+    title: "Title2",
+    published: new Date("2024-05-19T13:50:25+00:00"),
+    "last-modified": new Date("2024-04-19T13:50:25+00:00"),
+    "oscal-version": "1.0.3",
+  },
+];
 
 export const metadataTestData: PublicationMetadata = {
   title: "Test Title",


### PR DESCRIPTION
Creates a modal with a table to view metadata revision history.

Closes #705 


### Testing

http://localhost:3000/catalog/?url=https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/tuckerzp/revision-example/catalogs/basic-test-catalog.json

---

![image](https://user-images.githubusercontent.com/39490074/233097020-b1086b20-1db9-4c01-8fba-7b72a5a8e711.png)

---

![image](https://user-images.githubusercontent.com/39490074/233097100-a7999d8e-295b-4950-bf5d-a1ea3dd9a9ce.png)