### PR TITLE
feat: display params in catalogs, groups, controls

### DIFF
--- a/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
+++ b/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
@@ -1,0 +1,71 @@
+import IconButton from "@mui/material/IconButton";
+import Box from "@mui/material/Box";
+import React from "react";
+import StyledTooltip from "./OSCALStyledTooltip";
+import { Dialog, DialogContent, DialogTitle, SvgIcon, Typography } from "@mui/material";
+
+interface ButtonLaunchedDialogProps {
+  Icon: typeof SvgIcon;
+  title: string | React.ReactElement;
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
+  Icon,
+  disabled,
+  children,
+  title,
+}) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <StyledTooltip title={`Open ${title}`}>
+        {
+          // This Box is necessary to ensure the tooltip is present when the button is disabled.
+          // If the Button were never disabled, the Box can be removed. This change may be made
+          // when property editing is enabled to ensure that the dialog can be opened to edit &
+          // create properties, even when none exist. In that case, even the Tooltip wrapper may
+          // not be necessary.
+        }
+        <Box display="inline">
+          <IconButton
+            color="primary"
+            size="small"
+            onClick={handleOpen}
+            aria-label={`Open ${title}`}
+            disabled={disabled}
+          >
+            <Icon />
+          </IconButton>
+        </Box>
+      </StyledTooltip>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        scroll="paper"
+        aria-labelledby="scroll-dialog-title"
+        aria-describedby="scroll-dialog-description"
+        maxWidth="md"
+        fullWidth
+        sx={{ maxHeight: "75em" }}
+      >
+        <DialogContent>
+          <DialogTitle>
+            <Typography>{title}</Typography>
+          </DialogTitle>
+          {children}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
+++ b/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
@@ -5,10 +5,33 @@ import React from "react";
 import StyledTooltip from "./OSCALStyledTooltip";
 
 interface ButtonLaunchedDialogProps {
+  /**
+   * The icon to display to open the dialog
+   */
   Icon: typeof SvgIcon;
+
+  /**
+   * The title to display specifically in tooltips that describe the dialog
+   *
+   * @default the value of `title`
+   */
   toolTipTitle?: string;
+
+  /**
+   * The title of the item being viewed in the dialog
+   */
   title: React.ReactNode;
+
+  /**
+   * The dialog contents
+   */
   children: React.ReactNode;
+
+  /**
+   * Whether launching the dialog should be disabled.
+   *
+   * @default false - the dialog is enabled
+   */
   disabled?: boolean;
 }
 

--- a/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
+++ b/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
@@ -6,13 +6,15 @@ import StyledTooltip from "./OSCALStyledTooltip";
 
 interface ButtonLaunchedDialogProps {
   Icon: typeof SvgIcon;
-  title: string | React.ReactElement;
+  toolTipTitle?: string;
+  title: React.ReactNode;
   children: React.ReactNode;
   disabled?: boolean;
 }
 
 export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
   Icon,
+  toolTipTitle,
   disabled,
   children,
   title,
