### PR TITLE
chore: ignore lint-only revisions

### DIFF
--- a/packages/oscal-react-library/.git-blame-ignore-revs
+++ b/packages/oscal-react-library/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Increase allowed line length (to 100 characters)
+51da849362be9c8ff6dfee0303ead0393d2304d6


### PR DESCRIPTION
Notably, the repo refactor is not included here because a lot of actual
code changed.
