### PR TITLE
feat: add generic display of properties

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
@@ -16,6 +16,7 @@ import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
 import OSCALEditableTextField, { EditableFieldProps } from "./OSCALEditableTextField";
 import { Resource, ResourceLink, BackMatter } from "@easydynamics/oscal-types";
 import { ReactElement } from "react";
+import OSCALProperties from "./OSCALProperties";
 
 export const OSCALBackMatterCard = styled(Card)(
   ({ theme }) => `
@@ -100,13 +101,12 @@ interface BackMatterResourceProps extends OSCALBackMatterProps {
 }
 
 function BackMatterResource(props: BackMatterResourceProps) {
-  const { resource } = props;
+  const { resource, parentUrl, partialRestData, isEditable, backMatter, onFieldSave } = props;
 
   const getMediaType = (rlink: ResourceLink) =>
-    rlink["media-type"] ||
-    guessExtensionFromHref(getAbsoluteUrl(rlink.href, props.parentUrl) ?? "");
+    rlink["media-type"] || guessExtensionFromHref(getAbsoluteUrl(rlink.href, parentUrl) ?? "");
 
-  const objectKey = getObjectRootKey(props.partialRestData);
+  const objectKey = getObjectRootKey(partialRestData);
 
   return (
     <Grid item xs={3} key={resource.uuid}>
@@ -115,19 +115,23 @@ function BackMatterResource(props: BackMatterResourceProps) {
           <Grid container spacing={0}>
             <Grid item xs={11}>
               <TitleDisplay uuid={resource.uuid}>
+                <OSCALProperties
+                  properties={resource?.props}
+                  title={resource?.title ?? resource?.uuid}
+                />
                 <OSCALEditableTextField
                   fieldName="title"
-                  isEditable={props.isEditable}
-                  editedField={props.isEditable ? [objectKey, "back-matter", "resources"] : null}
-                  editedValue={props.backMatter?.resources}
+                  isEditable={isEditable}
+                  editedField={isEditable ? [objectKey, "back-matter", "resources"] : null}
+                  editedValue={backMatter?.resources}
                   editedValueId={resource.uuid}
-                  onFieldSave={props.onFieldSave}
+                  onFieldSave={onFieldSave}
                   partialRestData={
-                    props.isEditable
+                    isEditable
                       ? {
                           [objectKey]: {
-                            uuid: props.partialRestData?.[objectKey].uuid,
-                            "back-matter": props.backMatter,
+                            uuid: partialRestData?.[objectKey].uuid,
+                            "back-matter": backMatter,
                           },
                         }
                       : null
@@ -144,17 +148,17 @@ function BackMatterResource(props: BackMatterResourceProps) {
           </Grid>
           <OSCALEditableTextField
             fieldName="description"
-            isEditable={props.isEditable}
-            editedField={props.isEditable ? [objectKey, "back-matter", "resources"] : null}
-            editedValue={props.backMatter?.resources}
+            isEditable={isEditable}
+            editedField={isEditable ? [objectKey, "back-matter", "resources"] : null}
+            editedValue={backMatter?.resources}
             editedValueId={resource.uuid}
-            onFieldSave={props.onFieldSave}
+            onFieldSave={onFieldSave}
             partialRestData={
-              props.isEditable
+              isEditable
                 ? {
                     [objectKey]: {
-                      uuid: props.partialRestData?.[objectKey].uuid,
-                      "back-matter": props.backMatter,
+                      uuid: partialRestData?.[objectKey].uuid,
+                      "back-matter": backMatter,
                     },
                   }
                 : null
@@ -169,7 +173,7 @@ function BackMatterResource(props: BackMatterResourceProps) {
                 label={getMediaType(rlink)}
                 component="a"
                 role="button"
-                href={getAbsoluteUrl(rlink.href, props.parentUrl)}
+                href={getAbsoluteUrl(rlink.href, parentUrl)}
                 target="_blank"
                 variant="outlined"
                 clickable

--- a/packages/oscal-react-library/src/components/OSCALControl.js
+++ b/packages/oscal-react-library/src/components/OSCALControl.js
@@ -11,6 +11,7 @@ import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
 import { propWithName } from "./oscal-utils/OSCALPropUtils";
 import { appendToFragmentPrefix } from "./oscal-utils/OSCALLinkUtils";
+import OSCALProperties from "./OSCALProperties";
 
 const OSCALControlCard = styled(Card, {
   // https://github.com/mui/material-ui/blob/c34935814b81870ca325099cdf41a1025a85d4b5/packages/mui-system/src/createStyled.js#L56
@@ -44,6 +45,15 @@ function ControlsList(props) {
   } = props;
   return (
     <div>
+      <OSCALProperties
+        properties={control.props}
+        title={
+          <>
+            <OSCALControlLabel id={control.id} label={control.label} component="span" />
+            {` ${control.title} Discussion`}
+          </>
+        }
+      />
       {control.parts?.map((part, index) => (
         <OSCALControlPart
           componentId={componentId}

--- a/packages/oscal-react-library/src/components/OSCALMetadata.js
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.js
@@ -39,6 +39,7 @@ import { propWithName } from "./oscal-utils/OSCALPropUtils";
 import OSCALEditableTextField from "./OSCALEditableTextField";
 import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
 import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
+import OSCALProperties from "./OSCALProperties";
 
 const OSCALMetadataSectionInfoHeader = styled(Typography)`
   display: flex;
@@ -644,6 +645,9 @@ export default function OSCALMetadata(props) {
                 onFieldSave={props.onFieldSave}
               />
             </OSCALMetadataSection>
+            <OSCALMetadataSection>
+              <OSCALProperties properties={props.metadata.props} title={props.metadata.title} />
+            </ OSCALMetadataSection>
             <OSCALMarkupMultiLine>{props.metadata.remarks}</OSCALMarkupMultiLine>
             <OSCALMetadataKeywords
               keywords={propWithName(props.metadata.props, "keywords")?.value}

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -1,0 +1,144 @@
+import HomeIcon from "@mui/icons-material/Home";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Stack from "@mui/material/Stack";
+import { styled } from "@mui/material/styles";
+import React from "react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableRow from "@mui/material/TableRow";
+import StyledTooltip from "./OSCALStyledTooltip";
+import {
+  OSCALSystemImplementationTableTitle,
+  StyledHeaderTableCell,
+  StyledTableRow,
+  StyledTableHead,
+} from "./OSCALSystemImplementationTableStyles";
+
+const OSCALPropertiesButton = styled(Button)(
+  ({ theme }) => `
+    color: ${theme.palette.primary.main};
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+  `
+);
+
+function OSCALPropertiesCard(props: any) {
+  const { title, children } = props;
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <OSCALPropertiesButton
+        size="small"
+        variant="outlined"
+        onClick={handleOpen}
+        aria-label={`${title} properties button`}
+        startIcon={<HomeIcon />}
+      >
+        Properties
+      </OSCALPropertiesButton>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        scroll="paper"
+        aria-labelledby="scroll-dialog-title"
+        aria-describedby="scroll-dialog-description"
+        maxWidth="md"
+        fullWidth
+      >
+        {children}
+      </Dialog>
+    </>
+  );
+}
+
+function isNistNamespace(namespace: string) {
+  return !namespace || namespace.includes("nist.gov");
+}
+
+function getThirdPartyNamespaces(properties: any) {
+  let items: string[] = [""];
+
+  properties
+    ?.filter((property: any) => !isNistNamespace(property?.ns))
+    .map((property: any) => {
+      items.push(property?.ns);
+    });
+
+  return items;
+}
+
+function OSCALPropertiesTable(properties: any, namespace: string) {
+  return (
+    <DialogContent dividers>
+      <OSCALSystemImplementationTableTitle variant="h6" id={`${namespace}-table-title`}>
+        {namespace}
+      </OSCALSystemImplementationTableTitle>
+      <TableContainer sx={{ maxHeight: "25em" }}>
+        <Table aria-label="Components" sx={{ height: "max-content" }}>
+          <StyledTableHead>
+            <TableRow>
+              <StyledHeaderTableCell>Name</StyledHeaderTableCell>
+              <StyledHeaderTableCell>Class</StyledHeaderTableCell>
+              <StyledHeaderTableCell>Value</StyledHeaderTableCell>
+            </TableRow>
+          </StyledTableHead>
+          <TableBody>
+            {properties
+              ?.filter((property: any) =>
+                namespace === "NIST OSCAL"
+                  ? isNistNamespace(property.ns)
+                  : property?.ns === namespace
+              )
+              .map((property: any) => (
+                <StyledTooltip title={property?.remarks ?? ""}>
+                  <StyledTableRow key={property?.uuid}>
+                    <TableCell>{property?.name}</TableCell>
+                    <TableCell>{property?.class}</TableCell>
+                    <TableCell>{property?.value}</TableCell>
+                  </StyledTableRow>
+                </StyledTooltip>
+              ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </DialogContent>
+  );
+}
+
+export default function OSCALProperties(props: any) {
+  const { properties, title } = props;
+  const thirdPartyNamespaces = getThirdPartyNamespaces(properties);
+
+  return properties ? (
+    <OSCALPropertiesCard title={title}>
+      <DialogTitle id="scroll-dialog-title">
+        <Stack direction="column">{title} Properties</Stack>
+      </DialogTitle>
+      {/* Handle NIST properties */}
+      <OSCALPropertiesTable properties={properties} namespace={"NIST OSCAL"} />
+      {
+        /* Handle 3rd party properties */
+        thirdPartyNamespaces
+          ?.filter((namespace) => namespace !== "")
+          .map((namespace: any) => (
+            <OSCALPropertiesTable properties={properties} namespace={namespace} />
+          ))
+      }
+    </OSCALPropertiesCard>
+  ) : null;
+}


### PR DESCRIPTION
This creates a generic OSCALProperties component and adds it to back matter, controls, and metadata.

Closes https://github.com/EasyDynamics/oscal-react-library/issues/718