### PR TITLE
fix: default namespace is defined incorrectly

### DIFF
--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALPropUtils.test.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALPropUtils.test.ts
@@ -1,4 +1,4 @@
-import { propWithName } from "./OSCALPropUtils";
+import { NIST_DEFAULT_NAMESPACE, propWithName } from "./OSCALPropUtils";
 
 const TEST_NS = "https://test.easydynamics.com/ns/oscal-react/";
 
@@ -20,6 +20,16 @@ const testProps = {
       value: "value",
     },
   ],
+  defaultNistNsExplicit: [
+    {
+      name: "test",
+      value: "test",
+      // This is the default NIST OSCAL namespace from the documentation
+      // directly. This allows us to ensure that the constant we use is
+      // defined correctly.
+      ns: "http://csrc.nist.gov/ns/oscal",
+    },
+  ],
 };
 
 describe("OSCAL Prop Utils", () => {
@@ -35,5 +45,11 @@ describe("OSCAL Prop Utils", () => {
     const props = testProps.nsWithStuff;
     // THEN
     expect(propWithName(props, "test", TEST_NS)?.value).toBe("test2");
+  });
+
+  it("has the correct value for the NIST namespace", () => {
+    const props = testProps.defaultNistNsExplicit;
+    expect(propWithName(props, "test", NIST_DEFAULT_NAMESPACE)?.value).toBe("test");
+    expect(propWithName(props, "test")?.value).toBe("test");
   });
 });

--- a/packages/oscal-react-library/src/components/oscal-utils/OSCALPropUtils.ts
+++ b/packages/oscal-react-library/src/components/oscal-utils/OSCALPropUtils.ts
@@ -4,7 +4,8 @@ import type { Property } from "@easydynamics/oscal-types";
  * When a namespace is not specified for a property, the assumption is that the
  * namespace is default namespace.
  */
-export const NIST_DEFAULT_NAMESPACE = "https://csrc.nist.gov/ns/oscal";
+// Value is defined at https://pages.nist.gov/OSCAL/learn/tutorials/general/extension/#namespace
+export const NIST_DEFAULT_NAMESPACE = "http://csrc.nist.gov/ns/oscal";
 
 /**
  * Return the given namespace, or if undefined, the default namespace.


### PR DESCRIPTION
We incorrectly specified `https` and the namespace is actually `http`. This corrects that error and adds a test to make sure that we don't regress.

Closes #862 