### PR TITLE
chore: use lerna from node_modules

### DIFF
--- a/scripts/watch-viewer
+++ b/scripts/watch-viewer
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 
-npx lerna exec --stream --include-dependencies --scope="@easydynamics/oscal-viewer" -- npm run build
-npx lerna exec --stream --include-dependencies --scope="@easydynamics/oscal-viewer" --parallel -- npm run watch
+lerna="node_modules/.bin/lerna"
+
+if [ ! -f "$lerna" ]; then
+	echo "Please run 'npm ci' before running this script"
+	exit 1
+fi
+
+"$lerna" exec --stream --include-dependencies --scope="@easydynamics/oscal-viewer" -- npm run build
+"$lerna" exec --stream --include-dependencies --scope="@easydynamics/oscal-viewer" --parallel -- npm run watch


### PR DESCRIPTION
`npx` does weird things in some cases and users should `npm ci` first
anyway.