@@ -39,7 +41,7 @@ export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
 
   return (
     <>
-      <StyledTooltip title={`Open ${title}`}>
+      <StyledTooltip title={`Open ${toolTipTitle ?? title}`}>
         {
           // This Box is necessary to ensure the tooltip is present when the button is disabled.
           // If the Button were never disabled, the Box can be removed. This change may be made
@@ -52,7 +54,7 @@ export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
             color="primary"
             size="small"
             onClick={handleOpen}
-            aria-label={`Open ${title}`}
+            aria-label={`Open ${toolTipTitle ?? title}`}
             disabled={disabled}
           >
             <Icon />

--- a/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
+++ b/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
@@ -1,8 +1,8 @@
-import IconButton from "@mui/material/IconButton";
+import { Dialog, DialogContent, DialogTitle, SvgIcon, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
 import React from "react";
 import StyledTooltip from "./OSCALStyledTooltip";
-import { Dialog, DialogContent, DialogTitle, SvgIcon, Typography } from "@mui/material";
 
 interface ButtonLaunchedDialogProps {
   Icon: typeof SvgIcon;
@@ -19,12 +19,22 @@ export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
 }) => {
   const [open, setOpen] = React.useState(false);
 
-  const handleOpen = () => {
+  // These event handlers (and the dialog below) specify `stopPropagation` to
+  // avoid the click event from being passed on. This is because within the
+  // library, the button and dialog often appear in contexts where clicks
+  // matter (such as in an AccordionSummary).
+  const handleOpen = (e: React.MouseEvent) => {
     setOpen(true);
+    e.stopPropagation();
   };
-
-  const handleClose = () => {
+  // The type defined for `onClose` for a dialog is `{}` which doesn't seem
+  // to be correct it's unclear what it's supposed to be but `MouseEvent` is
+  // close enough and gives us the `stopPropagation` method.
+  const handleClose = (e: MouseEvent, reason: string) => {
     setOpen(false);
+    if (reason === "backdropClick") {
+      e.stopPropagation();
+    }
   };
 
   return (
@@ -57,9 +67,11 @@ export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
         aria-describedby="scroll-dialog-description"
         maxWidth="md"
         fullWidth
-        sx={{ maxHeight: "75em" }}
+        sx={{
+          maxHeight: "75em",
+        }}
       >
-        <DialogContent>
+        <DialogContent onClick={(e) => e.stopPropagation()}>
           <DialogTitle>
             <Typography>{title}</Typography>
           </DialogTitle>

--- a/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
+++ b/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
@@ -29,9 +29,10 @@ export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
     setOpen(true);
     e.stopPropagation();
   };
-  // The type defined for `onClose` for a dialog is `{}` which doesn't seem
-  // to be correct it's unclear what it's supposed to be but `MouseEvent` is
-  // close enough and gives us the `stopPropagation` method.
+  // The type defined for the `event` parameter for a dialog's `onClose` handler
+  // is `{}` which doesn't seem to be correct it's unclear what it's
+  // supposed to be but `MouseEvent` is close enough and gives us
+  // the `stopPropagation` method.
   const handleClose = (e: MouseEvent, reason: string) => {
     setOpen(false);
     if (reason === "backdropClick") {

--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -1,5 +1,5 @@
 import { Control, ControlGroup } from "@easydynamics/oscal-types";
-import { Typography } from "@mui/material";
+import { Grid, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import Stack from "@mui/material/Stack";
@@ -18,6 +18,7 @@ import OSCALControlLabel from "./OSCALControlLabel";
 import OSCALControlPart from "./OSCALControlPart";
 import { Accordion, AccordionDetails, AccordionSummary } from "./StyedAccordion";
 import { OSCALPropertiesDialog } from "./OSCALProperties";
+import { OSCALParamsDialog } from "./OSCALParam";
 
 const WithdrawnControlText = styled(Typography)(({ theme }) => ({
   color: theme.palette.grey[400],
@@ -216,6 +217,7 @@ export const OSCALCatalogControlListItem: React.FC<OSCALCatalogControlListItemPr
         </TitleComponent>
       </OSCALAnchorLinkHeader>
       <Box>
+        <OSCALParamsDialog params={control.params} />
         <OSCALPropertiesDialog
           properties={control.props}
           title={
@@ -313,6 +315,7 @@ const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
         </TitleComponent>
       </OSCALAnchorLinkHeader>
       <Box>
+        <OSCALParamsDialog params={group.params} />
         <OSCALPropertiesDialog
           properties={group.props}
           title={
@@ -418,8 +421,22 @@ export const OSCALCatalogGroup: React.FC<OSCALCatalogGroupProps> = (props) => {
     ? `${urlFragment.substring(urlFragment.indexOf("/") + 1)}`
     : undefined;
 
+  const label = propWithName(group.props, "label")?.value;
+
   return (
     <>
+      <Grid container justifyContent="flex-end">
+        <OSCALParamsDialog params={group.params} />{" "}
+        <OSCALPropertiesDialog
+          properties={group.props}
+          title={
+            <>
+              <OSCALControlLabel id={group.id} label={label} component="span" />
+              {` ${group.title}`}
+            </>
+          }
+        />
+      </Grid>
       {group.parts?.map((part, index) => (
         <OSCALControlPart
           control={group}

--- a/packages/oscal-react-library/src/components/OSCALControl.tsx
+++ b/packages/oscal-react-library/src/components/OSCALControl.tsx
@@ -24,6 +24,7 @@ import { EditableFieldProps } from "./OSCALEditableTextField";
 import { Stack } from "@mui/material";
 import { groupBy } from "../utils";
 import { Accordion, AccordionSummary, AccordionDetails } from "./StyedAccordion";
+import { OSCALParamsDialog } from "./OSCALParam";
 
 interface ControlListOptions {
   childLevel: number;
@@ -266,6 +267,7 @@ const OSCALControl: React.FC<OSCALControlProps> = (props) => {
               </OSCALAnchorLinkHeader>
               <Box>
                 {modificationDisplay}
+                <OSCALParamsDialog params={control.params} />
                 <OSCALPropertiesDialog
                   properties={control.props}
                   title={

--- a/packages/oscal-react-library/src/components/OSCALControlImplementationImplReq.js
+++ b/packages/oscal-react-library/src/components/OSCALControlImplementationImplReq.js
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
 import OSCALControl from "./OSCALControl";
 import getControlOrSubControl from "./oscal-utils/OSCALControlResolver";
 
@@ -21,7 +22,7 @@ const OSCALImplReqCard = styled(Card, {
   ${(props) => props.childLevel > 0 && "background-color: #fffcf0;"}
 `;
 
-const ComponentTabContainer = styled("div")(
+const ComponentTabContainer = styled(Grid)(
   ({ theme }) => `
   flex-grow: 1;
   background-color: ${theme.palette.background.paper};
@@ -92,7 +93,7 @@ function a11yProps(index) {
  * Creates the internal elements of Control Implementation.
  *
  * @param {object} props SSP properties
- * @returns The corresponding Control Implementation Request
+ * @returns The corresponding Control Implementation
  */
 export default function OSCALControlImplementationImplReq(props) {
   const [value, setValue] = React.useState(0);
@@ -111,41 +112,45 @@ export default function OSCALControlImplementationImplReq(props) {
   return (
     <OSCALImplReqCard>
       <CardContent>
-        <ComponentTabContainer>
-          <ComponentTabs
-            orientation="vertical"
-            variant="scrollable"
-            value={value}
-            onChange={handleChange}
-            aria-label="Vertical tabs example"
-          >
+        <ComponentTabContainer container>
+          <Grid item lg={2.5} sm={12}>
+            <ComponentTabs
+              orientation="vertical"
+              variant="scrollable"
+              value={value}
+              onChange={handleChange}
+              aria-label="Vertical tabs example"
+            >
+              {Object.values(props.components).map((component, index) => (
+                <ComponentTabButton
+                  label={component.title}
+                  {...a11yProps(index)}
+                  key={component.uuid}
+                />
+              ))}
+            </ComponentTabs>
+          </Grid>
+          <Grid item lg={9.5} sm={12}>
             {Object.values(props.components).map((component, index) => (
-              <ComponentTabButton
-                label={component.title}
-                {...a11yProps(index)}
-                key={component.uuid}
-              />
+              <ComponentTabPanelScrollable value={value} index={index} key={component.uuid}>
+                <OSCALControl
+                  control={getControlOrSubControl(
+                    props.controls,
+                    props.implementedRequirement["control-id"]
+                  )}
+                  childLevel={0}
+                  implementedRequirement={props.implementedRequirement}
+                  componentId={component.uuid}
+                  isEditable={props.isEditable}
+                  modificationAlters={modAlters}
+                  modificationSetParameters={modParams}
+                  onRestSuccess={props.onRestSuccess}
+                  onRestError={props.onRestError}
+                  partialRestData={props.partialRestData}
+                />
+              </ComponentTabPanelScrollable>
             ))}
-          </ComponentTabs>
-          {Object.values(props.components).map((component, index) => (
-            <ComponentTabPanelScrollable value={value} index={index} key={component.uuid}>
-              <OSCALControl
-                control={getControlOrSubControl(
-                  props.controls,
-                  props.implementedRequirement["control-id"]
-                )}
-                childLevel={0}
-                implementedRequirement={props.implementedRequirement}
-                componentId={component.uuid}
-                isEditable={props.isEditable}
-                modificationAlters={modAlters}
-                modificationSetParameters={modParams}
-                onRestSuccess={props.onRestSuccess}
-                onRestError={props.onRestError}
-                partialRestData={props.partialRestData}
-              />
-            </ComponentTabPanelScrollable>
-          ))}
+          </Grid>
         </ComponentTabContainer>
       </CardContent>
     </OSCALImplReqCard>

--- a/packages/oscal-react-library/src/components/OSCALParam.tsx
+++ b/packages/oscal-react-library/src/components/OSCALParam.tsx
@@ -6,6 +6,7 @@ import { OSCALPropertiesDialog } from "./OSCALProperties";
 import { Stack } from "@mui/system";
 import { Accordion, AccordionDetails, AccordionSummary } from "./StyedAccordion";
 import { ButtonLaunchedDialog } from "./ButtonLaunchedDialog";
+import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
 
 export interface OSCALParamProps {
   param: Parameter;
@@ -24,11 +25,19 @@ export const OSCALParam: React.FC<OSCALParamProps> = ({ param }) => {
     <Accordion expanded={isOpen} onChange={handleClick}>
       <AccordionSummary>
         <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
-          <Typography>{paramLabel}</Typography>
+          <Typography>{param.id}</Typography>
+          <Typography sx={{ color: "text.secondary" }}>{paramLabel}</Typography>
           <OSCALPropertiesDialog properties={param.props} />
         </Stack>
       </AccordionSummary>
-      <AccordionDetails>PUT INFO HERE</AccordionDetails>
+      <AccordionDetails>
+        <Stack direction="column" spacing={2}>
+          <OSCALMarkupMultiLine>{param.remarks}</OSCALMarkupMultiLine>
+          {param.guidelines?.map((guideline) => (
+            <OSCALMarkupMultiLine key={guideline.prose}>{guideline.prose}</OSCALMarkupMultiLine>
+          ))}
+        </Stack>
+      </AccordionDetails>
     </Accordion>
   );
 };

--- a/packages/oscal-react-library/src/components/OSCALParam.tsx
+++ b/packages/oscal-react-library/src/components/OSCALParam.tsx
@@ -1,0 +1,104 @@
+import { Parameter } from "@easydynamics/oscal-types";
+import IconButton from "@mui/material/IconButton";
+import DataObjectIcon from "@mui/icons-material/DataObject";
+import Box from "@mui/material/Box";
+import React from "react";
+import StyledTooltip from "./OSCALStyledTooltip";
+import { Dialog, DialogContent, DialogTitle, Typography } from "@mui/material";
+import { OSCALPropertiesDialog } from "./OSCALProperties";
+import { Stack } from "@mui/system";
+import { Accordion, AccordionDetails, AccordionSummary } from "./StyedAccordion";
+
+export interface OSCALParamProps {
+  param: Parameter;
+}
+
+export const OSCALParam: React.FC<OSCALParamProps> = ({ param }) => {
+  const paramLabel = param.label ?? param.values?.join(",");
+
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const handleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <Accordion expanded={isOpen} onChange={handleClick}>
+      <AccordionSummary>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
+          <Typography>{paramLabel}</Typography>
+          <OSCALPropertiesDialog properties={param.props} />
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails>PUT INFO HERE</AccordionDetails>
+    </Accordion>
+  );
+};
+
+export interface OSCALParamsProps {
+  params: Parameter[] | undefined;
+}
+
+export const OSCALParams: React.FC<OSCALParamsProps> = ({ params }) => {
+  return (
+    <>
+      {params?.map((param) => (
+        <div key={param.id}>{<OSCALParam param={param} />}</div>
+      ))}
+    </>
+  );
+};
+
+export const OSCALParamsDialog: React.FC<OSCALParamsProps> = ({ params }) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <StyledTooltip title="Open Parameters">
+        {
+          // This Box is necessary to ensure the tooltip is present when the button is disabled.
+          // If the Button were never disabled, the Box can be removed. This change may be made
+          // when property editing is enabled to ensure that the dialog can be opened to edit &
+          // create properties, even when none exist. In that case, even the Tooltip wrapper may
+          // not be necessary.
+        }
+        <Box display="inline">
+          <IconButton
+            color="primary"
+            size="small"
+            onClick={handleOpen}
+            aria-label="Open Parameters"
+            disabled={!params}
+          >
+            <DataObjectIcon />
+          </IconButton>
+        </Box>
+      </StyledTooltip>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        scroll="paper"
+        aria-labelledby="scroll-dialog-title"
+        aria-describedby="scroll-dialog-description"
+        maxWidth="md"
+        fullWidth
+        sx={{ maxHeight: "75em" }}
+      >
+        <DialogContent>
+          <DialogTitle>
+            <Typography>Parameters</Typography>
+          </DialogTitle>
+          <OSCALParams params={params} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/packages/oscal-react-library/src/components/OSCALParam.tsx
+++ b/packages/oscal-react-library/src/components/OSCALParam.tsx
@@ -1,13 +1,11 @@
 import { Parameter } from "@easydynamics/oscal-types";
-import IconButton from "@mui/material/IconButton";
 import DataObjectIcon from "@mui/icons-material/DataObject";
-import Box from "@mui/material/Box";
 import React from "react";
-import StyledTooltip from "./OSCALStyledTooltip";
-import { Dialog, DialogContent, DialogTitle, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { OSCALPropertiesDialog } from "./OSCALProperties";
 import { Stack } from "@mui/system";
 import { Accordion, AccordionDetails, AccordionSummary } from "./StyedAccordion";
+import { ButtonLaunchedDialog } from "./ButtonLaunchedDialog";
 
 export interface OSCALParamProps {
   param: Parameter;
@@ -49,56 +47,8 @@ export const OSCALParams: React.FC<OSCALParamsProps> = ({ params }) => {
   );
 };
 
-export const OSCALParamsDialog: React.FC<OSCALParamsProps> = ({ params }) => {
-  const [open, setOpen] = React.useState(false);
-
-  const handleOpen = () => {
-    setOpen(true);
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-  };
-
-  return (
-    <>
-      <StyledTooltip title="Open Parameters">
-        {
-          // This Box is necessary to ensure the tooltip is present when the button is disabled.
-          // If the Button were never disabled, the Box can be removed. This change may be made
-          // when property editing is enabled to ensure that the dialog can be opened to edit &
-          // create properties, even when none exist. In that case, even the Tooltip wrapper may
-          // not be necessary.
-        }
-        <Box display="inline">
-          <IconButton
-            color="primary"
-            size="small"
-            onClick={handleOpen}
-            aria-label="Open Parameters"
-            disabled={!params}
-          >
-            <DataObjectIcon />
-          </IconButton>
-        </Box>
-      </StyledTooltip>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        scroll="paper"
-        aria-labelledby="scroll-dialog-title"
-        aria-describedby="scroll-dialog-description"
-        maxWidth="md"
-        fullWidth
-        sx={{ maxHeight: "75em" }}
-      >
-        <DialogContent>
-          <DialogTitle>
-            <Typography>Parameters</Typography>
-          </DialogTitle>
-          <OSCALParams params={params} />
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-};
+export const OSCALParamsDialog = (props: OSCALParamsProps) => (
+  <ButtonLaunchedDialog title="Parameters" disabled={!props.params} Icon={DataObjectIcon}>
+    <OSCALParams params={props.params} />
+  </ButtonLaunchedDialog>
+);

--- a/packages/oscal-react-library/src/components/OSCALParam.tsx
+++ b/packages/oscal-react-library/src/components/OSCALParam.tsx
@@ -1,20 +1,216 @@
-import { Parameter } from "@easydynamics/oscal-types";
+import {
+  Constraint,
+  Guideline,
+  Parameter,
+  ParameterCardinality,
+  Link as OSCALLink,
+} from "@easydynamics/oscal-types";
 import DataObjectIcon from "@mui/icons-material/DataObject";
 import React from "react";
-import { Typography } from "@mui/material";
+import {
+  Divider,
+  FormControl,
+  FormHelperText,
+  Link,
+  MenuItem,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
 import { OSCALPropertiesDialog } from "./OSCALProperties";
 import { Stack } from "@mui/system";
 import { Accordion, AccordionDetails, AccordionSummary } from "./StyedAccordion";
 import { ButtonLaunchedDialog } from "./ButtonLaunchedDialog";
 import { OSCALMarkupMultiLine } from "./OSCALMarkupProse";
+import { OSCALSectionHeader } from "../styles/CommonPageStyles";
+import {
+  StyledHeaderTableCell,
+  StyledTableHead,
+  StyledTableRow,
+} from "./OSCALSystemImplementationTableStyles";
+
+interface OSCALParamUsageProps {
+  usage: string | undefined;
+}
+
+const OSCALParamUsage: React.FC<OSCALParamUsageProps> = ({ usage }) => {
+  if (!usage) {
+    return null;
+  }
+  return (
+    <>
+      <Divider />
+      <OSCALSectionHeader>Usage</OSCALSectionHeader>
+      <OSCALMarkupMultiLine>{usage}</OSCALMarkupMultiLine>
+    </>
+  );
+};
+
+interface OSCALParamConstraintsProps {
+  constraints: Constraint[] | undefined;
+}
+
+const OSCALParamConstraints: React.FC<OSCALParamConstraintsProps> = ({ constraints }) => {
+  if (!constraints) {
+    return null;
+  }
+
+  return (
+    <>
+      <Divider />
+      <OSCALSectionHeader>Constraints</OSCALSectionHeader>
+      {constraints?.map((constraint) => (
+        <>
+          <OSCALMarkupMultiLine>{constraint.description}</OSCALMarkupMultiLine>
+          <Table>
+            <StyledTableHead>
+              <TableRow>
+                <StyledHeaderTableCell>Expression</StyledHeaderTableCell>
+                <StyledHeaderTableCell>Remarks</StyledHeaderTableCell>
+              </TableRow>
+            </StyledTableHead>
+            <TableBody>
+              {constraint.tests?.map((test) => (
+                <StyledTableRow key={test.expression}>
+                  <TableCell>{test.expression}</TableCell>
+                  <TableCell>{test.remarks}</TableCell>
+                </StyledTableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </>
+      ))}
+    </>
+  );
+};
+
+interface OSCALParamGuidelinesProps {
+  guidelines: Guideline[] | undefined;
+}
+
+const OSCALParamGuidelines: React.FC<OSCALParamGuidelinesProps> = ({ guidelines }) => {
+  if (!guidelines) {
+    return null;
+  }
+
+  return (
+    <>
+      <Divider />
+      <OSCALSectionHeader>Guidelines</OSCALSectionHeader>
+      {guidelines?.map((guideline) => (
+        <OSCALMarkupMultiLine key={guideline.prose}>{guideline.prose}</OSCALMarkupMultiLine>
+      ))}
+    </>
+  );
+};
+
+interface OSCALParamValuesProps {
+  values: string[] | undefined;
+}
+
+const OSCALParamValues: React.FC<OSCALParamValuesProps> = ({ values }) => {
+  if (!values) {
+    return null;
+  }
+
+  return (
+    <>
+      <Divider />
+      <OSCALSectionHeader>Values</OSCALSectionHeader>
+      <Typography>{values?.join(", ")}</Typography>
+    </>
+  );
+};
+
+interface OSCALParamLinksProps {
+  links: OSCALLink[] | undefined;
+}
+
+const OSCALParamLinks: React.FC<OSCALParamLinksProps> = ({ links }) => {
+  if (!links) {
+    return null;
+  }
+  return (
+    <>
+      <Divider />
+      <OSCALSectionHeader>Links</OSCALSectionHeader>
+      {links?.map((link) => (
+        <Link key={link.href} href={link.href}>
+          {link.text ?? link.href}
+        </Link>
+      ))}
+    </>
+  );
+};
+
+interface OSCALSelectProps {
+  choice?: string[];
+}
+
+const OSCALSingleSelect: React.FC<OSCALSelectProps> = ({ choice }) => {
+  const [selectValue, setSelectValue] = React.useState("");
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setSelectValue(event.target.value as string);
+  };
+
+  if (!choice) {
+    return null;
+  }
+
+  return (
+    <FormControl size="small">
+      <Select value={selectValue} onChange={handleChange}>
+        {choice?.map((item) => (
+          <MenuItem key={item} value={item}>
+            {item}
+          </MenuItem>
+        ))}
+      </Select>
+      <FormHelperText>Select One</FormHelperText>
+    </FormControl>
+  );
+};
+
+const OSCALMultiSelect: React.FC<OSCALSelectProps> = ({ choice }) => {
+  const [selectValue, setSelectValue] = React.useState<string[]>([]);
+
+  const handleChange = (event: SelectChangeEvent<typeof selectValue>) => {
+    const {
+      target: { value },
+    } = event;
+    setSelectValue(
+      // On autofill we get a stringified value.
+      typeof value === "string" ? value.split(",") : value
+    );
+  };
+
+  if (!choice) {
+    return null;
+  }
+
+  return (
+    <FormControl size="small">
+      <Select value={selectValue} onChange={handleChange} multiple>
+        {choice?.map((item) => (
+          <MenuItem key={item} value={item}>
+            {item}
+          </MenuItem>
+        ))}
+      </Select>
+      <FormHelperText>Select One Or More</FormHelperText>
+    </FormControl>
+  );
+};
 
 export interface OSCALParamProps {
   param: Parameter;
 }
 
 export const OSCALParam: React.FC<OSCALParamProps> = ({ param }) => {
-  const paramLabel = param.label ?? param.values?.join(",");
-
   const [isOpen, setIsOpen] = React.useState(false);
 
   const handleClick = () => {
@@ -26,16 +222,24 @@ export const OSCALParam: React.FC<OSCALParamProps> = ({ param }) => {
       <AccordionSummary>
         <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
           <Typography>{param.id}</Typography>
-          <Typography sx={{ color: "text.secondary" }}>{paramLabel}</Typography>
+          <Typography sx={{ color: "text.secondary" }}>{param.label}</Typography>
           <OSCALPropertiesDialog properties={param.props} />
         </Stack>
       </AccordionSummary>
-      <AccordionDetails>
+      <AccordionDetails sx={{ maxHeight: "40em", overflowY: "scroll" }}>
         <Stack direction="column" spacing={2}>
           <OSCALMarkupMultiLine>{param.remarks}</OSCALMarkupMultiLine>
-          {param.guidelines?.map((guideline) => (
-            <OSCALMarkupMultiLine key={guideline.prose}>{guideline.prose}</OSCALMarkupMultiLine>
-          ))}
+          <OSCALParamUsage usage={param.usage} />
+          <OSCALParamConstraints constraints={param.constraints} />
+          <OSCALParamGuidelines guidelines={param.guidelines} />
+          <OSCALParamValues values={param.values} />
+          <OSCALParamLinks links={param.links} />
+          {param.select ? <Divider /> : null}
+          {param.select?.["how-many"] === ParameterCardinality.ONE ? (
+            <OSCALSingleSelect choice={param.select.choice} />
+          ) : (
+            <OSCALMultiSelect choice={param.select?.choice} />
+          )}
         </Stack>
       </AccordionDetails>
     </Accordion>

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -63,6 +63,7 @@ interface OSCALPropertiesProps {
 }
 
 const OSCALProperties: React.FC<OSCALPropertiesProps> = ({ properties, namespace }) => {
+  if (!properties?.length) return null;
   return (
     <>
       <OSCALSystemImplementationTableTitle variant="h6" id={`${namespace}-table-title`}>

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -21,6 +21,7 @@ import { Property } from "@easydynamics/oscal-types";
 import { NIST_DEFAULT_NAMESPACE, namespaceOf } from "./oscal-utils/OSCALPropUtils";
 import { NotSpecifiedTypography } from "./StyledTypography";
 import { groupBy } from "../utils";
+import { ButtonLaunchedDialog } from "./ButtonLaunchedDialog";
 
 /**
  *  Helper to sort properties by their `name` field.
@@ -115,69 +116,29 @@ export const OSCALPropertiesDialog: React.FC<OSCALPropertiesDialogProps> = ({
   properties,
   title,
 }) => {
-  const [open, setOpen] = React.useState(false);
-
   const { [NIST_DEFAULT_NAMESPACE]: nist, ...thirdParties } = groupBy(properties ?? [], (prop) =>
     namespaceOf(prop.ns)
   );
-
-  const handleOpen = () => {
-    setOpen(true);
-  };
-  const handleClose = () => {
-    setOpen(false);
-  };
-
   return (
-    <>
-      <StyledTooltip title="Open Properties">
-        {
-          // This Box is necessary to ensure the tooltip is present when the button is disabled.
-          // If the Button were never disabled, the Box can be removed. This change may be made
-          // when property editing is enabled to ensure that the dialog can be opened to edit &
-          // create properties, even when none exist. In that case, even the Tooltip wrapper may
-          // not be necessary.
-        }
-        <Box display="inline">
-          <IconButton
-            color="primary"
-            size="small"
-            onClick={handleOpen}
-            aria-label="Open Properties"
-            disabled={!properties}
-          >
-            <ConstructionIcon />
-          </IconButton>
-        </Box>
-      </StyledTooltip>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        scroll="paper"
-        aria-labelledby="scroll-dialog-title"
-        aria-describedby="scroll-dialog-description"
-        maxWidth="md"
-        fullWidth
-        sx={{ maxHeight: "75em" }}
-      >
-        <DialogContent sx={{ maxHeight: "75vh" }} dividers>
-          <DialogTitle id="scroll-dialog-title">{title} Properties</DialogTitle>
-          {/* Handle NIST properties */}
-          <OSCALProperties
-            properties={nist?.sort(byName)}
-            namespace={NIST_DEFAULT_NAMESPACE}
-            key={NIST_DEFAULT_NAMESPACE}
-          />
-          {
-            /* Handle 3rd party properties */
-            Object.entries(thirdParties)
-              .sort(([key1], [key2]) => key1.localeCompare(key2))
-              .map(([key, props]) => (
-                <OSCALProperties properties={props.sort(byName)} namespace={key} key={key} />
-              ))
-          }
-        </DialogContent>
-      </Dialog>
-    </>
+    <ButtonLaunchedDialog
+      Icon={ConstructionIcon}
+      disabled={!properties}
+      title={`${title} Properties`}
+    >
+      {/* Handle NIST properties */}
+      <OSCALProperties
+        properties={nist?.sort(byName)}
+        namespace={NIST_DEFAULT_NAMESPACE}
+        key={NIST_DEFAULT_NAMESPACE}
+      />
+      {
+        /* Handle 3rd party properties */
+        Object.entries(thirdParties)
+          .sort(([key1], [key2]) => key1.localeCompare(key2))
+          .map(([key, props]) => (
+            <OSCALProperties properties={props.sort(byName)} namespace={key} key={key} />
+          ))
+      }
+    </ButtonLaunchedDialog>
   );
 };

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -120,6 +120,7 @@ export const OSCALPropertiesDialog: React.FC<OSCALPropertiesDialogProps> = ({
       Icon={ConstructionIcon}
       disabled={!properties}
       title={`${title} Properties`}
+      toolTipTitle={"Properties"}
     >
       {/* Handle NIST properties */}
       <OSCALProperties

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -1,9 +1,4 @@
 import ConstructionIcon from "@mui/icons-material/Construction";
-import IconButton from "@mui/material/IconButton";
-import Box from "@mui/material/Box";
-import Dialog from "@mui/material/Dialog";
-import DialogContent from "@mui/material/DialogContent";
-import DialogTitle from "@mui/material/DialogTitle";
 import React, { ReactElement } from "react";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";


### PR DESCRIPTION
Creates a dialog box with accordions to display parameters. In theory, there can be quite a bit of information put here so accordions were chosen over using a table like we do for properties. 

closes #822 

### Testing

Based on example catalogs today, often most fields are undefined and only a few things are actually displayed. This example shows a "worst" case parameter definition. 

https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/tuckerzp/params/catalogs/basic-test-catalog.json

---

![image](https://github.com/EasyDynamics/oscal-react-library/assets/39490074/978f789f-6bdc-4e77-ac45-6361f620005b)

---

![image](https://github.com/EasyDynamics/oscal-react-library/assets/39490074/ba847f15-b195-4a6c-a2bc-89225cb82611)

![image](https://github.com/EasyDynamics/oscal-react-library/assets/39490074/8603a4d2-ba66-4b1f-93f6-c196651de790)
