### PR TITLE
fix(catalog): catalog viewer only shows controls if they are under a group

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALCatalog.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.test.tsx
@@ -1,4 +1,4 @@
-import { Catalog, Control } from "@easydynamics/oscal-types";
+import { Catalog, Control, ControlGroup } from "@easydynamics/oscal-types";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { metadataTestData } from "../test-data/CommonData";
@@ -8,6 +8,12 @@ const catalog: Catalog = {
   uuid: "a128d34d-6df8-4b86-8e7a-12e7e122a51b",
   metadata: metadataTestData,
 };
+
+const groups: ControlGroup[] = [
+  {
+    title: "Group 1",
+  },
+];
 
 const controls: Control[] = [
   {
@@ -24,10 +30,24 @@ const onResolutionComplete = () => {};
 const parentUrl = "oscal";
 
 describe("OSCALCatalogs", () => {
-  test("displayed ungrouped controls", () => {
+  test("displayed ungrouped controls without groups", () => {
     render(
       <OSCALCatalog
-        catalog={{ ...catalog, controls: controls }}
+        catalog={{ ...catalog, controls: controls, groups: groups }}
+        onResolutionComplete={onResolutionComplete}
+        parentUrl={parentUrl}
+      />
+    );
+
+    const controlTitle = screen.getByText(controls[0].title);
+
+    expect(controlTitle).toBeVisible();
+  });
+
+  test("displayed ungrouped controls with groups", () => {
+    render(
+      <OSCALCatalog
+        catalog={{ ...catalog, controls: controls, groups: groups }}
         onResolutionComplete={onResolutionComplete}
         parentUrl={parentUrl}
       />

--- a/packages/oscal-react-library/src/components/OSCALCatalog.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.test.tsx
@@ -1,0 +1,44 @@
+import { Catalog, Control } from "@easydynamics/oscal-types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { metadataTestData } from "../test-data/CommonData";
+import OSCALCatalog from "./OSCALCatalog";
+
+const catalog: Catalog = {
+  uuid: "a128d34d-6df8-4b86-8e7a-12e7e122a51b",
+  metadata: metadataTestData,
+};
+
+const controls: Control[] = [
+  {
+    id: "ac-1",
+    title: "AC-1",
+  },
+  {
+    id: "ac-2",
+    title: "AC-2",
+  },
+];
+
+const onResolutionComplete = () => {};
+const parentUrl = "oscal";
+
+describe("OSCALCatalogs", () => {
+  test("displayed ungrouped controls", () => {
+    render(
+      <OSCALCatalog
+        catalog={{ ...catalog, controls: controls }}
+        onResolutionComplete={onResolutionComplete}
+        parentUrl={parentUrl}
+      />
+    );
+
+    const ungrouped = screen.getByText("Ungrouped Controls");
+    fireEvent.click(ungrouped);
+
+    const controlTitle = screen.getByText(controls[0].title);
+
+    expect(ungrouped).toBeVisible();
+    expect(controlTitle).toBeVisible();
+  });
+});

--- a/packages/oscal-react-library/src/components/OSCALCatalog.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.test.tsx
@@ -33,7 +33,7 @@ describe("OSCALCatalogs", () => {
       />
     );
 
-    const ungrouped = screen.getByText("Ungrouped Controls");
+    const ungrouped = screen.getByText("Top");
     fireEvent.click(ungrouped);
 
     const controlTitle = screen.getByText(controls[0].title);

--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -1,10 +1,19 @@
+import { Catalog } from "@easydynamics/oscal-types";
 import React, { useEffect } from "react";
 import OSCALBackMatter from "./OSCALBackMatter";
 import OSCALCatalogGroups from "./OSCALCatalogGroups";
+import { EditableFieldProps } from "./OSCALEditableTextField";
 import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 import OSCALMetadata from "./OSCALMetadata";
 
-export default function OSCALCatalog(props) {
+export interface OSCALCatalogProps extends EditableFieldProps {
+  onResolutionComplete: React.EffectCallback;
+  catalog: Catalog;
+  urlFragment?: string | undefined;
+  parentUrl: string;
+}
+
+export const OSCALCatalog: React.FC<OSCALCatalogProps> = (props) => {
   const { onResolutionComplete, catalog, isEditable, onFieldSave, urlFragment, parentUrl } = props;
 
   useEffect(onResolutionComplete);
@@ -36,4 +45,6 @@ export default function OSCALCatalog(props) {
       />
     </OSCALDocumentRoot>
   );
-}
+};
+
+export default OSCALCatalog;

--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -1,12 +1,54 @@
 import { Catalog, ControlGroup } from "@easydynamics/oscal-types";
+import { Card, CardContent } from "@mui/material";
 import React, { useEffect } from "react";
+import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
+import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
 import OSCALBackMatter from "./OSCALBackMatter";
+import { OSCALCatalogControlListItem } from "./OSCALCatalogGroup";
 import OSCALCatalogGroups from "./OSCALCatalogGroups";
 import { EditableFieldProps } from "./OSCALEditableTextField";
 import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 import OSCALMetadata from "./OSCALMetadata";
 
-const UNGROUPED_CONTROLS_TITLE = "*Ungrouped Controls*";
+const UNGROUPED_CONTROLS_TITLE = "*Top*";
+
+interface OSCALCatalogControlsListProps {
+  readonly controls: Catalog["controls"];
+  readonly urlFragment?: string;
+}
+
+const OSCALCatalogControlsList: React.FC<OSCALCatalogControlsListProps> = ({
+  controls,
+  urlFragment,
+}) => {
+  const [isControlListItemOpened, setIsControlListItemOpened] = React.useState(false);
+  const [previousHandledFragment, setPreviousHandledFragment] = React.useState(undefined);
+
+  return (
+    <OSCALSection>
+      <Card>
+        <CardContent>
+          <OSCALAnchorLinkHeader>
+            <OSCALSectionHeader>Controls</OSCALSectionHeader>
+          </OSCALAnchorLinkHeader>
+          {controls?.map((control) => (
+            <OSCALCatalogControlListItem
+              key={control.id}
+              control={control}
+              urlFragment={urlFragment}
+              fragmentPrefix=""
+              fragmentSuffix=""
+              isControlListItemOpened={isControlListItemOpened}
+              setIsControlListItemOpened={setIsControlListItemOpened}
+              previousHandledFragment={previousHandledFragment}
+              setPreviousHandledFragment={setPreviousHandledFragment}
+            />
+          ))}
+        </CardContent>
+      </Card>
+    </OSCALSection>
+  );
+};
 
 export interface OSCALCatalogProps extends EditableFieldProps {
   readonly onResolutionComplete: React.EffectCallback;
@@ -15,9 +57,14 @@ export interface OSCALCatalogProps extends EditableFieldProps {
   readonly parentUrl: string;
 }
 
-export const OSCALCatalog: React.FC<OSCALCatalogProps> = (props) => {
-  const { onResolutionComplete, catalog, isEditable, onFieldSave, urlFragment, parentUrl } = props;
-
+export const OSCALCatalog: React.FC<OSCALCatalogProps> = ({
+  onResolutionComplete,
+  catalog,
+  isEditable,
+  onFieldSave,
+  urlFragment,
+  parentUrl,
+}) => {
   useEffect(onResolutionComplete);
 
   const partialRestData = {
@@ -41,10 +88,14 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = (props) => {
         urlFragment={urlFragment}
       />
 
-      <OSCALCatalogGroups
-        groups={catalog.controls ? [defaultGroup, ...(catalog.groups ?? [])] : catalog.groups}
-        urlFragment={urlFragment}
-      />
+      {catalog.groups ? (
+        <OSCALCatalogGroups
+          groups={catalog.controls ? [defaultGroup, ...(catalog.groups ?? [])] : catalog.groups}
+          urlFragment={urlFragment}
+        />
+      ) : catalog.controls ? (
+        <OSCALCatalogControlsList controls={catalog.controls} urlFragment={urlFragment} />
+      ) : undefined}
 
       <OSCALBackMatter
         backMatter={catalog["back-matter"]}

--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -2,7 +2,7 @@ import { Catalog, ControlGroup } from "@easydynamics/oscal-types";
 import { Card, CardContent } from "@mui/material";
 import React, { useEffect } from "react";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import OSCALBackMatter from "./OSCALBackMatter";
 import { OSCALCatalogControlListItem } from "./OSCALCatalogGroup";
 import OSCALCatalogGroups from "./OSCALCatalogGroups";

--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -6,6 +6,8 @@ import { EditableFieldProps } from "./OSCALEditableTextField";
 import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 import OSCALMetadata from "./OSCALMetadata";
 
+const UNGROUPED_CONTROLS_TITLE = "*Ungrouped Controls*";
+
 export interface OSCALCatalogProps extends EditableFieldProps {
   readonly onResolutionComplete: React.EffectCallback;
   readonly catalog: Catalog;
@@ -25,7 +27,7 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = (props) => {
   };
 
   const defaultGroup: ControlGroup = {
-    title: "*Ungrouped Controls*",
+    title: UNGROUPED_CONTROLS_TITLE,
     controls: catalog.controls,
   };
 

--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -1,4 +1,4 @@
-import { Catalog } from "@easydynamics/oscal-types";
+import { Catalog, ControlGroup } from "@easydynamics/oscal-types";
 import React, { useEffect } from "react";
 import OSCALBackMatter from "./OSCALBackMatter";
 import OSCALCatalogGroups from "./OSCALCatalogGroups";
@@ -24,6 +24,11 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = (props) => {
     },
   };
 
+  const defaultGroup: ControlGroup = {
+    title: "*Ungrouped Controls*",
+    controls: catalog.controls,
+  };
+
   return (
     <OSCALDocumentRoot>
       <OSCALMetadata
@@ -34,7 +39,10 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = (props) => {
         urlFragment={urlFragment}
       />
 
-      <OSCALCatalogGroups groups={catalog.groups} urlFragment={urlFragment} />
+      <OSCALCatalogGroups
+        groups={catalog.controls ? [defaultGroup, ...(catalog.groups ?? [])] : catalog.groups}
+        urlFragment={urlFragment}
+      />
 
       <OSCALBackMatter
         backMatter={catalog["back-matter"]}

--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -7,10 +7,10 @@ import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 import OSCALMetadata from "./OSCALMetadata";
 
 export interface OSCALCatalogProps extends EditableFieldProps {
-  onResolutionComplete: React.EffectCallback;
-  catalog: Catalog;
-  urlFragment?: string | undefined;
-  parentUrl: string;
+  readonly onResolutionComplete: React.EffectCallback;
+  readonly catalog: Catalog;
+  readonly urlFragment?: string | undefined;
+  readonly parentUrl: string;
 }
 
 export const OSCALCatalog: React.FC<OSCALCatalogProps> = (props) => {

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.js
@@ -17,6 +17,7 @@ import {
   shiftFragmentSuffix,
   conformLinkIdText,
 } from "./oscal-utils/OSCALLinkUtils";
+import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
 export const OSCALControlList = styled(List)`
   padding-left: 2em;
@@ -436,6 +437,11 @@ export default function OSCALCatalogGroup(props) {
           setPreviousHandledFragment={setPreviousHandledFragment}
         />
       ))}
+      {group.parts
+        ?.map((groupPart) => groupPart.prose)
+        .map((prose) => (
+          <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
+        ))}
     </OSCALControlList>
   );
 }

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -6,7 +6,7 @@ import List from "@mui/material/List";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemText from "@mui/material/ListItemText";
 import { styled } from "@mui/material/styles";
-import React, { useEffect } from "react";
+import React, { ReactNode, useEffect } from "react";
 import OSCALControl from "./OSCALControl";
 import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
@@ -18,6 +18,12 @@ import {
   conformLinkIdText,
 } from "./oscal-utils/OSCALLinkUtils";
 import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
+import { Control, ControlGroup, Part } from "@easydynamics/oscal-types";
+
+interface CatalogGroupFragmentProps {
+  previousHandledFragment: string | undefined;
+  setPreviousHandledFragment: (...args: any[]) => void;
+}
 
 export const OSCALControlList = styled(List)`
   padding-left: 2em;
@@ -52,39 +58,38 @@ const StyledControlDescriptionWrapper = styled("div")`
  * @param {string} listId The group/control ID
  * @returns {boolean} Whether the top list item matches a list ID or not.
  */
-function isMatchingListItem(urlFragment, previousHandledFragment, fragmentSuffix, listId) {
+function isMatchingListItem(
+  urlFragment: string | undefined,
+  previousHandledFragment: string | undefined,
+  fragmentSuffix: string | undefined,
+  listId: string
+): boolean {
   // Ensure fragment exists and split by groupings
   if (!urlFragment || previousHandledFragment === urlFragment) {
-    return;
+    return false;
   }
   // Determine if current control/group list state matches ID
-  const currentList = fragmentSuffix.split("/")[0];
+  const currentList = fragmentSuffix?.split("/")[0];
   return currentList === listId;
+}
+
+interface CollapsibleListItemProps extends CatalogGroupFragmentProps {
+  urlFragment?: string;
+  group?: ControlGroup;
+  listId: string;
+  itemText: ReactNode;
+  children: ReactNode;
+  fragmentSuffix: string | undefined;
+  listItemOpened?: boolean;
+  setListItemOpened: (...args: any[]) => void;
 }
 
 /**
  * Creates a collapsible component for a catalog group/control.
  *
- * @param {any} props A set of properties pertaining to a collapsible list item
  * @returns A list item component with collapsible information
  */
-function CollapsibleListItem(props) {
-  /**
-   * {string} urlFragment - The current fragment being handled
-   * {any} group - A catalog group that contains either groups/controls
-   * {string} listId - Identification used for a list
-   * {string} itemText - The title of an item
-   * {any} children - Children underneath the list item - either a control/group or control/group
-   *   list
-   * {string} fragmentSuffix - The end of a fragment which starts with the current group/control
-   *   being handled
-   * {boolean} listItemOpened - Tells whether or not the current list item is opened
-   * {function} setIsListItemOpened - Callback function to set list item opened
-   * {function} setIsListItemNavigatedTo - Callback function to set whether the list item has been
-   *   navigated to
-   * {string} previousHandledFragment - The fragment that was handled previously
-   * {function} setPreviousHandledFragment - Callback function to set the previously handled fragment
-   */
+const CollapsibleListItem: React.FC<CollapsibleListItemProps> = (props) => {
   const {
     urlFragment,
     group,
@@ -94,7 +99,6 @@ function CollapsibleListItem(props) {
     fragmentSuffix,
     listItemOpened,
     setListItemOpened,
-    setIsListItemNavigatedTo,
     previousHandledFragment,
     setPreviousHandledFragment,
   } = props;
@@ -105,15 +109,13 @@ function CollapsibleListItem(props) {
   };
 
   useEffect(() => {
-    if (listItemOpened) {
-      setIsListItemNavigatedTo(true);
-      return;
-    }
-
-    if (isMatchingListItem(urlFragment, previousHandledFragment, fragmentSuffix, listId)) {
+    if (
+      urlFragment &&
+      isMatchingListItem(urlFragment, previousHandledFragment, fragmentSuffix, listId)
+    ) {
       setIsOpen(true);
 
-      if (fragmentSuffix.split("/").length <= 1) {
+      if (fragmentSuffix && fragmentSuffix.split("/").length <= 1) {
         const elementWithFragment = document.getElementById(urlFragment);
         elementWithFragment?.scrollIntoView?.({ behavior: "smooth" });
         setPreviousHandledFragment(urlFragment);
@@ -123,7 +125,6 @@ function CollapsibleListItem(props) {
     urlFragment,
     fragmentSuffix,
     listItemOpened,
-    setIsListItemNavigatedTo,
     listId,
     previousHandledFragment,
     setPreviousHandledFragment,
@@ -145,26 +146,21 @@ function CollapsibleListItem(props) {
       </Collapse>
     </StyledListItemPaper>
   );
+};
+
+interface WithdrawnListItemProps extends CatalogGroupFragmentProps {
+  children: ReactNode;
+  urlFragment?: string;
+  listId: string;
+  fragmentSuffix: string | undefined;
 }
 
 /**
  * Creates a top-level withdrawn control list item.
  *
- * @param {any} props A set of properties pertaining to a withdrawn control list item
  * @returns A top-level withdrawn control list item component
  */
-function WithdrawnListItem(props) {
-  /**
-   * {string} urlFragment - The current fragment being handled
-   * {string} listId - Identification used for a list
-   * {any} children - Children underneath the list item - either a control/group or control/group
-   *   list
-   * {string} fragmentSuffix - The end of a fragment which starts with the current group/control
-   *   being handled
-   * {string} previousHandledFragment - The fragment that was handled previously
-   * {function} setPreviousHandledFragment - Callback function to set the previously handled
-   *   fragment
-   */
+const WithdrawnListItem: React.FC<WithdrawnListItemProps> = (props) => {
   const {
     children,
     urlFragment,
@@ -174,11 +170,14 @@ function WithdrawnListItem(props) {
     setPreviousHandledFragment,
   } = props;
   useEffect(() => {
-    if (isMatchingListItem(urlFragment, previousHandledFragment, fragmentSuffix, listId)) {
+    if (
+      urlFragment &&
+      isMatchingListItem(urlFragment, previousHandledFragment, fragmentSuffix, listId)
+    ) {
       const elementWithFragment = document.getElementById(urlFragment);
       elementWithFragment?.scrollIntoView?.({ behavior: "smooth" });
 
-      if (fragmentSuffix.split("/").length <= 1) {
+      if (fragmentSuffix && fragmentSuffix.split("/").length <= 1) {
         setPreviousHandledFragment(urlFragment);
       }
     }
@@ -189,29 +188,23 @@ function WithdrawnListItem(props) {
       <StyledListItem>{children}</StyledListItem>
     </StyledListItemPaper>
   );
+};
+
+interface OSCALCatalogControlListItemProps extends CatalogGroupFragmentProps {
+  control: Control;
+  urlFragment?: string;
+  fragmentPrefix: string;
+  fragmentSuffix: string | undefined;
+  isControlListItemOpened: boolean;
+  setIsControlListItemOpened: (...args: any[]) => void;
 }
 
 /**
  * Creates a catalog list item component containing a catalog group/control.
  *
- * @param {any} props A set of properties pertaining to a list item
  * @returns A list item component which contains sub list item(s) and/or collapsible information
  */
-function OSCALCatalogControlListItem(props) {
-  /**
-   * {any} control - The current control
-   * {string} urlFragment - The current fragment being handled
-   * {string} fragmentPrefix - The beginning of a fragment which ends with the current
-   *   group/control being handled
-   * {string} fragmentSuffix - The end of a fragment which starts with the current group/control
-   *   being handled
-   * {boolean} isControlListItemOpened - Tells whether the current list item is opened
-   * {function} setIsControlListItemOpened - Callback function to set whether the list item has
-   *   been navigated to
-   * {string} previousHandledFragment - The fragment that was handled previously
-   * {function} setPreviousHandledFragment - Callback function to set the previously handled
-   *   fragment
-   */
+const OSCALCatalogControlListItem: React.FC<OSCALCatalogControlListItemProps> = (props) => {
   const {
     control,
     urlFragment,
@@ -243,15 +236,13 @@ function OSCALCatalogControlListItem(props) {
 
   return withdrawn ? (
     <WithdrawnListItem
-      primary={itemText}
-      withdrawn={withdrawn}
       urlFragment={urlFragment}
       listId={control?.id}
       previousHandledFragment={previousHandledFragment}
       setPreviousHandledFragment={setPreviousHandledFragment}
       fragmentSuffix={shiftFragmentSuffix(fragmentSuffix)}
     >
-      <WithdrawnListItemText primary={itemText} withdrawn={withdrawn} />
+      <WithdrawnListItemText primary={itemText} />
     </WithdrawnListItem>
   ) : (
     <CollapsibleListItem
@@ -261,8 +252,6 @@ function OSCALCatalogControlListItem(props) {
       listItemOpened={isControlListItemOpened}
       setListItemOpened={setIsControlListItemOpened}
       listId={control?.id}
-      isListItemNavigatedTo={isListItemNavigatedTo}
-      setIsListItemNavigatedTo={setIsListItemNavigatedTo}
       previousHandledFragment={previousHandledFragment}
       setPreviousHandledFragment={setPreviousHandledFragment}
     >
@@ -281,30 +270,23 @@ function OSCALCatalogControlListItem(props) {
       />
     </CollapsibleListItem>
   );
+};
+
+interface OSCALCatalogGroupListProps extends CatalogGroupFragmentProps {
+  group: ControlGroup;
+  urlFragment?: string;
+  fragmentPrefix: string;
+  fragmentSuffix: string | undefined;
+  isControlListItemOpened: boolean;
+  setIsControlListItemOpened: (...args: any[]) => void;
 }
 
 /**
  * Creates a catalog group list which contains groups/controls.
  *
- * @param {any} props A set of properties pertaining to a group list
  * @returns A group list component which contains a set of items
  */
-function OSCALCatalogGroupList(props) {
-  /**
-   * {any} group - The current group
-   * {string} urlFragment - The current fragment being handled
-   * {string} fragmentPrefix - The beginning of a fragment which ends with the current group/control
-   *   being handled
-   * {string} fragmentSuffix - The end of a fragment which starts with the current group/control
-   *   being handled
-   * {boolean} setIsControlListItemOpened - isControlListItemOpened Tells whether the current list
-   *   item is opened
-   * {function} setIsControlListItemOpened - Callback function to set whether the list item has
-   *   been navigated to
-   * {string} previousHandledFragment - The fragment that was handled previously
-   * {function} setPreviousHandledFragment - Callback function to set the previously handled
-   *   fragment
-   */
+const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
   const {
     group,
     urlFragment,
@@ -315,7 +297,6 @@ function OSCALCatalogGroupList(props) {
     previousHandledFragment,
     setPreviousHandledFragment,
   } = props;
-  const [isListItemNavigatedTo, setIsListItemNavigatedTo] = React.useState(false);
   const itemText = (
     <OSCALAnchorLinkHeader
       name={appendToFragmentPrefix(
@@ -340,8 +321,6 @@ function OSCALCatalogGroupList(props) {
       fragmentSuffix={fragmentSuffix}
       listItemOpened={isControlListItemOpened}
       setListItemOpened={setIsControlListItemOpened}
-      isListItemNavigatedTo={isListItemNavigatedTo}
-      setIsListItemNavigatedTo={setIsListItemNavigatedTo}
       previousHandledFragment={previousHandledFragment}
       setPreviousHandledFragment={setPreviousHandledFragment}
     >
@@ -381,19 +360,16 @@ function OSCALCatalogGroupList(props) {
       </OSCALControlList>
     </CollapsibleListItem>
   );
+};
+
+export interface OSCALCatalogGroupProps extends CatalogGroupFragmentProps {
+  group: ControlGroup;
+  urlFragment?: string;
+  isControlListItemOpened: boolean;
+  setIsControlListItemOpened: (...args: any[]) => void;
 }
 
-export default function OSCALCatalogGroup(props) {
-  /**
-   * {any} group - The current group
-   * {string} urlFragment - The current fragment being handled
-   * {boolean} isControlListItemOpened - Tells whether the current list item is opened
-   * {function} setIsControlListItemOpened - Callback function to set whether the list item has
-   *   been navigated to
-   * {string} previousHandledFragment - The fragment that was handled previously
-   * {function} setPreviousHandledFragment - Callback function to set the previously handled
-   *   fragment
-   */
+export const OSCALCatalogGroup: React.FC<OSCALCatalogGroupProps> = (props) => {
   const {
     group,
     urlFragment,
@@ -407,11 +383,11 @@ export default function OSCALCatalogGroup(props) {
   const fragmentPrefix = group.id ?? conformLinkIdText(group.title) ?? "";
   const fragmentSuffix = urlFragment
     ? `${urlFragment.substring(urlFragment.indexOf("/") + 1)}`
-    : null;
+    : undefined;
 
   return (
     <OSCALControlList>
-      {group.groups?.map((innerGroup) => (
+      {group.groups?.map((innerGroup: ControlGroup) => (
         <OSCALCatalogGroupList
           group={innerGroup}
           key={innerGroup.title}
@@ -424,7 +400,7 @@ export default function OSCALCatalogGroup(props) {
           setPreviousHandledFragment={setPreviousHandledFragment}
         />
       ))}
-      {group.controls?.map((control) => (
+      {group.controls?.map((control: Control) => (
         <OSCALCatalogControlListItem
           control={control}
           key={control.id}
@@ -438,10 +414,12 @@ export default function OSCALCatalogGroup(props) {
         />
       ))}
       {group.parts
-        ?.map((groupPart) => groupPart.prose)
+        ?.map((groupPart: Part) => groupPart.prose)
         .map((prose) => (
           <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
         ))}
     </OSCALControlList>
   );
-}
+};
+
+export default OSCALCatalogGroup;

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -403,7 +403,7 @@ const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
       setPreviousHandledFragment={setPreviousHandledFragment}
     >
       {group.parts
-        ?.map((groupPart: Part) => groupPart.prose)
+        ?.map((groupPart) => groupPart.prose)
         .map((prose) => (
           <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
         ))}

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -358,6 +358,11 @@ const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
           />
         ))}
       </OSCALControlList>
+      {group.parts
+        ?.map((groupPart: Part) => groupPart.prose)
+        .map((prose) => (
+          <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
+        ))}
     </CollapsibleListItem>
   );
 };
@@ -386,39 +391,41 @@ export const OSCALCatalogGroup: React.FC<OSCALCatalogGroupProps> = (props) => {
     : undefined;
 
   return (
-    <OSCALControlList>
-      {group.groups?.map((innerGroup: ControlGroup) => (
-        <OSCALCatalogGroupList
-          group={innerGroup}
-          key={innerGroup.title}
-          urlFragment={urlFragment}
-          fragmentPrefix={fragmentPrefix}
-          fragmentSuffix={fragmentSuffix}
-          isControlListItemOpened={isControlListItemOpened}
-          setIsControlListItemOpened={setIsControlListItemOpened}
-          previousHandledFragment={previousHandledFragment}
-          setPreviousHandledFragment={setPreviousHandledFragment}
-        />
-      ))}
-      {group.controls?.map((control: Control) => (
-        <OSCALCatalogControlListItem
-          control={control}
-          key={control.id}
-          urlFragment={urlFragment}
-          fragmentPrefix={fragmentPrefix}
-          fragmentSuffix={urlFragment}
-          isControlListItemOpened={isControlListItemOpened}
-          setIsControlListItemOpened={setIsControlListItemOpened}
-          previousHandledFragment={previousHandledFragment}
-          setPreviousHandledFragment={setPreviousHandledFragment}
-        />
-      ))}
+    <>
+      <OSCALControlList>
+        {group.groups?.map((innerGroup: ControlGroup) => (
+          <OSCALCatalogGroupList
+            group={innerGroup}
+            key={innerGroup.title}
+            urlFragment={urlFragment}
+            fragmentPrefix={fragmentPrefix}
+            fragmentSuffix={fragmentSuffix}
+            isControlListItemOpened={isControlListItemOpened}
+            setIsControlListItemOpened={setIsControlListItemOpened}
+            previousHandledFragment={previousHandledFragment}
+            setPreviousHandledFragment={setPreviousHandledFragment}
+          />
+        ))}
+        {group.controls?.map((control: Control) => (
+          <OSCALCatalogControlListItem
+            control={control}
+            key={control.id}
+            urlFragment={urlFragment}
+            fragmentPrefix={fragmentPrefix}
+            fragmentSuffix={urlFragment}
+            isControlListItemOpened={isControlListItemOpened}
+            setIsControlListItemOpened={setIsControlListItemOpened}
+            previousHandledFragment={previousHandledFragment}
+            setPreviousHandledFragment={setPreviousHandledFragment}
+          />
+        ))}
+      </OSCALControlList>
       {group.parts
         ?.map((groupPart: Part) => groupPart.prose)
         .map((prose) => (
           <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
         ))}
-    </OSCALControlList>
+    </>
   );
 };
 

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -21,8 +21,8 @@ import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 import { Control, ControlGroup, Part } from "@easydynamics/oscal-types";
 
 interface CatalogGroupFragmentProps {
-  previousHandledFragment: string | undefined;
-  setPreviousHandledFragment: (...args: any[]) => void;
+  readonly previousHandledFragment: string | undefined;
+  readonly setPreviousHandledFragment: (...args: any[]) => void;
 }
 
 export const OSCALControlList = styled(List)`
@@ -74,14 +74,14 @@ function isMatchingListItem(
 }
 
 interface CollapsibleListItemProps extends CatalogGroupFragmentProps {
-  urlFragment?: string;
-  group?: ControlGroup;
-  listId: string;
-  itemText: ReactNode;
-  children: ReactNode;
-  fragmentSuffix: string | undefined;
-  listItemOpened?: boolean;
-  setListItemOpened: (...args: any[]) => void;
+  readonly urlFragment?: string;
+  readonly group?: ControlGroup;
+  readonly listId: string;
+  readonly itemText: ReactNode;
+  readonly children: ReactNode;
+  readonly fragmentSuffix: string | undefined;
+  readonly listItemOpened?: boolean;
+  readonly setListItemOpened: (...args: any[]) => void;
 }
 
 /**
@@ -149,10 +149,10 @@ const CollapsibleListItem: React.FC<CollapsibleListItemProps> = (props) => {
 };
 
 interface WithdrawnListItemProps extends CatalogGroupFragmentProps {
-  children: ReactNode;
-  urlFragment?: string;
-  listId: string;
-  fragmentSuffix: string | undefined;
+  readonly children: ReactNode;
+  readonly urlFragment?: string;
+  readonly listId: string;
+  readonly fragmentSuffix: string | undefined;
 }
 
 /**
@@ -191,12 +191,12 @@ const WithdrawnListItem: React.FC<WithdrawnListItemProps> = (props) => {
 };
 
 interface OSCALCatalogControlListItemProps extends CatalogGroupFragmentProps {
-  control: Control;
-  urlFragment?: string;
-  fragmentPrefix: string;
-  fragmentSuffix: string | undefined;
-  isControlListItemOpened: boolean;
-  setIsControlListItemOpened: (...args: any[]) => void;
+  readonly control: Control;
+  readonly urlFragment?: string;
+  readonly fragmentPrefix: string;
+  readonly fragmentSuffix: string | undefined;
+  readonly isControlListItemOpened: boolean;
+  readonly setIsControlListItemOpened: (...args: any[]) => void;
 }
 
 /**
@@ -273,12 +273,12 @@ const OSCALCatalogControlListItem: React.FC<OSCALCatalogControlListItemProps> = 
 };
 
 interface OSCALCatalogGroupListProps extends CatalogGroupFragmentProps {
-  group: ControlGroup;
-  urlFragment?: string;
-  fragmentPrefix: string;
-  fragmentSuffix: string | undefined;
-  isControlListItemOpened: boolean;
-  setIsControlListItemOpened: (...args: any[]) => void;
+  readonly group: ControlGroup;
+  readonly urlFragment?: string;
+  readonly fragmentPrefix: string;
+  readonly fragmentSuffix: string | undefined;
+  readonly isControlListItemOpened: boolean;
+  readonly setIsControlListItemOpened: (...args: any[]) => void;
 }
 
 /**
@@ -368,10 +368,10 @@ const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
 };
 
 export interface OSCALCatalogGroupProps extends CatalogGroupFragmentProps {
-  group: ControlGroup;
-  urlFragment?: string;
-  isControlListItemOpened: boolean;
-  setIsControlListItemOpened: (...args: any[]) => void;
+  readonly group: ControlGroup;
+  readonly urlFragment?: string;
+  readonly isControlListItemOpened: boolean;
+  readonly setIsControlListItemOpened: (...args: any[]) => void;
 }
 
 export const OSCALCatalogGroup: React.FC<OSCALCatalogGroupProps> = (props) => {

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -232,7 +232,7 @@ const WithdrawnListItem: React.FC<WithdrawnListItemProps> = (props) => {
   );
 };
 
-interface OSCALCatalogControlListItemProps extends CatalogGroupFragmentProps {
+export interface OSCALCatalogControlListItemProps extends CatalogGroupFragmentProps {
   /**
    * The current control
    */
@@ -264,7 +264,7 @@ interface OSCALCatalogControlListItemProps extends CatalogGroupFragmentProps {
  *
  * @returns A list item component which contains sub list item(s) and/or collapsible information
  */
-const OSCALCatalogControlListItem: React.FC<OSCALCatalogControlListItemProps> = (props) => {
+export const OSCALCatalogControlListItem: React.FC<OSCALCatalogControlListItemProps> = (props) => {
   const {
     control,
     urlFragment,

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -65,12 +65,12 @@ function isMatchingListItem(
   listId: string
 ): boolean {
   // Ensure fragment exists and split by groupings
-  if (!urlFragment || previousHandledFragment === urlFragment) {
-    return false;
-  }
-  // Determine if current control/group list state matches ID
-  const currentList = fragmentSuffix?.split("/")[0];
-  return currentList === listId;
+  //  & Determine if current control/group list state matches ID
+  return (
+    !!urlFragment &&
+    previousHandledFragment !== urlFragment &&
+    fragmentSuffix?.split("/")?.[0] === listId
+  );
 }
 
 interface CollapsibleListItemProps extends CatalogGroupFragmentProps {

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -21,7 +21,13 @@ import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 import { Control, ControlGroup, Part } from "@easydynamics/oscal-types";
 
 interface CatalogGroupFragmentProps {
+  /**
+   * The fragment that was handled previously
+   */
   readonly previousHandledFragment: string | undefined;
+  /**
+   * Callback function to set the previously handled fragment
+   */
   readonly setPreviousHandledFragment: (...args: any[]) => void;
 }
 
@@ -74,13 +80,37 @@ function isMatchingListItem(
 }
 
 interface CollapsibleListItemProps extends CatalogGroupFragmentProps {
+  /**
+   * The current fragment being handled
+   */
   readonly urlFragment?: string;
+  /**
+   * A catalog group that contains either groups/controls
+   */
   readonly group?: ControlGroup;
+  /**
+   * Identification used for a list
+   */
   readonly listId: string;
+  /**
+   * The title of an item
+   */
   readonly itemText: ReactNode;
+  /**
+   * Children underneath the list item - either a control/group or control/group
+   */
   readonly children: ReactNode;
+  /**
+   * The end of a fragment which starts with the current group/control being handled
+   */
   readonly fragmentSuffix: string | undefined;
+  /**
+   * Tells whether or not the current list item is opened
+   */
   readonly listItemOpened?: boolean;
+  /**
+   * Callback function to set list item opened
+   */
   readonly setListItemOpened: (...args: any[]) => void;
 }
 
@@ -149,9 +179,21 @@ const CollapsibleListItem: React.FC<CollapsibleListItemProps> = (props) => {
 };
 
 interface WithdrawnListItemProps extends CatalogGroupFragmentProps {
+  /**
+   * Children underneath the list item - either a control/group or control/group
+   */
   readonly children: ReactNode;
+  /**
+   * The current fragment being handled
+   */
   readonly urlFragment?: string;
+  /**
+   * Identification used for a list
+   */
   readonly listId: string;
+  /**
+   * The end of a fragment which starts with the current group/control being handled
+   */
   readonly fragmentSuffix: string | undefined;
 }
 
@@ -191,12 +233,30 @@ const WithdrawnListItem: React.FC<WithdrawnListItemProps> = (props) => {
 };
 
 interface OSCALCatalogControlListItemProps extends CatalogGroupFragmentProps {
+  /**
+   * The current control
+   */
   readonly control: Control;
+  /**
+   * he current fragment being handled
+   */
   readonly urlFragment?: string;
+  /**
+   * The beginning of a fragment which ends with the current group/control being handled
+   */
   readonly fragmentPrefix: string;
+  /**
+   * The end of a fragment which starts with the current group/control being handled
+   */
   readonly fragmentSuffix: string | undefined;
+  /**
+   * Tells whether the current list item is opened
+   */
   readonly isControlListItemOpened: boolean;
-  readonly setIsControlListItemOpened: (...args: any[]) => void;
+  /**
+   * Callback function to set whether the list item has been navigated to
+   */
+  readonly setIsControlListItemOpened: (value: boolean) => void;
 }
 
 /**
@@ -273,12 +333,30 @@ const OSCALCatalogControlListItem: React.FC<OSCALCatalogControlListItemProps> = 
 };
 
 interface OSCALCatalogGroupListProps extends CatalogGroupFragmentProps {
+  /**
+   * The current group
+   */
   readonly group: ControlGroup;
+  /**
+   * The current fragment being handled
+   */
   readonly urlFragment?: string;
+  /**
+   * The beginning of a fragment which ends with the current group/control
+   */
   readonly fragmentPrefix: string;
+  /**
+   * The end of a fragment which starts with the current group/control being handled
+   */
   readonly fragmentSuffix: string | undefined;
+  /**
+   * Tells whether the current list item is opened
+   */
   readonly isControlListItemOpened: boolean;
-  readonly setIsControlListItemOpened: (...args: any[]) => void;
+  /**
+   * Callback function to set whether the list item has been navigated to
+   */
+  readonly setIsControlListItemOpened: (value: boolean) => void;
 }
 
 /**
@@ -324,6 +402,11 @@ const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
       previousHandledFragment={previousHandledFragment}
       setPreviousHandledFragment={setPreviousHandledFragment}
     >
+      {group.parts
+        ?.map((groupPart: Part) => groupPart.prose)
+        .map((prose) => (
+          <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
+        ))}
       <OSCALControlList>
         {group.groups?.map((innerGroup) => (
           <OSCALCatalogGroupList
@@ -358,20 +441,27 @@ const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
           />
         ))}
       </OSCALControlList>
-      {group.parts
-        ?.map((groupPart: Part) => groupPart.prose)
-        .map((prose) => (
-          <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
-        ))}
     </CollapsibleListItem>
   );
 };
 
 export interface OSCALCatalogGroupProps extends CatalogGroupFragmentProps {
+  /**
+   * The current group
+   */
   readonly group: ControlGroup;
+  /**
+   * The current fragment being handled
+   */
   readonly urlFragment?: string;
+  /**
+   * Tells whether the current list item is opened
+   */
   readonly isControlListItemOpened: boolean;
-  readonly setIsControlListItemOpened: (...args: any[]) => void;
+  /**
+   * Callback function to set whether the list item has been navigated to
+   */
+  readonly setIsControlListItemOpened: (value: boolean) => void;
 }
 
 export const OSCALCatalogGroup: React.FC<OSCALCatalogGroupProps> = (props) => {
@@ -392,6 +482,11 @@ export const OSCALCatalogGroup: React.FC<OSCALCatalogGroupProps> = (props) => {
 
   return (
     <>
+      {group.parts
+        ?.map((groupPart: Part) => groupPart.prose)
+        .map((prose) => (
+          <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
+        ))}
       <OSCALControlList>
         {group.groups?.map((innerGroup: ControlGroup) => (
           <OSCALCatalogGroupList
@@ -420,11 +515,6 @@ export const OSCALCatalogGroup: React.FC<OSCALCatalogGroupProps> = (props) => {
           />
         ))}
       </OSCALControlList>
-      {group.parts
-        ?.map((groupPart: Part) => groupPart.prose)
-        .map((prose) => (
-          <OSCALMarkupMultiLine key={prose}>{prose}</OSCALMarkupMultiLine>
-        ))}
     </>
   );
 };

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroups.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroups.js
@@ -13,6 +13,7 @@ import OSCALCatalogGroup from "./OSCALCatalogGroup";
 import OSCALControlParamLegend from "./OSCALControlParamLegend";
 import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import { conformLinkIdText } from "./oscal-utils/OSCALLinkUtils";
+import { OSCALMarkupLine } from "./OSCALMarkupProse";
 
 export const OSCALControlList = styled(List)`
   padding-left: 2em;
@@ -131,7 +132,7 @@ export default function OSCALCatalogGroups(props) {
           <Grid container>
             <Grid item sm={9}>
               <OSCALAnchorLinkHeader>
-                <OSCALSectionHeader>Control Groups</OSCALSectionHeader>
+                <OSCALSectionHeader>Controls</OSCALSectionHeader>
               </OSCALAnchorLinkHeader>
             </Grid>
             <Grid item sm={3}>
@@ -149,7 +150,7 @@ export default function OSCALCatalogGroups(props) {
                 {groups?.map((group) => (
                   <ComponentTab
                     key={group.title}
-                    label={group.title}
+                    label={<OSCALMarkupLine>{group.title}</OSCALMarkupLine>}
                     {...a11yProps(group.id ?? conformLinkIdText(group.title))}
                     value={group.id ?? conformLinkIdText(group.title)}
                   />

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroups.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroups.test.tsx
@@ -1,5 +1,5 @@
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
 import OSCALCatalogGroups from "./OSCALCatalogGroups";
 
 const testGroups = [
@@ -35,9 +35,9 @@ const testGroups = [
   },
 ];
 
-function getTextByChildren(text) {
-  function result(_content, node) {
-    const hasText = (checkNode) => checkNode.textContent === text;
+function getTextByChildren(text: string) {
+  function result(_content: any, node: any) {
+    const hasText = (checkNode: any) => checkNode.textContent === text;
     const nodeHasText = hasText(node);
     // This is necessary because we are providing a query function to override how
     // text search is performed.

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroups.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroups.test.tsx
@@ -1,8 +1,9 @@
+import { ControlGroup } from "@easydynamics/oscal-types";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import OSCALCatalogGroups from "./OSCALCatalogGroups";
 
-const testGroups = [
+const testGroups: ControlGroup[] = [
   {
     id: "parent-group",
     class: "family",
@@ -30,6 +31,22 @@ const testGroups = [
         class: "family",
         title: "Sibling Title",
         controls: [{ id: "control2-id", title: "Audit Events" }],
+        parts: [
+          {
+            name: "Parent part prose",
+            prose: "Prose",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Test Group C",
+    parts: [
+      {
+        id: "test-c-overview-1",
+        name: "overview",
+        prose: "This group has prose",
       },
     ],
   },
@@ -84,5 +101,27 @@ describe("OSCALCatalogGroup", () => {
 
     const expand2 = screen.getByText(getTextByChildren("control2-id Audit Events"));
     fireEvent.click(expand2);
+  });
+
+  test("displays outer group prose", () => {
+    render(<OSCALCatalogGroups groups={testGroups} />);
+
+    const expand1 = screen.getByText("Test Group C");
+    fireEvent.click(expand1);
+
+    const prose = screen.getByText("This group has prose");
+
+    expect(prose).toBeVisible();
+  });
+
+  test("displays child group prose", () => {
+    render(<OSCALCatalogGroups groups={testGroups} />);
+
+    const expand1 = screen.getByText("Sibling Title");
+    fireEvent.click(expand1);
+
+    const prose = screen.getByText("Prose");
+
+    expect(prose).toBeVisible();
   });
 });

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroups.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroups.tsx
@@ -75,15 +75,15 @@ TabPanel.propTypes = {
  * Validates if the lowest control provided in an decending list (controlLayers) can be found
  * within the provided groups.
  *
- * @param {*} groups The control groupings
- * @param {*} controlLayers An decending list of groups/controls
- * @param {*} rootLayer The top most layer
+ * @param groups The control groupings
+ * @param controlLayers An decending list of groups/controls
+ * @param rootLayer The top most layer
  * @returns This returns the lowest found control or undefined if not
  */
 function determineControlExists(
   groups: ControlGroup[] | undefined,
-  controlLayers: any,
-  rootLayer: any
+  controlLayers: string[],
+  rootLayer: string
 ): ControlGroup | undefined {
   // Ensure catalog tab grouping exists
   let upperLayer = groups?.find(

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.ts
@@ -98,7 +98,7 @@ export function appendToFragmentPrefix(fragmentPrefix: string, controlId: string
  * @param fragmentSuffix The end of a fragment
  * @returns fragmentSuffix with a removed control
  */
-export function shiftFragmentSuffix(fragmentSuffix: string): string | undefined {
+export function shiftFragmentSuffix(fragmentSuffix: string | undefined): string | undefined {
   return fragmentSuffix
     ? `${fragmentSuffix.substring(fragmentSuffix.indexOf("/") + 1)}`
     : undefined;


### PR DESCRIPTION
Previously OSCALCatalog ignored the `Controls` prop it was passed.
This creates an OSCALControls component to display controls outside
a group.

closes #741 
closes #742


### Testing

**No controls**

https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/main/catalogs/NIST_SP-800-53_rev4_catalog.json

**Controls + Groups**

https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/tuckerzp/group-prose/catalogs/basic-test-catalog.json

**Just Controls**

https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/tuckerzp/group-prose/catalogs/basic-test-catalog-no-groups.json


---

Groups without controls is displayed the same

![image](https://user-images.githubusercontent.com/39490074/234925726-663417e8-8ab3-4ced-b143-0fa768ea4df8.png)

---

`Top Controls` is now shown as a group

![image](https://user-images.githubusercontent.com/39490074/234927875-8dfbc6d2-0986-4e8e-99a9-529375507c2f.png)

---

Top level control groups with `prose` is displayed

![image](https://user-images.githubusercontent.com/39490074/234927950-d86dcfe3-975a-4dee-a8b0-d6b35b9996ea.png)

---

Children groups with `prose` is displayed

![image](https://user-images.githubusercontent.com/39490074/234927988-9ded9b58-3067-4077-a0f6-1ad5a33001b9.png)

---

No groups listed

![image](https://user-images.githubusercontent.com/39490074/234924258-3b749cc2-8c46-4f7b-97e7-3e64fef3e923.png)
