### PR TITLE
fix: make properties button smaller

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALBackMatter.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import OSCALBackMatter from "./OSCALBackMatter";
 import { parentUrlTestData, revFourCatalog } from "../test-data/Urls";
 import {
@@ -75,16 +75,5 @@ describe("OSCAL Backmatter", () => {
       name: "Unknown",
     });
     expect(button.getAttribute("href")).toBeTruthy();
-  });
-
-  test("displays props", async () => {
-    render(<OSCALBackMatter backMatter={backMatterTestData} parentUrl={parentUrlTestData} />);
-    const openProperties = screen.getByText("Open Properties");
-    fireEvent.click(openProperties);
-
-    const modalTitle = screen.getByText("Resource Test Title Properties");
-    expect(modalTitle).toBeVisible();
-    const keywordsText = screen.getByText("Resource test keywords");
-    expect(keywordsText).toBeVisible();
   });
 });

--- a/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
+++ b/packages/oscal-react-library/src/components/OSCALBackMatter.tsx
@@ -213,17 +213,21 @@ function BackMatterResource(props: BackMatterResourceProps) {
             </TitleDisplay>
           }
           subheader={typeDisplay}
-          action={<CitationDisplay resource={resource} />}
+          action={
+            <>
+              <OSCALPropertiesDialog
+                properties={resource?.props}
+                title={
+                  resource?.title ?? (
+                    <NotSpecifiedTypography component="span">Resource</NotSpecifiedTypography>
+                  )
+                }
+              />
+              <CitationDisplay resource={resource} />
+            </>
+          }
         />
         <CardContent>
-          <OSCALPropertiesDialog
-            properties={resource?.props}
-            title={
-              resource?.title ?? (
-                <NotSpecifiedTypography component="span">Resource</NotSpecifiedTypography>
-              )
-            }
-          />
           <OSCALEditableTextField
             fieldName="description"
             isEditable={isEditable}

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -2,7 +2,9 @@ import ArrowForwardSharp from "@mui/icons-material/ArrowForwardIosSharp";
 import MuiAccordion from "@mui/material/Accordion";
 import MuiAccordionSummary from "@mui/material/AccordionSummary";
 import MuiAccordionDetails from "@mui/material/AccordionDetails";
+import Box from "@mui/material/Box";
 import List from "@mui/material/List";
+import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import React, { ReactNode, useEffect } from "react";
 import OSCALControl from "./OSCALControl";
@@ -18,6 +20,7 @@ import { Control, ControlGroup } from "@easydynamics/oscal-types";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
 import { Typography } from "@mui/material";
 import OSCALControlPart from "./OSCALControlPart";
