### PR TITLE
fix: update type workflow fails because of duplicate path

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -59,7 +59,7 @@ jobs:
           path: schema
       - name: Run the update command
         run: |
-          npx ts-node scripts/generate-types.ts schema/oscal_complete_schema.json packages/oscal-types/src
+          npx ts-node scripts/generate-types.ts schema packages/oscal-types/src
       - name: Save version as output
         id: version
         run: 


### PR DESCRIPTION
Including `oscal_complete_schema.json` in the invocation meant that it was trying to open `schema/oscal_complete_schema.json/oscal_complete_schema.json` which isn't valid -- it should try to open `schema/oscal_complete_schema.json`, which it now does.