### PR TITLE
chore: fix update workflow (by ignoring TypeScript)

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -34,18 +34,22 @@ jobs:
           cache: npm
 
       - name: Install latest npm and and npm-check-updates
-        run: npm install -g npm@latest npm-check-updates@latest
+        run: npm install -g npm@latest npm-check-updates@latest lerna@latest
+
+      - name: Install the required project tooling
+        run: |
+          npm ci
 
       - name: Update project dependencies
         run: |-
           # Only allow minor/patch versions of react (and tightly-couple packages) and
           # upgrade all others to the newest version available.
           # Upgrade packages in the root
-          ncu --deep --upgrade --filter "react* @testing-library/react" --target minor
-          ncu --deep --upgrade --reject "react* @testing-library/react"
+          ncu --deep --upgrade --filter "react* @testing-library/react typescript" --target minor
+          ncu --deep --upgrade --reject "react* @testing-library/react typescript"
           # Upgrade packaes everyhwere (same as we just did but with lerna)
-          lerna exec --parallel ncu -- --deep --upgrade --filter "'react* @testing-library/react'" --target minor
-          lerna exec --parallel ncu -- --deep --upgrade --reject "'react* @testing-library/react'"
+          lerna exec --parallel ncu -- --deep --upgrade --filter "'react* @testing-library/react typescript'" --target minor
+          lerna exec --parallel ncu -- --deep --upgrade --reject "'react* @testing-library/react typescript'"
 
       - name: Install updated dependencies
         run: |-


### PR DESCRIPTION
Because `react-scripts` (incorrectly) specifies that it is only
compatible with TypeScript `^4.0`. TypeScript doesn't use semantic
versioning so that isn't correct. TypeScript 5.0 is out now without any
relevant breaking changes; however, `react-scripts` still declares
itself as incompatible and has not updated its `package.json` to reflect
the compatibility. Issues and PRs have been opened upstream but have not
been merged.

We will hold on TS v4.9.x for now rather than trying to handle this
manually with `overrides` which will add more complexity than we need.
We can remove `typescript` from the lists in the `ncu` command once our
dependencies fix their packaging bugs.
