### PR TITLE
feat: display back matter resource types

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
@@ -74,10 +74,12 @@ interface BackMatterTypeRepresentationOptions {
 }
 
 /**
+ * Transform the text for a `type` property on a back matter resource to a more
+ * human-friendly representation.
  *
- * @param value
- * @param opts
- * @returns
+ * @param value the string to transform
+ * @param opts options for the transformation
+ * @returns the transformed string
  */
 function backMatterTypeRepresentation(
   value: string,

--- a/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
@@ -16,6 +16,7 @@ import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
 import OSCALEditableTextField, { EditableFieldProps } from "./OSCALEditableTextField";
 import { Resource, ResourceLink, BackMatter } from "@easydynamics/oscal-types";
 import { ReactElement } from "react";
+import { propWithName } from "./oscal-utils/OSCALPropUtils";
 
 export const OSCALBackMatterCard = styled(Card)(
   ({ theme }) => `
@@ -24,6 +25,73 @@ export const OSCALBackMatterCard = styled(Card)(
     flex-direction: column;
 `
 );
+
+interface BackMatterTypeRepresentationOptions {
+  convertToTitleCase?: boolean;
+}
+
+function backMatterTypeRepresentation(
+  value: string,
+  opts?: BackMatterTypeRepresentationOptions
+): string {
+  switch (value) {
+    case "logo":
+      return "Logo";
+    case "image":
+      return "Image";
+    case "screen-shot":
+      return "Screenshot";
+    case "law":
+      return "Law";
+    case "regulation":
+      return "Regulation";
+    case "standard":
+      return "Standard";
+    case "external-guidance":
+      return "External Guidance";
+    case "acronymns":
+      return "Acronyms";
+    case "citation":
+      return "Citation";
+    case "policy":
+      return "Policy";
+    case "procedure":
+      return "Procedure";
+    case "system-guide":
+      return "System Guide";
+    case "users-guide":
+      return "User's/Administrator's Guide";
+    case "administrators-guide":
+      return "Administrator's Guide";
+    case "rules-of-behavior":
+      return "Rules of Behavior";
+    case "plan":
+      return "Plan";
+    case "artifact":
+      return "Artifact";
+    case "evidence":
+      return "Evidence";
+    case "tool-output":
+      return "Output from a tool";
+    case "raw-data":
+      return "Raw Machine Data";
+    case "interview-notes":
+      return "Interview Notes";
+    case "questionnaire":
+      return "Questionnaire";
+    case "report":
+      return "Report";
+    case "agreement":
+      return "Agreement";
+  }
+  if (opts?.convertToTitleCase) {
+    return value
+      .split("-")
+      .map((str) => str.charAt(0).toUpperCase() + str.slice(1))
+      .join(" ");
+  }
+  return value;
+}
 
 interface TitleDisplayProps {
   /**
@@ -106,6 +174,8 @@ function BackMatterResource(props: BackMatterResourceProps) {
     rlink["media-type"] ||
     guessExtensionFromHref(getAbsoluteUrl(rlink.href, props.parentUrl) ?? "");
 
+  //const resourceType = propWithName(resource.props, "type")?.value;
+  const resourceType = "logo";
   const objectKey = getObjectRootKey(props.partialRestData);
 
   return (
@@ -113,7 +183,7 @@ function BackMatterResource(props: BackMatterResourceProps) {
       <OSCALBackMatterCard>
         <CardContent>
           <Grid container spacing={0}>
-            <Grid item xs={11}>
+            <Grid item xs={10}>
               <TitleDisplay uuid={resource.uuid}>
                 <OSCALEditableTextField
                   fieldName="title"
@@ -136,10 +206,11 @@ function BackMatterResource(props: BackMatterResourceProps) {
                 />
               </TitleDisplay>
             </Grid>
-            <Grid item xs={1}>
-              <Grid container spacing={0} justifyContent="flex-end">
+            <Grid item xs={2}>
+              <Stack direction="row" justifyContent="flex-end">
+                {resourceType && <Chip label={backMatterTypeRepresentation(resourceType)} />}
                 <CitationDisplay resource={resource} />
-              </Grid>
+              </Stack>
             </Grid>
           </Grid>
           <OSCALEditableTextField

--- a/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { styled } from "@mui/material/styles";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
 import Chip from "@mui/material/Chip";
 import Grid from "@mui/material/Grid";
 import Stack from "@mui/material/Stack";
@@ -26,64 +27,67 @@ export const OSCALBackMatterCard = styled(Card)(
 `
 );
 
+// This maps the well-known back matter types to more human-readable names
+// based on their descriptions.
+const backMatterTypeLookup: Record<string, string> = {
+  logo: "Logo",
+  image: "Image",
+  "screen-shot": "Screenshot",
+  law: "Law",
+  regulation: "Regulation",
+  standard: "Standard",
+  "external-guidance": "External Guidance",
+  acronymns: "Acronyms",
+  citation: "Citation",
+  policy: "Policy",
+  procedure: "Procedure",
+  "system-guide": "System Guide",
+  "users-guide": "User's/Administrator's Guide",
+  "administrators-guide": "Administrator's Guide",
+  "rules-of-behavior": "Rules of Behavior",
+  plan: "Plan",
+  artifact: "Artifact",
+  evidence: "Evidence",
+  "tool-output": "Tool output",
+  "raw-data": "Raw Data",
+  "interview-notes": "Interview Notes",
+  questionnaire: "Questionnaire",
+  report: "Report",
+  agreement: "Agreement",
+};
+
 interface BackMatterTypeRepresentationOptions {
+  /**
+   * A mapping of possible values for the `type` field to descriptive names.
+   *
+   * @default - `backMatterTypeLookup`
+   */
+  mapToFriendlyName?: Record<string, string>;
+
+  /**
+   * For values not in the given mapping, whether to transform the name from
+   * the typical kebab-case to title case.
+   *
+   * @default - no conversion is applied to unknown values
+   */
   convertToTitleCase?: boolean;
 }
 
+/**
+ *
+ * @param value
+ * @param opts
+ * @returns
+ */
 function backMatterTypeRepresentation(
   value: string,
   opts?: BackMatterTypeRepresentationOptions
 ): string {
-  switch (value) {
-    case "logo":
-      return "Logo";
-    case "image":
-      return "Image";
-    case "screen-shot":
-      return "Screenshot";
-    case "law":
-      return "Law";
-    case "regulation":
-      return "Regulation";
-    case "standard":
-      return "Standard";
-    case "external-guidance":
-      return "External Guidance";
-    case "acronymns":
-      return "Acronyms";
-    case "citation":
-      return "Citation";
-    case "policy":
-      return "Policy";
-    case "procedure":
-      return "Procedure";
-    case "system-guide":
-      return "System Guide";
-    case "users-guide":
-      return "User's/Administrator's Guide";
-    case "administrators-guide":
-      return "Administrator's Guide";
-    case "rules-of-behavior":
-      return "Rules of Behavior";
-    case "plan":
-      return "Plan";
-    case "artifact":
-      return "Artifact";
-    case "evidence":
-      return "Evidence";
-    case "tool-output":
-      return "Output from a tool";
-    case "raw-data":
-      return "Raw Machine Data";
-    case "interview-notes":
-      return "Interview Notes";
-    case "questionnaire":
-      return "Questionnaire";
-    case "report":
-      return "Report";
-    case "agreement":
-      return "Agreement";
+  const knownName = (opts?.mapToFriendlyName ?? backMatterTypeLookup)[value];
+  if (knownName) {
+    return knownName;
   }
+
   if (opts?.convertToTitleCase) {
     return value
       .split("-")
@@ -174,45 +178,41 @@ function BackMatterResource(props: BackMatterResourceProps) {
     rlink["media-type"] ||
     guessExtensionFromHref(getAbsoluteUrl(rlink.href, props.parentUrl) ?? "");
 
-  //const resourceType = propWithName(resource.props, "type")?.value;
-  const resourceType = "logo";
+  const resourceType = propWithName(resource.props, "type")?.value;
+  const typeDisplay = resourceType && backMatterTypeRepresentation(resourceType);
   const objectKey = getObjectRootKey(props.partialRestData);
 
   return (
     <Grid item xs={3} key={resource.uuid}>
-      <OSCALBackMatterCard>
+      <OSCALBackMatterCard sx={{ height: "100%" }}>
+        <CardHeader
+          title={
+            <TitleDisplay uuid={resource.uuid}>
+              <OSCALEditableTextField
+                fieldName="title"
+                isEditable={props.isEditable}
+                editedField={props.isEditable ? [objectKey, "back-matter", "resources"] : null}
+                editedValue={props.backMatter?.resources}
+                editedValueId={resource.uuid}
+                onFieldSave={props.onFieldSave}
+                partialRestData={
+                  props.isEditable
+                    ? {
+                        [objectKey]: {
+                          uuid: props.partialRestData?.[objectKey].uuid,
+                          "back-matter": props.backMatter,
+                        },
+                      }
+                    : null
+                }
+                value={resource.title}
+              />
+            </TitleDisplay>
+          }
+          subheader={typeDisplay}
+          action={<CitationDisplay resource={resource} />}
+        />
         <CardContent>
-          <Grid container spacing={0}>
-            <Grid item xs={10}>
-              <TitleDisplay uuid={resource.uuid}>
-                <OSCALEditableTextField
-                  fieldName="title"
-                  isEditable={props.isEditable}
-                  editedField={props.isEditable ? [objectKey, "back-matter", "resources"] : null}
-                  editedValue={props.backMatter?.resources}
-                  editedValueId={resource.uuid}
-                  onFieldSave={props.onFieldSave}
-                  partialRestData={
-                    props.isEditable
-                      ? {
-                          [objectKey]: {
-                            uuid: props.partialRestData?.[objectKey].uuid,
-                            "back-matter": props.backMatter,
-                          },
-                        }
-                      : null
-                  }
-                  value={resource.title}
-                />
-              </TitleDisplay>
-            </Grid>
-            <Grid item xs={2}>
-              <Stack direction="row" justifyContent="flex-end">
-                {resourceType && <Chip label={backMatterTypeRepresentation(resourceType)} />}
-                <CitationDisplay resource={resource} />
-              </Stack>
-            </Grid>
-          </Grid>
           <OSCALEditableTextField
             fieldName="description"
             isEditable={props.isEditable}


### PR DESCRIPTION
This adds the `type` prop more prominently on back matter resources, converting it to a human-friendly name. This refactors the back matter cards to use the `CardHeader` so that it's easier to add a subtitle. Additionally, cards use 100% of their height so they're all the same size, which makes them appear more consistent.

![image](https://user-images.githubusercontent.com/850893/234904653-c0b14247-6e98-4162-ab28-c06e0f538590.png)

Resolves https://github.com/EasyDynamics/oscal-react-library/issues/789