### PR TITLE
feat: display control/group `class`

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalogGroup.tsx
@@ -1,8 +1,5 @@
 import { Control, ControlGroup } from "@easydynamics/oscal-types";
-import { Grid, Typography } from "@mui/material";
-import Box from "@mui/material/Box";
-import List from "@mui/material/List";
-import Stack from "@mui/material/Stack";
+import { Box, Grid, List, Stack, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React, { ReactNode, useEffect } from "react";
 import isWithdrawn from "./oscal-utils/OSCALCatalogUtils";
@@ -13,12 +10,10 @@ import {
 } from "./oscal-utils/OSCALLinkUtils";
 import { propWithName } from "./oscal-utils/OSCALPropUtils";
 import { AnchorLinkProps, OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
-import OSCALControl from "./OSCALControl";
+import OSCALControl, { ControlMetadataItems } from "./OSCALControl";
 import OSCALControlLabel from "./OSCALControlLabel";
 import OSCALControlPart from "./OSCALControlPart";
 import { Accordion, AccordionDetails, AccordionSummary } from "./StyedAccordion";
-import { OSCALPropertiesDialog } from "./OSCALProperties";
-import { OSCALParamsDialog } from "./OSCALParam";
 
 const WithdrawnControlText = styled(Typography)(({ theme }) => ({
   color: theme.palette.grey[400],
@@ -217,16 +212,7 @@ export const OSCALCatalogControlListItem: React.FC<OSCALCatalogControlListItemPr
         </TitleComponent>
       </OSCALAnchorLinkHeader>
       <Box>
-        <OSCALParamsDialog params={control.params} />
-        <OSCALPropertiesDialog
-          properties={control.props}
-          title={
-            <>
-              <OSCALControlLabel id={control.id} label={label} component="span" />
-              {` ${control.title}`}
-            </>
-          }
-        />
+        <ControlMetadataItems item={control} />
       </Box>
     </Stack>
   );
@@ -315,16 +301,7 @@ const OSCALCatalogGroupList: React.FC<OSCALCatalogGroupListProps> = (props) => {
         </TitleComponent>
       </OSCALAnchorLinkHeader>
       <Box>
-        <OSCALParamsDialog params={group.params} />
-        <OSCALPropertiesDialog
-          properties={group.props}
-          title={
-            <>
-              <OSCALControlLabel id={group.id} label={label} component="span" />
-              {` ${group.title}`}
-            </>
-          }
-        />
+        <ControlMetadataItems item={group} />
       </Box>
     </Stack>
   );
@@ -421,21 +398,10 @@ export const OSCALCatalogGroup: React.FC<OSCALCatalogGroupProps> = (props) => {
     ? `${urlFragment.substring(urlFragment.indexOf("/") + 1)}`
     : undefined;
 
-  const label = propWithName(group.props, "label")?.value;
-
   return (
     <>
       <Grid container justifyContent="flex-end">
-        <OSCALParamsDialog params={group.params} />{" "}
-        <OSCALPropertiesDialog
-          properties={group.props}
-          title={
-            <>
-              <OSCALControlLabel id={group.id} label={label} component="span" />
-              {` ${group.title}`}
-            </>
-          }
-        />
+        <ControlMetadataItems item={group} />
       </Grid>
       {group.parts?.map((part, index) => (
         <OSCALControlPart

--- a/packages/oscal-react-library/src/components/OSCALClass.tsx
+++ b/packages/oscal-react-library/src/components/OSCALClass.tsx
@@ -1,0 +1,17 @@
+import { Chip } from "@mui/material";
+import React from "react";
+import { colorFromString } from "../utils";
+
+interface HasClass {
+  class?: string;
+}
+
+interface SmallInlineClassDisplayProps {
+  item: HasClass;
+}
+
+export const SmallInlineClassDisplay: React.FC<SmallInlineClassDisplayProps> = ({ item }) => {
+  return item.class ? (
+    <Chip size="small" label={item.class} sx={{ bgcolor: colorFromString(item.class) }} />
+  ) : null;
+};

--- a/packages/oscal-react-library/src/components/OSCALControl.tsx
+++ b/packages/oscal-react-library/src/components/OSCALControl.tsx
@@ -16,6 +16,7 @@ import { OSCALPropertiesDialog } from "./OSCALProperties";
 import { shouldForwardProp } from "@mui/system";
 import {
   Control,
+  ControlGroup,
   ImplementedRequirementElement,
   SetParameterValue,
   Alteration,
@@ -25,6 +26,7 @@ import { Stack } from "@mui/material";
 import { groupBy } from "../utils";
 import { Accordion, AccordionSummary, AccordionDetails } from "./StyedAccordion";
 import { OSCALParamsDialog } from "./OSCALParam";
+import { SmallInlineClassDisplay } from "./OSCALClass";
 
 interface ControlListOptions {
   childLevel: number;
@@ -59,6 +61,38 @@ interface ControlsListProps extends EditableFieldProps, AnchorLinkProps, Control
   modificationSetParameters?: SetParameterValue[];
   withdrawn: boolean;
 }
+
+export interface ControlMetadataItemsProps {
+  /**
+   * The control or group to display details about.
+   */
+  item: Control | ControlGroup;
+}
+
+/**
+ * Metadata to display about the control (or group).
+ */
+export const ControlMetadataItems: React.FC<ControlMetadataItemsProps> = ({ item }) => {
+  return (
+    <>
+      <SmallInlineClassDisplay item={item} />
+      <OSCALParamsDialog params={item.params} />
+      <OSCALPropertiesDialog
+        properties={item.props}
+        title={
+          <>
+            <OSCALControlLabel
+              id={item.id}
+              label={propWithName(item.props, "label")?.value}
+              component="span"
+            />
+            {` ${item.title}`}
+          </>
+        }
+      />
+    </>
+  );
+};
 
 const ControlsList: React.FC<ControlsListProps> = (props) => {
   const {
@@ -267,16 +301,7 @@ const OSCALControl: React.FC<OSCALControlProps> = (props) => {
               </OSCALAnchorLinkHeader>
               <Box>
                 {modificationDisplay}
-                <OSCALParamsDialog params={control.params} />
-                <OSCALPropertiesDialog
-                  properties={control.props}
-                  title={
-                    <>
-                      <OSCALControlLabel id={control.id} label={label} component="span" />
-                      {` ${control.title}`}
-                    </>
-                  }
-                />
+                <ControlMetadataItems item={control} />
               </Box>
             </Stack>
           </Grid>

--- a/packages/oscal-react-library/src/components/OSCALMetadata.tsx
+++ b/packages/oscal-react-library/src/components/OSCALMetadata.tsx
@@ -53,6 +53,7 @@ import { NotSpecifiedTypography } from "./StyledTypography";
 import resolveLinkHref, { UriReferenceLookup } from "./oscal-utils/OSCALLinkUtils";
 import { Accordion, AccordionSummary, AccordionDetails } from "./StyedAccordion";
 import { OSCALPropertiesDialog } from "./OSCALProperties";
+import { colorFromString } from "../utils";
 
 const OSCALMetadataSectionInfoHeader = styled(Typography)`
   display: flex;
@@ -224,25 +225,6 @@ interface MetadataAvatarProps {
 const MetadataAvatar: React.FC<MetadataAvatarProps> = (props) => {
   const { id, text, fallbackIcon } = props;
 
-  const avatarColor = (name: string) => {
-    // This implementation hashes the given string to create a
-    // color string. This is based of the example algorithm given
-    // in the MUI documentation and adapted to our use case.
-    let hash = 0;
-    for (let i = 0; i < name.length; i += 1) {
-      // eslint-disable-next-line no-bitwise
-      hash = name.charCodeAt(i) + ((hash << 5) - hash);
-    }
-
-    let color = "#";
-    for (let i = 0; i < 3; i += 1) {
-      // eslint-disable-next-line no-bitwise
-      const value = (hash >> (i * 8)) & 0xff;
-      color += `00${value.toString(16)}`.slice(-2);
-    }
-    return color;
-  };
-
   const avatarValue = (name: string | undefined) =>
     name
       ?.split(" ")
@@ -251,7 +233,7 @@ const MetadataAvatar: React.FC<MetadataAvatarProps> = (props) => {
       .substring(0, 2)
       .toUpperCase();
 
-  return <Avatar sx={{ bgcolor: avatarColor(id) }}>{avatarValue(text) ?? fallbackIcon}</Avatar>;
+  return <Avatar sx={{ bgcolor: colorFromString(id) }}>{avatarValue(text) ?? fallbackIcon}</Avatar>;
 };
 
 enum MetadataInfoType {

--- a/packages/oscal-react-library/src/components/OSCALParam.tsx
+++ b/packages/oscal-react-library/src/components/OSCALParam.tsx
@@ -31,6 +31,7 @@ import {
   StyledTableHead,
   StyledTableRow,
 } from "./OSCALSystemImplementationTableStyles";
+import { SmallInlineClassDisplay } from "./OSCALClass";
 
 interface OSCALParamUsageProps {
   usage: string | undefined;
@@ -223,6 +224,7 @@ export const OSCALParam: React.FC<OSCALParamProps> = ({ param }) => {
         <Stack direction="row" alignItems="center" justifyContent="space-between" width="100%">
           <Typography>{param.id}</Typography>
           <Typography sx={{ color: "text.secondary" }}>{param.label}</Typography>
+          <SmallInlineClassDisplay item={param} />
           <OSCALPropertiesDialog properties={param.props} />
         </Stack>
       </AccordionSummary>

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -17,6 +17,7 @@ import { NIST_DEFAULT_NAMESPACE, namespaceOf } from "./oscal-utils/OSCALPropUtil
 import { NotSpecifiedTypography } from "./StyledTypography";
 import { groupBy } from "../utils";
 import { ButtonLaunchedDialog } from "./ButtonLaunchedDialog";
+import { SmallInlineClassDisplay } from "./OSCALClass";
 
 /**
  *  Helper to sort properties by their `name` field.
@@ -44,7 +45,9 @@ const OSCALProperty: React.FC<OSCALPropertyProps> = ({ property }) => {
     <StyledTooltip title={property.remarks ?? ""}>
       <StyledTableRow key={property.uuid}>
         <TableCell>{property.name ?? NO_INFORMATION}</TableCell>
-        <TableCell>{property.class ?? NO_INFORMATION}</TableCell>
+        <TableCell>
+          {property.class ? <SmallInlineClassDisplay item={property} /> : NO_INFORMATION}
+        </TableCell>
         <TableCell>{property.value ?? NO_INFORMATION}</TableCell>
       </StyledTableRow>
     </StyledTooltip>

--- a/packages/oscal-react-library/src/utils.ts
+++ b/packages/oscal-react-library/src/utils.ts
@@ -5,3 +5,23 @@ export function groupBy<T, K extends PropertyKey>(list: T[], key: (item: T) => K
     return map;
   }, {} as Record<K, T[]>);
 }
+
+export const colorFromString = (name: string): string => {
+  // This implementation hashes the given string to create a
+  // color string. This is based of the example algorithm given
+  // in the MUI documentation and adapted to our use case.
+  let hash = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    // eslint-disable-next-line no-bitwise
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  let color = "#";
+  for (let i = 0; i < 3; i += 1) {
+    // eslint-disable-next-line no-bitwise
+    const value = (hash >> (i * 8)) & 0xff;
+    color += `00${value.toString(16)}`.slice(-2);
+  }
+  // Add an alpha channe to prevent the color from being too dark
+  return `${color}C0`;
+};


### PR DESCRIPTION
This displays the `class` attribute on controls, groups, parameters,
and properties. It uses a consistent way to display them.

![image](https://github.com/EasyDynamics/oscal-react-library/assets/850893/2b04f970-d964-43f8-b60b-e333a3a94bd3)

![image](https://github.com/EasyDynamics/oscal-react-library/assets/850893/9fbe473a-42a6-4864-b751-a71590d14f4e)


Closes #819