### PR TITLE
fix(test): warning from test hovers

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.test.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.test.js
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { usersTestData } from "../test-data/SystemData";
 import OSCALSystemImplementationUsers from "./OSCALSystemImplementationUsers";
+import { act } from "react-dom/test-utils";
 
 describe("OSCALSystemImplementationUsers", () => {
   test("shows 'Users' section title", () => {
@@ -31,7 +32,9 @@ describe("OSCALSystemImplementationUsers", () => {
 
   test("shows name of a user listed", async () => {
     render(<OSCALSystemImplementationUsers users={usersTestData} />);
-    await userEvent.hover(screen.getByText("User 1"));
+    act(() => {
+      userEvent.hover(screen.getByText("User 1"));
+    });
     expect(await screen.findByText("A system user")).toBeInTheDocument();
   });
 
@@ -43,7 +46,9 @@ describe("OSCALSystemImplementationUsers", () => {
 
   test("shows 'Authorized Privileges' description", async () => {
     render(<OSCALSystemImplementationUsers users={usersTestData} />);
-    await userEvent.hover(screen.getByText("privilege title"));
+    act(() => {
+      userEvent.hover(screen.getByText("privilege title"));
+    });
     expect(await screen.findByText("privilege description")).toBeInTheDocument();
   });
 

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.test.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.test.js
@@ -1,9 +1,7 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { usersTestData } from "../test-data/SystemData";
 import OSCALSystemImplementationUsers from "./OSCALSystemImplementationUsers";
-import { act } from "react-dom/test-utils";
 
 describe("OSCALSystemImplementationUsers", () => {
   test("shows 'Users' section title", () => {
@@ -32,9 +30,7 @@ describe("OSCALSystemImplementationUsers", () => {
 
   test("shows name of a user listed", async () => {
     render(<OSCALSystemImplementationUsers users={usersTestData} />);
-    act(() => {
-      userEvent.hover(screen.getByText("User 1"));
-    });
+    fireEvent.mouseOver(screen.getByText("User 1"));
     expect(await screen.findByText("A system user")).toBeInTheDocument();
   });
 
@@ -46,9 +42,7 @@ describe("OSCALSystemImplementationUsers", () => {
 
   test("shows 'Authorized Privileges' description", async () => {
     render(<OSCALSystemImplementationUsers users={usersTestData} />);
-    act(() => {
-      userEvent.hover(screen.getByText("privilege title"));
-    });
+    fireEvent.mouseOver(screen.getByText("privilege title"));
     expect(await screen.findByText("privilege description")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
This resolves the following warning that appears when running our React tests:

    Warning: An update to ForwardRef(Tooltip) inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */