### PR TITLE
chore: bump timeout on profile tests

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALProfile.test.js
+++ b/packages/oscal-react-library/src/components/OSCALProfile.test.js
@@ -20,11 +20,10 @@ function profileRenderer() {
 }
 
 function testOSCALProfile(parentElementName, renderer) {
-  jest.setTimeout(6000);
   test(`${parentElementName} displays controls`, async () => {
     renderer();
     const result = await screen.findByText("AC-1", {
-      timeout: 5000,
+      timeout: 30_000,
     });
     expect(result).toBeVisible();
   });
@@ -32,7 +31,7 @@ function testOSCALProfile(parentElementName, renderer) {
   test(`${parentElementName} displays parameter constraints`, async () => {
     renderer();
     const result = await screen.findAllByText("< organization-defined frequency >", {
-      timeout: 5000,
+      timeout: 30_000,
     });
     fireEvent.mouseOver(result[0]);
     expect(await screen.findByText("at least every 3 years")).toBeVisible();


### PR DESCRIPTION
These tests perform profile resolution and reach out to do HTTP requests
and all sorts of things. We have not set specific performance
thresholds; the goal of this test is to ensure the underlying code
works, not necessarily that it works *quickly*.

This increases the timeout to 30s because we've been bumping it by a
second or two and I'm a bit tired of that. This should give us enough
padding to know whether we're slow or broken.
