### PR TITLE
chore(anchorlinks): Switch AnchorLinkHeader to .tsx

### DIFF
--- a/packages/oscal-react-library/docs/adding-anchor-links.md
+++ b/packages/oscal-react-library/docs/adding-anchor-links.md
@@ -18,8 +18,8 @@ Within an `oscal-react-library` component, in order to add an anchor link:
 2. Surround the element/text within an `OSCALAnchorLinkHeader` component (which
    must be imported from `src/components/OSCALAnchorLinkHeader`)
 3. (Optional) If you wish for the fragment to be a different value than the
-   default value, specify a string with the `value` property
-   - `value` by default is the embedded text within an `OSCALAnchorLinkHeader`,
+   default value, specify a string with the `name` property
+   - `name` by default is the embedded text within an `OSCALAnchorLinkHeader`,
      lower cased and hyphen separated
 
 ## A Basic Example
@@ -27,7 +27,7 @@ Within an `oscal-react-library` component, in order to add an anchor link:
 Here's an example of a header with an `OSCALAnchorLinkHeader`:
 
 ```js
-<OSCALAnchorLinkHeader value="sample-header">
+<OSCALAnchorLinkHeader name="sample-header">
   <OSCALSectionHeader>Sample Section Header Text</OSCALSectionHeader>
 </OSCALAnchorLinkHeader>
 ```

