### PR TITLE
chore: update metadata accordion style

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -1,59 +1,25 @@
-import ArrowForwardSharp from "@mui/icons-material/ArrowForwardIosSharp";
-import MuiAccordion from "@mui/material/Accordion";
-import MuiAccordionSummary from "@mui/material/AccordionSummary";
-import MuiAccordionDetails from "@mui/material/AccordionDetails";
+import { Control, ControlGroup } from "@easydynamics/oscal-types";
+import { Typography } from "@mui/material";
 import List from "@mui/material/List";
 import { styled } from "@mui/material/styles";
 import React, { ReactNode, useEffect } from "react";
-import OSCALControl from "./OSCALControl";
-import { AnchorLinkProps, OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
-import OSCALControlLabel from "./OSCALControlLabel";
-import { propWithName } from "./oscal-utils/OSCALPropUtils";
+import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
 import {
   appendToFragmentPrefix,
-  shiftFragmentSuffix,
   conformLinkIdText,
+  shiftFragmentSuffix,
 } from "./oscal-utils/OSCALLinkUtils";
-import { Control, ControlGroup } from "@easydynamics/oscal-types";
-import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
-import { Typography } from "@mui/material";
+import { propWithName } from "./oscal-utils/OSCALPropUtils";
+import { AnchorLinkProps, OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
+import OSCALControl from "./OSCALControl";
+import OSCALControlLabel from "./OSCALControlLabel";
 import OSCALControlPart from "./OSCALControlPart";
+import { Accordion, AccordionDetails, AccordionSummary } from "./StyedAccordion";
 
 const WithdrawnControlText = styled(Typography)(({ theme }) => ({
   color: theme.palette.grey[400],
   textDecoration: "line-through",
 })) as typeof Typography;
-
-const Accordion = styled((props: any) => (
-  <MuiAccordion disableGutters elevation={0} square {...props} />
-))(({ theme }) => ({
-  border: `1px solid ${theme.palette.divider}`,
-  "&:not(:last-child)": {
-    borderBottom: 0,
-  },
-  "&:before": {
-    display: "none",
-  },
-})) as typeof MuiAccordion;
-
-const AccordionSummary = styled((props) => (
-  <MuiAccordionSummary expandIcon={<ArrowForwardSharp sx={{ fontSize: "0.9rem" }} />} {...props} />
-))(({ theme }) => ({
-  backgroundColor:
-    theme.palette.mode === "dark" ? "rgba(255, 255, 255, .05)" : "rgba(0, 0, 0, .03)",
-  flexDirection: "row-reverse",
-  "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
-    transform: "rotate(90deg)",
-  },
-  "& .MuiAccordionSummary-content": {
-    marginLeft: theme.spacing(1),
-  },
-})) as typeof MuiAccordionSummary;
-
-const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
-  padding: theme.spacing(2),
-  borderTop: "1px solid rgba(0, 0, 0, .125)",
-})) as typeof MuiAccordionDetails;
 
 interface CatalogGroupFragmentProps {
   /**

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -14,6 +14,7 @@ import SmartphoneIcon from "@mui/icons-material/Smartphone";
 import WorkIcon from "@mui/icons-material/Work";
 import { CardContent } from "@mui/material";
 import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
@@ -836,7 +837,7 @@ export const OSCALMetadataKeywords: React.FC<OSCALMetadataKeywordsProps> = (prop
 
   return (
     <OSCALMetadataFieldArea title="Keywords" urlFragment={urlFragment}>
-      {chips}
+      <Box sx={{ margin: "1em" }}>{chips}</Box>
     </OSCALMetadataFieldArea>
   );
 };

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -1,7 +1,6 @@
 import BusinessIcon from "@mui/icons-material/Business";
 import EmailIcon from "@mui/icons-material/Email";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import GroupIcon from "@mui/icons-material/Group";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import HomeIcon from "@mui/icons-material/Home";
@@ -14,9 +13,6 @@ import PlaceIcon from "@mui/icons-material/Place";
 import SmartphoneIcon from "@mui/icons-material/Smartphone";
 import WorkIcon from "@mui/icons-material/Work";
 import { CardContent } from "@mui/material";
-import Accordion from "@mui/material/Accordion";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import AccordionSummary from "@mui/material/AccordionSummary";
 import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
@@ -54,6 +50,7 @@ import { OSCALRevisionsButton } from "./OSCALRevision";
 import { OSCALMetadataLabel } from "./OSCALMetadataCommon";
 import { NotSpecifiedTypography } from "./StyledTypography";
 import resolveLinkHref, { UriReferenceLookup } from "./oscal-utils/OSCALLinkUtils";
+import { Accordion, AccordionSummary, AccordionDetails } from "./StyedAccordion";
 
 const OSCALMetadataSectionInfoHeader = styled(Typography)`
   display: flex;
@@ -496,7 +493,7 @@ const OSCALMetadataCard: React.FC<OSCALMetadataCardProps> = (props) => {
   );
 
   return (
-    <>
+    <Card sx={{ height: "100%" }}>
       <CardHeader title={cardTitle} subheader={subheader} avatar={avatar} />
       <CardActions>
         <Button
@@ -521,7 +518,7 @@ const OSCALMetadataCard: React.FC<OSCALMetadataCardProps> = (props) => {
           {children}
         </Dialog>
       </CardActions>
-    </>
+    </Card>
   );
 };
 
@@ -602,7 +599,7 @@ interface OSCALMetadataRolesProps extends AnchorLinkProps {
 const OSCALMetadataRoles: React.FC<OSCALMetadataRolesProps> = (props) => {
   const { roles, urlFragment } = props;
   const cards = roles?.map((role) => (
-    <Grid item xs={12} md={4} key={role.id} component={Card}>
+    <Grid item xs={12} md={4} key={role.id}>
       <OSCALMetadataRole role={role} />
     </Grid>
   ));
@@ -636,7 +633,7 @@ const OSCALMetadataParties: React.FC<OSCALMetadataPartiesProps> = ({
       .filter((item): item is Role => !!item);
 
   const cards = parties?.map((party) => (
-    <Grid item xs={12} md={4} key={party.uuid} component={Card}>
+    <Grid item xs={12} md={4} key={party.uuid}>
       <OSCALMetadataParty
         party={party}
         partyRolesText={getPartyRolesText(party)}
@@ -660,7 +657,7 @@ const OSCALMetadataLocations: React.FC<OSCALMetadataLocationsProps> = (props) =>
   const { locations, urlFragment } = props;
 
   const cards = locations?.map((location) => (
-    <Grid item xs={12} md={4} key={location.uuid} component={Card}>
+    <Grid item xs={12} md={4} key={location.uuid}>
       <OSCALMetadataLocation location={location} />
     </Grid>
   ));
@@ -793,14 +790,14 @@ const OSCALMetadataFieldArea: React.FC<OSCALMetadataFieldAreaProps> = (props) =>
 
   return (
     <Accordion expanded={isExpanded} onChange={handleExpand}>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+      <AccordionSummary>
         <OSCALAnchorLinkHeader>
           <Typography>{title}</Typography>
         </OSCALAnchorLinkHeader>
         <Typography sx={{ color: "text.secondary" }}>{summary}</Typography>
       </AccordionSummary>
       <AccordionDetails>
-        <Grid container alignItems="stretch">
+        <Grid container spacing={2}>
           {children}
         </Grid>
       </AccordionDetails>

--- a/packages/oscal-react-library/src/components/StyedAccordion.tsx
+++ b/packages/oscal-react-library/src/components/StyedAccordion.tsx
@@ -1,0 +1,37 @@
+import ArrowForwardSharp from "@mui/icons-material/ArrowForwardIosSharp";
+import MuiAccordion from "@mui/material/Accordion";
+import MuiAccordionDetails from "@mui/material/AccordionDetails";
+import MuiAccordionSummary from "@mui/material/AccordionSummary";
+import { styled } from "@mui/material/styles";
+import React from "react";
+
+export const Accordion = styled((props: any) => (
+  <MuiAccordion disableGutters elevation={0} square {...props} />
+))(({ theme }) => ({
+  border: `1px solid ${theme.palette.divider}`,
+  "&:not(:last-child)": {
+    borderBottom: 0,
+  },
+  "&:before": {
+    display: "none",
+  },
+})) as typeof MuiAccordion;
+
+export const AccordionSummary = styled((props) => (
+  <MuiAccordionSummary expandIcon={<ArrowForwardSharp sx={{ fontSize: "0.9rem" }} />} {...props} />
+))(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === "dark" ? "rgba(255, 255, 255, .05)" : "rgba(0, 0, 0, .03)",
+  flexDirection: "row-reverse",
+  "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
+    transform: "rotate(90deg)",
+  },
+  "& .MuiAccordionSummary-content": {
+    marginLeft: theme.spacing(1),
+  },
+})) as typeof MuiAccordionSummary;
+
+export const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
+  padding: theme.spacing(2),
+  borderTop: "1px solid rgba(0, 0, 0, .125)",
+})) as typeof MuiAccordionDetails;


### PR DESCRIPTION
This applies a common style to all Accordion elements using a shared
`StyledAccordion` module.

This also makes a small change to "unsquish" the cards within metadata a
bit, so that they appear more like back matter while retaining a
consistent height.

![image](https://user-images.githubusercontent.com/850893/236220666-8dc97bf5-a667-4e29-ada1-882b0be80c23.png)
Sample document: https://raw.githubusercontent.com/GSA/fedramp-automation/master/dist/content/rev4/templates/ssp/json/FedRAMP-SSP-OSCAL-Template.json