### PR TITLE
feat(party): display metadata party logos

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -86,6 +86,8 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = ({
         onFieldSave={onFieldSave}
         partialRestData={partialRestData}
         urlFragment={urlFragment}
+        parentUrl={parentUrl}
+        backMatter={catalog["back-matter"]}
       />
 
       {catalog.groups ? (

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinition.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinition.js
@@ -66,6 +66,8 @@ export default function OSCALComponentDefinition(props) {
         onFieldSave={props.onFieldSave}
         partialRestData={partialRestData}
         urlFragment={props.urlFragment}
+        parentUrl={props.parentUrl}
+        backMatter={props.componentDefinition["back-matter"]}
       />
       <OSCALProfileCatalogInheritance inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs} />
       {Object.entries(props.componentDefinition.components).map(([key, component]) => (

--- a/packages/oscal-react-library/src/components/OSCALDiagram.js
+++ b/packages/oscal-react-library/src/components/OSCALDiagram.js
@@ -14,9 +14,9 @@ export default function OSCALDiagram(props) {
     diagramUri = resolveLinkHref(
       props.backMatter,
       link.href,
-      props.parentUrl.startsWith(".") ? null : props.parentUrl,
       /^image\//,
-      false
+      false,
+      props.parentUrl.startsWith(".") ? null : props.parentUrl
     );
   } catch (err) {
     // Silently fail on unresolved diagram resources

--- a/packages/oscal-react-library/src/components/OSCALDiagram.js
+++ b/packages/oscal-react-library/src/components/OSCALDiagram.js
@@ -11,13 +11,13 @@ export default function OSCALDiagram(props) {
 
   let diagramUri;
   try {
-    diagramUri = resolveLinkHref(
-      props.backMatter,
-      link.href,
-      /^image\//,
-      false,
-      props.parentUrl.startsWith(".") ? null : props.parentUrl
-    );
+    diagramUri = resolveLinkHref({
+      backMatter: props.backMatter,
+      href: link.href,
+      mediaType: /^image\//,
+      parentUrl: props.parentUrl.startsWith(".") ? null : props.parentUrl,
+      preferBase64: false,
+    });
   } catch (err) {
     // Silently fail on unresolved diagram resources
     diagramUri = link.href;

--- a/packages/oscal-react-library/src/components/OSCALMetadata.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.test.tsx
@@ -47,6 +47,24 @@ describe("OSCAL metadata parties", () => {
     expect(button).toBeVisible();
   });
 
+  test(`displays logo`, () => {
+    render(<OSCALMetadata metadata={metadataTestData} />);
+
+    const expand = screen.getByText("Parties");
+    fireEvent.click(expand);
+
+    const button = screen.getByRole("button", {
+      name: /some group of people details button/i,
+    });
+
+    fireEvent.click(button);
+
+    const logo = screen.getByAltText("Some group of people logo");
+
+    expect(logo).toBeVisible();
+    expect(logo).toHaveAttribute("src", "https://example.png");
+  });
+
   test(`displays email contact info`, () => {
     render(<OSCALMetadata metadata={metadataTestData} />);
 
@@ -57,7 +75,7 @@ describe("OSCAL metadata parties", () => {
       name: /some group of people details button/i,
     });
 
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Email")).toBeVisible();
     expect(screen.getByRole("link", { name: /owners@email\.org/i })).toBeVisible();
@@ -72,7 +90,7 @@ describe("OSCAL metadata parties", () => {
     const button = screen.getByRole("button", {
       name: /some group of people details button/i,
     });
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Phone")).toBeVisible();
     expect(screen.getByRole("link", { name: /\+18005555555/i })).toBeVisible();
@@ -88,7 +106,7 @@ describe("OSCAL metadata parties", () => {
       name: /some group of people details button/i,
     });
 
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Phone")).toBeVisible();
     expect(screen.getByRole("link", { name: /\+18004444444/i })).toBeVisible();
@@ -104,7 +122,7 @@ describe("OSCAL metadata parties", () => {
       name: /some group of people details button/i,
     });
 
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Phone")).toBeVisible();
     expect(screen.getByRole("link", { name: /\+18007777777/i })).toBeVisible();
@@ -120,7 +138,7 @@ describe("OSCAL metadata parties", () => {
       name: /some group of people details button/i,
     });
 
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Phone")).toBeVisible();
     expect(screen.getByRole("link", { name: /\+1800666666/i })).toBeVisible();
@@ -136,7 +154,7 @@ describe("OSCAL metadata parties", () => {
       name: /some group of people details button/i,
     });
 
-    button.click();
+    fireEvent.click(button);
     expect(screen.getByText("Address")).toBeVisible();
     expect(screen.getByText(/0000 stsuite 3city, state 0000us/i)).toBeVisible();
   });
@@ -151,7 +169,7 @@ describe("OSCAL metadata parties", () => {
       name: /some group of people details button/i,
     });
 
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Address")).toBeVisible();
     expect(screen.getByText(/1111 road stcity, state 0000us/i)).toBeVisible();
@@ -167,7 +185,7 @@ describe("OSCAL metadata parties", () => {
       name: /some group of people details button/i,
     });
 
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Address")).toBeVisible();
     expect(screen.getByText(/2222 stcity, state 0000us/i)).toBeVisible();
@@ -197,7 +215,7 @@ describe("OSCAL metadata roles", () => {
     const button = screen.getByRole("button", {
       name: /document creator details button/i,
     });
-    button.click();
+    fireEvent.click(button);
 
     const title = screen.getByRole("heading", { name: /document creator/i });
     const description = screen.getByText("Creates documents");
@@ -230,7 +248,7 @@ describe("OSCAL metadata locations", () => {
     const button = screen.getByRole("button", {
       name: /Example Location details button/i,
     });
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Address")).toBeVisible();
     expect(screen.getByText(/0000 stsuite 3city, state 0000us/i)).toBeVisible();
@@ -245,7 +263,7 @@ describe("OSCAL metadata locations", () => {
     const button = screen.getByRole("button", {
       name: /Example Location details button/i,
     });
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Phone")).toBeVisible();
     expect(screen.getByRole("link", { name: /\+18004444444/i })).toBeVisible();
@@ -260,7 +278,7 @@ describe("OSCAL metadata locations", () => {
     const button = screen.getByRole("button", {
       name: /Example Location details button/i,
     });
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("Email")).toBeVisible();
     expect(screen.getByRole("link", { name: /owners@email\.org/i })).toBeVisible();
@@ -275,7 +293,7 @@ describe("OSCAL metadata locations", () => {
     const button = screen.getByRole("button", {
       name: /Example Location details button/i,
     });
-    button.click();
+    fireEvent.click(button);
 
     expect(screen.getByText("URLs")).toBeVisible();
     expect(screen.getByRole("link", { name: /www\.website\.com/i })).toBeVisible();

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -319,15 +319,15 @@ const maybeResolveUri = (
   backMatter: BackMatter | undefined,
   href: string,
   mediaType: RegExp,
-  preferBase64: boolean,
-  parentUrl?: string
+  parentUrl?: string,
+  preferBase64?: boolean
 ) => {
   if (!backMatter) {
     return undefined;
   }
 
   try {
-    return resolveLinkHref(backMatter, href, mediaType, preferBase64, parentUrl);
+    return resolveLinkHref({ backMatter, href, mediaType, preferBase64, parentUrl });
   } catch (_) {
     return undefined;
   }
@@ -343,8 +343,8 @@ const OSCALMetadataPartyLogo: React.FC<OSCALMetadataPartyLogoProps> = ({
       uriReferenceLookup.backMatter,
       link.href,
       /^image\//,
-      false,
-      uriReferenceLookup.parentUrl
+      uriReferenceLookup.parentUrl,
+      false
     ) ?? link.href;
 
   return <img src={imageSrc} alt={`${partyName} logo`} style={{ maxWidth: "10em" }} />;
@@ -906,6 +906,7 @@ export const OSCALMetadata: React.FC<OSCALMetadataProps> = (props) => {
             <OSCALMetadataParties
               parties={props.metadata?.parties}
               metadata={props.metadata}
+              urlFragment={props.urlFragment}
               uriReferenceLookup={{ backMatter: props.backMatter, parentUrl: props.parentUrl }}
             />
             <OSCALMetadataRoles roles={props.metadata?.roles} urlFragment={props.urlFragment} />

--- a/packages/oscal-react-library/src/components/OSCALProfile.js
+++ b/packages/oscal-react-library/src/components/OSCALProfile.js
@@ -146,6 +146,8 @@ export default function OSCALProfile(props) {
         onFieldSave={props.onFieldSave}
         partialRestData={partialRestData}
         urlFragment={props.urlFragment}
+        parentUrl={props.parentUrl}
+        backMatter={props.profile["back-matter"]}
       />
       <OSCALProfileCatalogInheritance inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs} />
       {profileImports}

--- a/packages/oscal-react-library/src/components/OSCALSsp.js
+++ b/packages/oscal-react-library/src/components/OSCALSsp.js
@@ -78,6 +78,8 @@ export default function OSCALSsp(props) {
         onFieldSave={props.onFieldSave}
         partialRestData={partialRestData}
         urlFragment={props.urlFragment}
+        backMatter={ssp["back-matter"]}
+        parentUrl={props.parentUrl}
       />
       <OSCALProfileCatalogInheritance inheritedProfilesAndCatalogs={inheritedProfilesAndCatalogs} />
       <OSCALSystemCharacteristics

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.ts
@@ -1,7 +1,10 @@
 import type { BackMatter } from "@easydynamics/oscal-types";
 import { BackMatterLookup } from "./OSCALBackMatterUtils";
 
-export function getAbsoluteUrl(href: string | undefined, parentUrl: string): string | undefined {
+export function getAbsoluteUrl(
+  href: string | undefined,
+  parentUrl: string | undefined
+): string | undefined {
   if (
     href?.startsWith("https://") ||
     href?.startsWith("http://") ||
@@ -13,10 +16,21 @@ export function getAbsoluteUrl(href: string | undefined, parentUrl: string): str
   return new URL(href ?? "", parentUrl).toString();
 }
 
+export interface ResolvableLinkHref {
+  /**
+   * A BackMatter object to resolve relative links against.
+   */
+  backMatter?: BackMatter;
+  /**
+   * Url of parent for relative links.
+   */
+  parentUrl?: string;
+}
+
 export default function resolveLinkHref(
   backMatter: BackMatter,
   href: string,
-  parentUrl: string,
+  parentUrl: string | undefined,
   mediaType: RegExp,
   preferBase64 = false
 ) {

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.ts
@@ -16,7 +16,7 @@ export function getAbsoluteUrl(
   return new URL(href ?? "", parentUrl).toString();
 }
 
-export interface ResolvableLinkHref {
+export interface UriReferenceLookup {
   /**
    * A BackMatter object to resolve relative links against.
    */
@@ -30,9 +30,9 @@ export interface ResolvableLinkHref {
 export default function resolveLinkHref(
   backMatter: BackMatter,
   href: string,
-  parentUrl: string | undefined,
   mediaType: RegExp,
-  preferBase64 = false
+  preferBase64 = false,
+  parentUrl?: string
 ) {
   const lookup = new BackMatterLookup(backMatter, preferBase64);
   return getAbsoluteUrl(lookup?.resolve(href, mediaType)?.uri, parentUrl);

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALLinkUtils.ts
@@ -27,15 +27,17 @@ export interface UriReferenceLookup {
   parentUrl?: string;
 }
 
-export default function resolveLinkHref(
-  backMatter: BackMatter,
-  href: string,
-  mediaType: RegExp,
-  preferBase64 = false,
-  parentUrl?: string
-) {
-  const lookup = new BackMatterLookup(backMatter, preferBase64);
-  return getAbsoluteUrl(lookup?.resolve(href, mediaType)?.uri, parentUrl);
+interface ResolveLinkHrefProps {
+  backMatter: BackMatter;
+  href: string;
+  mediaType: RegExp;
+  preferBase64?: boolean;
+  parentUrl?: string;
+}
+
+export default function resolveLinkHref(props: ResolveLinkHrefProps) {
+  const lookup = new BackMatterLookup(props.backMatter, props.preferBase64);
+  return getAbsoluteUrl(lookup?.resolve(props.href, props.mediaType)?.uri, props.parentUrl);
 }
 
 /**

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALProfileResolver.js
@@ -76,9 +76,9 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
             const importUrl = resolveLinkHref(
               profileBackMatter,
               profileImport.href,
-              null,
               OSCAL_MEDIA_TYPE,
-              false
+              false,
+              null
             );
             OSCALResolveProfileOrCatalogUrlControls(
               resolvedControls,
@@ -129,7 +129,7 @@ export function OSCALResolveProfile(profile, parentUrl, onSuccess, onError) {
     OSCALResolveProfileOrCatalogUrlControls(
       profile.resolvedControls,
       profile.modifications,
-      resolveLinkHref(profile?.["back-matter"] ?? [], imp.href, parentUrl, OSCAL_MEDIA_TYPE, false),
+      resolveLinkHref(profile?.["back-matter"] ?? [], imp.href, OSCAL_MEDIA_TYPE, false, parentUrl),
       parentUrl,
       profile?.["back-matter"] ?? [],
       inheritedProfilesAndCatalogs.inherited,

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALProfileResolver.js
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALProfileResolver.js
@@ -73,13 +73,13 @@ export default function OSCALResolveProfileOrCatalogUrlControls(
 
           result.profile.imports.forEach((profileImport) => {
             const profileBackMatter = result.profile?.["back-matter"] ?? [];
-            const importUrl = resolveLinkHref(
-              profileBackMatter,
-              profileImport.href,
-              OSCAL_MEDIA_TYPE,
-              false,
-              null
-            );
+            const importUrl = resolveLinkHref({
+              backMatter: profileBackMatter,
+              href: profileImport.href,
+              mediaType: OSCAL_MEDIA_TYPE,
+              parentUrl: null,
+              preferBase64: false,
+            });
             OSCALResolveProfileOrCatalogUrlControls(
               resolvedControls,
               modifications,
@@ -129,7 +129,13 @@ export function OSCALResolveProfile(profile, parentUrl, onSuccess, onError) {
     OSCALResolveProfileOrCatalogUrlControls(
       profile.resolvedControls,
       profile.modifications,
-      resolveLinkHref(profile?.["back-matter"] ?? [], imp.href, OSCAL_MEDIA_TYPE, false, parentUrl),
+      resolveLinkHref({
+        backMatter: profile?.["back-matter"] ?? [],
+        href: imp.href,
+        mediaType: OSCAL_MEDIA_TYPE,
+        parentUrl: parentUrl,
+        preferBase64: false,
+      }),
       parentUrl,
       profile?.["back-matter"] ?? [],
       inheritedProfilesAndCatalogs.inherited,

--- a/packages/oscal-react-library/src/test-data/CommonData.ts
+++ b/packages/oscal-react-library/src/test-data/CommonData.ts
@@ -55,6 +55,12 @@ export const exampleParties: PartyOrganizationOrPerson[] = [
         country: "US",
       },
     ],
+    links: [
+      {
+        href: "https://example.png",
+        rel: "logo",
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
This adds the logo of a metadata party to the Details modal.

closes #411 

### Testing

https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/tuckerzp/display-logo/catalogs/basic-test-catalog.json

---

![image](https://user-images.githubusercontent.com/39490074/235255095-f9d98c72-fa2b-43ac-8689-262dad48921b.png)

---

![image](https://user-images.githubusercontent.com/39490074/235255119-694031d1-94e4-404b-87b1-70ad9fb0b125.png)