--- a/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
+++ b/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
@@ -26,11 +26,11 @@ export interface OSCALAnchorLinkHeaderProps {
   /**
    * Value to be used in the id and fragment.
    */
-  value?: any;
+  name?: any;
 }
 
 export const OSCALAnchorLinkHeader: React.FC<OSCALAnchorLinkHeaderProps> = (props) => {
-  const { children, value } = props;
+  const { children, name } = props;
   const [isHover, setIsHover] = useState(false);
   const onEnter = () => {
     setIsHover(true);
@@ -39,7 +39,7 @@ export const OSCALAnchorLinkHeader: React.FC<OSCALAnchorLinkHeaderProps> = (prop
     setIsHover(false);
   };
 
-  const linkId = value || conformLinkIdText(children);
+  const linkId = name || conformLinkIdText(children);
 
   return (
     <Stack

--- a/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
+++ b/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { ReactNode, useState } from "react";
 import Stack from "@mui/material/Stack";
 import LinkIcon from "@mui/icons-material/Link";
 import { Link } from "react-router-dom";
@@ -22,9 +22,10 @@ export interface OSCALAnchorLinkHeaderProps {
    *
    * @example a <Typography />
    */
-  children: any;
+  children: ReactNode;
   /**
-   * Value to be used in the id and fragment.
+   * Value to be used in the id and fragment. If not specified,
+   * children will be used.
    */
   name?: string;
 }

--- a/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
+++ b/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
@@ -54,5 +54,3 @@ export const OSCALAnchorLinkHeader: React.FC<OSCALAnchorLinkHeaderProps> = (prop
     </Stack>
   );
 };
-
-export default OSCALAnchorLinkHeader;

--- a/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
+++ b/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
@@ -26,7 +26,7 @@ export interface OSCALAnchorLinkHeaderProps {
   /**
    * Value to be used in the id and fragment.
    */
-  name?: any;
+  name?: string;
 }
 
 export const OSCALAnchorLinkHeader: React.FC<OSCALAnchorLinkHeaderProps> = (props) => {

--- a/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
+++ b/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
@@ -12,7 +12,16 @@ const AnchorLinkIcon = styled(LinkIcon)(({ theme }) => ({
   color: theme.palette.grey[500],
 }));
 
-export default function OSCALAnchorLinkHeader(props) {
+export interface AnchorLinkProps {
+  urlFragment?: string;
+}
+
+export interface OSCALAnchorLinkHeaderProps {
+  children: any;
+  value?: any;
+}
+
+export const OSCALAnchorLinkHeader: React.FC<OSCALAnchorLinkHeaderProps> = (props) => {
   const { children, value } = props;
   const [isHover, setIsHover] = useState(false);
   const onEnter = () => {
@@ -44,4 +53,6 @@ export default function OSCALAnchorLinkHeader(props) {
       )}
     </Stack>
   );
-}
+};
+
+export default OSCALAnchorLinkHeader;

--- a/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
+++ b/packages/oscal-react-library/src/components/OSCALAnchorLinkHeader.tsx
@@ -17,7 +17,15 @@ export interface AnchorLinkProps {
 }
 
 export interface OSCALAnchorLinkHeaderProps {
+  /**
+   * Text or element to link to.
+   *
+   * @example a <Typography />
+   */
   children: any;
+  /**
+   * Value to be used in the id and fragment.
+   */
   value?: any;
 }
 

--- a/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
@@ -12,7 +12,7 @@ import StyledTooltip from "./OSCALStyledTooltip";
 import { getAbsoluteUrl, guessExtensionFromHref } from "./oscal-utils/OSCALLinkUtils";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import { OSCALMarkupLine } from "./OSCALMarkupProse";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import OSCALEditableTextField, { EditableFieldProps } from "./OSCALEditableTextField";
 import { Resource, ResourceLink, BackMatter } from "@easydynamics/oscal-types";
 import { ReactElement } from "react";

--- a/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
@@ -39,7 +39,7 @@ interface TitleDisplayProps {
 function TitleDisplay(props: TitleDisplayProps): ReactElement {
   const { children, uuid } = props;
   return (
-    <OSCALAnchorLinkHeader value={uuid}>
+    <OSCALAnchorLinkHeader name={uuid}>
       <Typography variant="subtitle1">{children}</Typography>
     </OSCALAnchorLinkHeader>
   );

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.js
@@ -8,7 +8,7 @@ import ListItemText from "@mui/material/ListItemText";
 import { styled } from "@mui/material/styles";
 import React, { useEffect } from "react";
 import OSCALControl from "./OSCALControl";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
 import OSCALControlLabel from "./OSCALControlLabel";
 import { propWithName } from "./oscal-utils/OSCALPropUtils";

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.js
@@ -230,7 +230,7 @@ function OSCALCatalogControlListItem(props) {
 
   const withdrawn = isWithdrawn(control);
   const itemText = (
-    <OSCALAnchorLinkHeader value={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}>
+    <OSCALAnchorLinkHeader name={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}>
       <OSCALControlLabel
         label={propWithName(control.props, "label")?.value}
         id={control.id}
@@ -317,7 +317,7 @@ function OSCALCatalogGroupList(props) {
   const [isListItemNavigatedTo, setIsListItemNavigatedTo] = React.useState(false);
   const itemText = (
     <OSCALAnchorLinkHeader
-      value={appendToFragmentPrefix(
+      name={appendToFragmentPrefix(
         fragmentPrefix,
         group.id ?? conformLinkIdText(group.title)
       ).toLowerCase()}

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroups.js
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroups.js
@@ -11,7 +11,7 @@ import React, { useEffect } from "react";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import OSCALCatalogGroup from "./OSCALCatalogGroup";
 import OSCALControlParamLegend from "./OSCALControlParamLegend";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import { conformLinkIdText } from "./oscal-utils/OSCALLinkUtils";
 
 export const OSCALControlList = styled(List)`

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinitionComponent.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinitionComponent.js
@@ -12,7 +12,7 @@ import TableRow from "@mui/material/TableRow";
 import OSCALResponsibleRoles from "./OSCALResponsibleRoles";
 import StyledTooltip from "./OSCALStyledTooltip";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 
 export default function OSCALComponentDefinitionComponent(props) {
   return (

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinitionControlImplementation.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinitionControlImplementation.js
@@ -6,7 +6,7 @@ import { List, ListItem, ListItemText } from "@mui/material";
 import OSCALControlImplementationImplReq from "./OSCALControlImplementationImplReq";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import OSCALControlParamLegend from "./OSCALControlParamLegend";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 
 export default function OSCALComponentDefinitionControlImplementation(props) {
   return (

--- a/packages/oscal-react-library/src/components/OSCALControl.js
+++ b/packages/oscal-react-library/src/components/OSCALControl.js
@@ -142,7 +142,7 @@ export default function OSCALControl(props) {
         <Grid container spacing={1}>
           <Grid item xs={12}>
             <OSCALAnchorLinkHeader
-              value={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}
+              name={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}
             >
               <Typography
                 variant="h6"

--- a/packages/oscal-react-library/src/components/OSCALControl.js
+++ b/packages/oscal-react-library/src/components/OSCALControl.js
@@ -7,7 +7,7 @@ import Grid from "@mui/material/Grid";
 import OSCALControlLabel from "./OSCALControlLabel";
 import OSCALControlPart from "./OSCALControlPart";
 import OSCALControlModification from "./OSCALControlModification";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
 import { propWithName } from "./oscal-utils/OSCALPropUtils";
 import { appendToFragmentPrefix } from "./oscal-utils/OSCALLinkUtils";

--- a/packages/oscal-react-library/src/components/OSCALControlImplementation.js
+++ b/packages/oscal-react-library/src/components/OSCALControlImplementation.js
@@ -8,7 +8,7 @@ import OSCALControlImplementationImplReq from "./OSCALControlImplementationImplR
 import OSCALControlImplementationAdd from "./OSCALControlImplementationAdd";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import OSCALControlParamLegend from "./OSCALControlParamLegend";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 
 /**
  * Creates the control implementation by setting up the header and outer grid elements

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -37,7 +37,7 @@ import React, { ReactNode, useEffect } from "react";
 import { OSCALSection } from "../styles/CommonPageStyles";
 import { propWithName } from "./oscal-utils/OSCALPropUtils";
 import OSCALEditableTextField, { EditableFieldProps } from "./OSCALEditableTextField";
-import OSCALAnchorLinkHeader, { AnchorLinkProps } from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader, AnchorLinkProps } from "./OSCALAnchorLinkHeader";
 import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 import {
   Address,

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -37,7 +37,7 @@ import React, { ReactNode, useEffect } from "react";
 import { OSCALSection } from "../styles/CommonPageStyles";
 import { propWithName } from "./oscal-utils/OSCALPropUtils";
 import OSCALEditableTextField, { EditableFieldProps } from "./OSCALEditableTextField";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import OSCALAnchorLinkHeader, { AnchorLinkProps } from "./OSCALAnchorLinkHeader";
 import { OSCALMarkupLine, OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 import {
   Address,
@@ -543,9 +543,8 @@ const OSCALMetadataBasicData: React.FC<OSCALMetadataBasicDataProps> = (props) =>
   );
 };
 
-interface OSCALMetadataRolesProps {
+interface OSCALMetadataRolesProps extends AnchorLinkProps {
   roles: Role[] | undefined;
-  urlFragment?: string;
 }
 
 const OSCALMetadataRoles: React.FC<OSCALMetadataRolesProps> = (props) => {
@@ -563,10 +562,9 @@ const OSCALMetadataRoles: React.FC<OSCALMetadataRolesProps> = (props) => {
   );
 };
 
-interface OSCALMetadataPartiesProps {
+interface OSCALMetadataPartiesProps extends AnchorLinkProps {
   metadata: PublicationMetadata;
   parties: PartyOrganizationOrPerson[] | undefined;
-  urlFragment?: string;
 }
 
 const OSCALMetadataParties: React.FC<OSCALMetadataPartiesProps> = (props) => {
@@ -595,9 +593,8 @@ const OSCALMetadataParties: React.FC<OSCALMetadataPartiesProps> = (props) => {
   );
 };
 
-interface OSCALMetadataLocationsProps {
+interface OSCALMetadataLocationsProps extends AnchorLinkProps {
   locations: Location[] | undefined;
-  urlFragment?: string | undefined;
 }
 
 const OSCALMetadataLocations: React.FC<OSCALMetadataLocationsProps> = (props) => {
@@ -702,7 +699,7 @@ export const OSCALMetadataLocation: React.FC<OSCALMetadataLocationProps> = (prop
   );
 };
 
-interface OSCALMetadataFieldAreaProps {
+interface OSCALMetadataFieldAreaProps extends AnchorLinkProps {
   /**
    * Title of the accordion.
    */
@@ -715,7 +712,6 @@ interface OSCALMetadataFieldAreaProps {
    * Summary element near title.
    */
   summary?: ReactNode;
-  urlFragment?: string;
 }
 
 const OSCALMetadataFieldArea: React.FC<OSCALMetadataFieldAreaProps> = (props) => {
@@ -764,12 +760,11 @@ export const OSCALMetadataKeyword: React.FC<OSCALMetadataKeywordProps> = (props)
   return <>{text && <Chip label={text} size="small" role="chip" />}</>;
 };
 
-export interface OSCALMetadataKeywordsProps {
+export interface OSCALMetadataKeywordsProps extends AnchorLinkProps {
   /**
    * Comma seperated list of keywords.
    */
   keywords: string | undefined;
-  urlFragment?: string;
 }
 
 export const OSCALMetadataKeywords: React.FC<OSCALMetadataKeywordsProps> = (props) => {
@@ -789,12 +784,11 @@ export const OSCALMetadataKeywords: React.FC<OSCALMetadataKeywordsProps> = (prop
   );
 };
 
-interface OSCALMetadataProps extends EditableFieldProps {
+interface OSCALMetadataProps extends EditableFieldProps, AnchorLinkProps {
   /**
    * The metadata of an OSCAL document.
    */
   metadata: PublicationMetadata;
-  urlFragment?: string;
 }
 
 export const OSCALMetadata: React.FC<OSCALMetadataProps> = (props) => {

--- a/packages/oscal-react-library/src/components/OSCALProfile.js
+++ b/packages/oscal-react-library/src/components/OSCALProfile.js
@@ -10,7 +10,7 @@ import OSCALBackMatter from "./OSCALBackMatter";
 import { OSCALResolveProfile } from "./oscal-utils/OSCALProfileResolver";
 import OSCALProfileCatalogInheritance from "./OSCALProfileCatalogInheritance";
 import OSCALControlParamLegend from "./OSCALControlParamLegend";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 
 /**
  * Displays a given OSCAL Profile is an easily consumable format. According to NIST, a profile

--- a/packages/oscal-react-library/src/components/OSCALProfileCatalogInheritance.js
+++ b/packages/oscal-react-library/src/components/OSCALProfileCatalogInheritance.js
@@ -8,7 +8,7 @@ import Chip from "@mui/material/Chip";
 import Typography from "@mui/material/Typography";
 import CardContent from "@mui/material/CardContent";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 
 export default function OSCALProfileCatalogInheritance(props) {
   const documentLabel = (item) => (

--- a/packages/oscal-react-library/src/components/OSCALProfileCatalogInheritance.js
+++ b/packages/oscal-react-library/src/components/OSCALProfileCatalogInheritance.js
@@ -27,7 +27,7 @@ export default function OSCALProfileCatalogInheritance(props) {
     <OSCALSection>
       <Card>
         <CardContent>
-          <OSCALAnchorLinkHeader value="profile-catalog-inheritance">
+          <OSCALAnchorLinkHeader name="profile-catalog-inheritance">
             <OSCALSectionHeader>Profiles/Catalog Inheritance</OSCALSectionHeader>
           </OSCALAnchorLinkHeader>
           <TreeView

--- a/packages/oscal-react-library/src/components/OSCALSystemCharacteristics.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemCharacteristics.js
@@ -15,7 +15,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import StyledTooltip from "./OSCALStyledTooltip";
 import OSCALDiagram from "./OSCALDiagram";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 
 export default function OSCALSystemCharacteristics(props) {
   return (

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementation.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementation.js
@@ -8,7 +8,7 @@ import OSCALSystemImplementationComponents from "./OSCALSystemImplementationComp
 import OSCALSystemImplementationInventoryItems from "./OSCALSystemImplementationInventoryItems";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 
 export default function OSCALSystemImplementation(props) {
   if (!props.systemImplementation) {

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationComponents.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationComponents.js
@@ -14,7 +14,7 @@ import {
   ComponentTableCell,
   StyledTableHead,
 } from "./OSCALSystemImplementationTableStyles";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import PropertiesTable from "./OSCALSystemImplementationPropertiesTable";
 
 export default function OSCALSystemImplementationComponents(props) {

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationInventoryItems.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationInventoryItems.js
@@ -10,7 +10,7 @@ import {
   StyledTableRow,
   StyledTableHead,
 } from "./OSCALSystemImplementationTableStyles";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import PropertiesTable from "./OSCALSystemImplementationPropertiesTable";
 
 function OSCALResponsibleParties(props) {

--- a/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.js
+++ b/packages/oscal-react-library/src/components/OSCALSystemImplementationUsers.js
@@ -12,7 +12,7 @@ import {
   StyledTableRow,
   StyledTableHead,
 } from "./OSCALSystemImplementationTableStyles";
-import OSCALAnchorLinkHeader from "./OSCALAnchorLinkHeader";
+import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
 import PropertiesTable from "./OSCALSystemImplementationPropertiesTable";
 
 function FunctionsPreformedTable(props) {


### PR DESCRIPTION
This adds an interface with two `any` values. We should eventually be
more explicit about the type, but the helper this function relies on
must be `any`.