+import { OSCALPropertiesDialog } from "./OSCALProperties";
 
 const WithdrawnControlText = styled(Typography)(({ theme }) => ({
   color: theme.palette.grey[400],
@@ -235,17 +238,29 @@ export const OSCALCatalogControlListItem: React.FC<OSCALCatalogControlListItemPr
   const withdrawn = props.withdrawn || isWithdrawn(control);
   const TitleComponent = withdrawn ? WithdrawnControlText : Typography;
 
+  const label = propWithName(control.props, "label")?.value;
   const itemText = (
-    <OSCALAnchorLinkHeader name={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}>
-      <TitleComponent style={{ fontWeight: "bold" }}>
-        <OSCALControlLabel
-          label={propWithName(control.props, "label")?.value}
-          id={control.id}
-          component="span"
+    <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
+      <OSCALAnchorLinkHeader
+        name={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}
+      >
+        <TitleComponent style={{ fontWeight: "bold" }}>
+          <OSCALControlLabel label={label} id={control.id} component="span" />
+          {control.title}
+        </TitleComponent>
+      </OSCALAnchorLinkHeader>
+      <Box>
+        <OSCALPropertiesDialog
+          properties={control.props}
+          title={
+            <>
+              <OSCALControlLabel id={control.id} label={label} component="span" />
+              {` ${control.title}`}
+            </>
+          }
         />
-        {control.title}
-      </TitleComponent>
-    </OSCALAnchorLinkHeader>
+      </Box>
+    </Stack>
   );
 
   return (
@@ -313,22 +328,36 @@ const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
   const withdrawn = props.withdrawn || isWithdrawn(group);
   const TitleComponent = withdrawn ? WithdrawnControlText : Typography;
 
+  const label = propWithName(group.props, "label")?.value;
   const itemText = (
-    <OSCALAnchorLinkHeader
-      name={appendToFragmentPrefix(
-        fragmentPrefix,
-        group.id ?? conformLinkIdText(group.title)
-      ).toLowerCase()}
-    >
-      <TitleComponent style={{ fontWeight: "bold" }}>
-        <OSCALControlLabel
-          label={propWithName(group.props, "label")?.value}
-          id={group.id ?? conformLinkIdText(group.title)}
-          component="span"
+    <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
+      <OSCALAnchorLinkHeader
+        name={appendToFragmentPrefix(
+          fragmentPrefix,
+          group.id ?? conformLinkIdText(group.title)
+        ).toLowerCase()}
+      >
+        <TitleComponent style={{ fontWeight: "bold" }}>
+          <OSCALControlLabel
+            label={label}
+            id={group.id ?? conformLinkIdText(group.title)}
+            component="span"
+          />
+          {group.title}
+        </TitleComponent>
+      </OSCALAnchorLinkHeader>
+      <Box>
+        <OSCALPropertiesDialog
+          properties={group.props}
+          title={
+            <>
+              <OSCALControlLabel id={group.id} label={label} component="span" />
+              {` ${group.title}`}
+            </>
+          }
         />
-        {group.title}
-      </TitleComponent>
-    </OSCALAnchorLinkHeader>
+      </Box>
+    </Stack>
   );
   return (
     <CollapsibleListItem

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroups.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroups.test.tsx
@@ -52,73 +52,6 @@ const testGroups: ControlGroup[] = [
   },
 ];
 
-const testGroupswithProps: ControlGroup[] = [
-  {
-    id: "parent-group",
-    class: "family",
-    title: "Parent Group",
-    groups: [
-      {
-        id: "child-group",
-        class: "family",
-        title: "Access Control",
-        groups: [
-          {
-            id: "child-child-group",
-            title: "Sub Access Control",
-            controls: [
-              {
-                id: "control-id",
-                title: "Access Control Policy and Procedures",
-                props: [
-                  {
-                    name: "label",
-                    value: "Access Control test label",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        id: "sibling-group",
-        class: "family",
-        title: "Sibling Title",
-        controls: [
-          {
-            id: "control2-id",
-            title: "Audit Events",
-            props: [
-              {
-                name: "label 2",
-                ns: "https://another.source.com/ns/oscal",
-                value: "Audit Events test label",
-              },
-            ],
-          },
-        ],
-        parts: [
-          {
-            name: "Parent part prose",
-            prose: "Prose",
-          },
-        ],
-      },
-    ],
-  },
-  {
-    title: "Test Group C",
-    parts: [
-      {
-        id: "test-c-overview-1",
-        name: "overview",
-        prose: "This group has prose",
-      },
-    ],
-  },
-];
-
 function getTextByChildren(text: string) {
   function result(_content: any, node: any) {
     const hasText = (checkNode: any) => checkNode.textContent === text;
@@ -168,47 +101,6 @@ describe("OSCALCatalogGroup", () => {
 
     const expand2 = screen.getByText(getTextByChildren("control2-id Audit Events"));
     fireEvent.click(expand2);
-  });
-
-  test("displays parent properties", () => {
-    render(<OSCALCatalogGroups groups={testGroupswithProps} />);
-    const expand1 = screen.getByText("Access Control");
-    fireEvent.click(expand1);
-
-    const expand2 = screen.getByText("Sub Access Control");
-    fireEvent.click(expand2);
-
-    const expand3 = screen.getByText("Access Control Policy and Procedures");
-    fireEvent.click(expand3);
-
-    const openProperties = screen.getByText("Open Properties");
-    fireEvent.click(openProperties);
-
-    const modalTitle = screen.getByText("Access Control Policy and Procedures Properties");
-    expect(modalTitle).toBeVisible();
-    const nistText = screen.getByText("https://csrc.nist.gov/ns/oscal");
-    expect(nistText).toBeVisible();
-    const labelText = screen.getByText("label");
-    expect(labelText).toBeVisible();
-  });
-
-  test("displays sibling properties", () => {
-    render(<OSCALCatalogGroups groups={testGroupswithProps} />);
-    const expand1 = screen.getByText("Sibling Title");
-    fireEvent.click(expand1);
-
-    const expand2 = screen.getByText("Audit Events");
-    fireEvent.click(expand2);
-
-    const openProperties = screen.getByText("Open Properties");
-    fireEvent.click(openProperties);
-
-    const modalTitle = screen.getByText("Audit Events Properties");
-    expect(modalTitle).toBeVisible();
-    const nistText = screen.getByText("https://another.source.com/ns/oscal");
-    expect(nistText).toBeVisible();
-    const labelText = screen.getByText("Audit Events test label");
-    expect(labelText).toBeVisible();
   });
 
   test("displays outer group prose", () => {

--- a/packages/oscal-react-library/src/components/OSCALControl.tsx
+++ b/packages/oscal-react-library/src/components/OSCALControl.tsx
@@ -21,6 +21,7 @@ import {
   Alteration,
 } from "@easydynamics/oscal-types";
 import { EditableFieldProps } from "./OSCALEditableTextField";
+import { Stack } from "@mui/material";
 
 interface ControlListOptions {
   childLevel: number;
@@ -72,7 +73,6 @@ const ControlsList: React.FC<ControlsListProps> = (props) => {
     urlFragment,
     fragmentPrefix,
   } = props;
-  const label = propWithName(control.props, "label")?.value;
   return (
     <Box
       sx={[
@@ -82,15 +82,6 @@ const ControlsList: React.FC<ControlsListProps> = (props) => {
         }),
       ]}
     >
-      <OSCALPropertiesDialog
-        properties={control.props}
-        title={
-          <>
-            <OSCALControlLabel id={control.id} label={label} component="span" />
-            {` ${control.title}`}
-          </>
-        }
-      />
       {control.parts?.map((part, index) => (
         <OSCALControlPart
           componentId={componentId}
@@ -198,18 +189,31 @@ const OSCALControl: React.FC<OSCALControlProps> = (props) => {
       <CardContent>
         <Grid container spacing={1}>
           <Grid item xs={12}>
-            <OSCALAnchorLinkHeader
-              name={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}
-            >
-              <Typography
-                variant="h6"
-                component="h2"
-                style={childLevel ? { fontSize: "1.1rem" } : undefined}
+            <Stack alignItems="center" direction="row" justifyContent="space-between">
+              <OSCALAnchorLinkHeader
+                name={appendToFragmentPrefix(fragmentPrefix, control.id).toLowerCase()}
               >
-                <OSCALControlLabel component="span" label={label} id={control.id} /> {control.title}{" "}
-                {modificationDisplay}
-              </Typography>
-            </OSCALAnchorLinkHeader>
+                <Typography
+                  variant="h6"
+                  component="h2"
+                  style={childLevel ? { fontSize: "1.1rem" } : undefined}
+                >
+                  <OSCALControlLabel component="span" label={label} id={control.id} />{" "}
+                  {control.title} {modificationDisplay}
+                </Typography>
+              </OSCALAnchorLinkHeader>
+              <Box>
+                <OSCALPropertiesDialog
+                  properties={control.props}
+                  title={
+                    <>
+                      <OSCALControlLabel id={control.id} label={label} component="span" />
+                      {` ${control.title}`}
+                    </>
+                  }
+                />
+              </Box>
+            </Stack>
           </Grid>
         </Grid>
         <ControlsList {...props} withdrawn={controlOrParentWithdrawn} />

--- a/packages/oscal-react-library/src/components/OSCALControlImplementationImplReq.test.js
+++ b/packages/oscal-react-library/src/components/OSCALControlImplementationImplReq.test.js
@@ -76,7 +76,9 @@ export default function testOSCALControlImplementationImplReq(parentElementName,
         timeout: 10000,
       })
     ).toBeInTheDocument();
-    await expect(() => screen.findByRole("button")).rejects.toThrow('Unable to find role="button"');
+    await expect(() => screen.findByRole("button", { name: /.* modifications/ })).rejects.toThrow(
+      /Unable to find role="button"/
+    );
   });
 }
 

--- a/packages/oscal-react-library/src/components/OSCALMetadata.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.test.tsx
@@ -373,7 +373,7 @@ describe("OSCAL metadata keywords", () => {
   test("displays props", () => {
     render(<OSCALMetadata metadata={{ ...metadataTestData, props: keywordValuesList.setns }} />);
 
-    const openProperties = screen.getByText("Open Properties");
+    const openProperties = screen.getByRole("button", { name: "Open Properties" });
     fireEvent.click(openProperties);
 
     const modalTitle = screen.getByText("Test Title Properties");

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -592,6 +592,7 @@ const OSCALMetadataBasicData: React.FC<OSCALMetadataBasicDataProps> = (props) =>
         data={metadata.published ? formatDate(metadata.published) : "Not published"}
       />
       <OSCALRevisionsButton revisions={metadata.revisions} />
+      <OSCALPropertiesDialog properties={props.metadata.props} title={props.metadata.title} />
     </Stack>
   );
 };
@@ -897,12 +898,6 @@ export const OSCALMetadata: React.FC<OSCALMetadataProps> = (props) => {
                 isEditable={props.isEditable}
                 partialRestData={props.partialRestData}
                 onFieldSave={props.onFieldSave}
-              />
-            </OSCALMetadataSection>
-            <OSCALMetadataSection>
-              <OSCALPropertiesDialog
-                properties={props.metadata.props}
-                title={props.metadata.title}
               />
             </OSCALMetadataSection>
             <OSCALMarkupMultiLine>{props.metadata.remarks}</OSCALMarkupMultiLine>

--- a/packages/oscal-react-library/src/components/OSCALProperties.test.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { OSCALPropertiesDialog } from "./OSCALProperties";
+import { Property } from "@easydynamics/oscal-types";
+import { NIST_DEFAULT_NAMESPACE } from "./oscal-utils/OSCALPropUtils";
+
+const TEST_NAMESPACE = "http://easydynamics.com/ns/oscal/test";
+const props: Property[] = [
+  {
+    name: "Test Property",
+    value: "Test Value",
+    ns: TEST_NAMESPACE,
+  },
+  {
+    name: "marking",
+    value: "test",
+    ns: NIST_DEFAULT_NAMESPACE,
+  },
+  {
+    name: "status",
+    value: "test",
+  },
+];
+
+const NAMESPACES = [TEST_NAMESPACE, NIST_DEFAULT_NAMESPACE];
+
+describe("OSCAL Properties", () => {
+  test("displays the property button", async () => {
+    render(<OSCALPropertiesDialog properties={props} />);
+    expect(await screen.findByRole("button", { name: "Open Properties" })).toBeInTheDocument();
+  });
+  test("clicking the button opens the dialog", async () => {
+    render(<OSCALPropertiesDialog properties={props} title="Test" />);
+    const button = await screen.findByRole("button", { name: "Open Properties" });
+    fireEvent.click(button);
+    expect(screen.getByText("Test Properties")).toBeVisible();
+  });
+  test.each(NAMESPACES)("namespace title appears (%s)", async (ns) => {
+    render(<OSCALPropertiesDialog properties={props} title="Test" />);
+    const button = await screen.findByRole("button", { name: "Open Properties" });
+    fireEvent.click(button);
+    expect(screen.getByText(ns)).toBeVisible();
+  });
+  test.each(props.map(({ name }) => name))("property name appears (%s)", async (name) => {
+    render(<OSCALPropertiesDialog properties={props} title="Test" />);
+    const button = await screen.findByRole("button", { name: "Open Properties" });
+    fireEvent.click(button);
+    expect(screen.getByText(name)).toBeVisible();
+  });
+});

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -81,14 +81,17 @@ const OSCALProperties: React.FC<OSCALPropertiesProps> = ({ properties, namespace
             </TableRow>
           </StyledTableHead>
           <TableBody>
-            {properties
-              ?.filter((property) => namespaceOf(property?.ns) === namespace)
-              .map((property) => (
-                <OSCALProperty
-                  property={property}
-                  key={`${namespaceOf(property?.ns)}-properties`}
-                />
-              ))}
+            {
+              // The index must be used because there is no combination of attributes of
+              // a property that is guaranteed to be unique; the index is the best available
+              // option. A UUID is not guaranteed to be present.
+            }
+            {properties?.map((property, idx) => (
+              <OSCALProperty
+                property={property}
+                key={`${namespaceOf(property?.ns)}-property-${idx}`}
+              />
+            ))}
           </TableBody>
         </Table>
       </TableContainer>

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -1,9 +1,9 @@
 import ConstructionIcon from "@mui/icons-material/Construction";
-import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import { styled } from "@mui/material/styles";
 import React, { ReactElement } from "react";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -20,14 +20,6 @@ import {
 import { Property } from "@easydynamics/oscal-types";
 import { NIST_DEFAULT_NAMESPACE, namespaceOf } from "./oscal-utils/OSCALPropUtils";
 import { NotSpecifiedTypography } from "./StyledTypography";
-
-const OSCALPropertiesButton = styled(Button)(
-  ({ theme }) => `
-    color: ${theme.palette.primary.main};
-    margin-top: 1em;
-    margin-bottom: 0.5em;
-  `
-) as typeof Button;
 
 /**
  *  Helper to sort properties by their `name` field.
@@ -121,11 +113,8 @@ export const OSCALPropertiesDialog: React.FC<OSCALPropertiesDialogProps> = ({
 }) => {
   const [open, setOpen] = React.useState(false);
 
-  if (!properties) {
-    return null;
-  }
   const namespaceToProps: Record<string, Property[]> = {};
-  for (const prop of properties) {
+  for (const prop of properties ?? []) {
     const ns = namespaceOf(prop.ns);
     namespaceToProps[ns] ??= [];
     namespaceToProps[ns].push(prop);
@@ -141,15 +130,26 @@ export const OSCALPropertiesDialog: React.FC<OSCALPropertiesDialogProps> = ({
 
   return (
     <>
-      <OSCALPropertiesButton
-        size="small"
-        variant="outlined"
-        onClick={handleOpen}
-        aria-label={"Open Properties"}
-        startIcon={<ConstructionIcon />}
-      >
-        Open Properties
-      </OSCALPropertiesButton>
+      <StyledTooltip title="Open Properties">
+        {
+          // This Box is necessary to ensure the tooltip is present when the button is disabled.
+          // If the Button were never disabled, the Box can be removed. This change may be made
+          // when property editing is enabled to ensure that the dialog can be opened to edit &
+          // create properties, even when none exist. In that case, even the Tooltip wrapper may
+          // not be necessary.
+        }
+        <Box display="inline">
+          <IconButton
+            color="primary"
+            size="small"
+            onClick={handleOpen}
+            aria-label="Open Properties"
+            disabled={!properties}
+          >
+            <ConstructionIcon />
+          </IconButton>
+        </Box>
+      </StyledTooltip>
       <Dialog
         open={open}
         onClose={handleClose}


### PR DESCRIPTION
This changes the "Open Properties" button to be only an icon. This then,
in turn, makes it so we can put it in the Control Title areas and in the
action areas for Back Matter resources. This should give us more
flexibility about where and how to display this without "Open
Properties" as text all over the page.

A workaround is added to make it so that even a `disabled` properties
button appears with a tooltip; this should make it easier to understand
the purpose of the button. As explained in the inline comment, we can
probably remove that when we add full editing support.

Finally, the tests are reworked to centralize testing in a single file and
to actually test the contents and different properties there. Tests are left
in `OSCALMetadata.test.tsx` to have a test for a consumer of the API.

![image](https://user-images.githubusercontent.com/850893/236334681-bf7883ef-f6a1-4771-ac84-e948daf58199.png)

