### PR TITLE
chore: use FedRAMP/NIST content for default SSP, Profile, Catalog

### DIFF
--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALObjectData.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALObjectData.ts
@@ -17,7 +17,7 @@ export const oscalObjectTypes: Record<
   catalog: {
     name: "Catalog",
     defaultUrl:
-      "https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/main/catalogs/NIST_SP-800-53_rev5_catalog.json",
+      "https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json",
     defaultUuid: "613fca2d-704a-42e7-8e2b-b206fb92b456",
     jsonRootName: "catalog",
     restPath: "catalogs",
@@ -33,7 +33,7 @@ export const oscalObjectTypes: Record<
   profile: {
     name: "Profile",
     defaultUrl:
-      "https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/main/profiles/NIST_SP-800-53_rev4_MODERATE-baseline_profile.json",
+      "https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
     defaultUuid: "8b3beca1-fcdc-43e0-aebb-ffc0a080c486",
     jsonRootName: "profile",
     restPath: "profiles",

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALObjectData.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALObjectData.ts
@@ -41,7 +41,7 @@ export const oscalObjectTypes: Record<
   ssp: {
     name: "System Security Plan",
     defaultUrl:
-      "https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/main/system-security-plans/ssp-example.json",
+      "https://raw.githubusercontent.com/GSA/fedramp-automation/master/dist/content/rev4/templates/ssp/json/FedRAMP-SSP-OSCAL-Template.json",
     defaultUuid: "cff8385f-108e-40a5-8f7a-82f3dc0eaba8",
     jsonRootName: "system-security-plan",
     restPath: "system-security-plans",


### PR DESCRIPTION
There are a few benefits to making this change. Primarily, this is a
much more complete SSP than our existing example, despite the fact that
it is a template. This gives better visibility into how many fields in
an SSP are/may be used. Additionally, it proves that our viewer works
directly with content that we did not curate specifically in our own
repository.

This make break internal tests that rely on the content of the SSP to be a
specific value (but if they want that, they should provide a specific
SSP, not rely on the default).