### PR TITLE
chore: display params for catalog

### DIFF
--- a/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
+++ b/packages/oscal-react-library/src/components/ButtonLaunchedDialog.tsx
@@ -11,16 +11,18 @@ interface ButtonLaunchedDialogProps {
   Icon: typeof SvgIcon;
 
   /**
-   * The title to display specifically in tooltips that describe the dialog
+   * The title of the dialog.
    *
-   * @default the value of `title`
+   * @example "Properties"
    */
-  toolTipTitle?: string;
+  dialogTitle: string;
 
   /**
-   * The title of the item being viewed in the dialog
+   * The title of the item being viewed in the dialog.
+   *
+   * @example "AC-1"
    */
-  title: React.ReactNode;
+  componentTitle?: React.ReactNode;
 
   /**
    * The content of the dialog. This will be displayed in the dialog's body.
@@ -37,10 +39,10 @@ interface ButtonLaunchedDialogProps {
 
 export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
   Icon,
-  toolTipTitle,
+  dialogTitle,
   disabled,
   children,
-  title,
+  componentTitle,
 }) => {
   const [open, setOpen] = React.useState(false);
 
@@ -65,7 +67,7 @@ export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
 
   return (
     <>
-      <StyledTooltip title={`Open ${toolTipTitle ?? title}`}>
+      <StyledTooltip title={`Open ${dialogTitle}`}>
         {
           // This Box is necessary to ensure the tooltip is present when the button is disabled.
           // If the Button were never disabled, the Box can be removed. This change may be made
@@ -78,7 +80,7 @@ export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
             color="primary"
             size="small"
             onClick={handleOpen}
-            aria-label={`Open ${toolTipTitle ?? title}`}
+            aria-label={`Open ${dialogTitle}`}
             disabled={disabled}
           >
             <Icon />
@@ -99,7 +101,9 @@ export const ButtonLaunchedDialog: React.FC<ButtonLaunchedDialogProps> = ({
       >
         <DialogContent onClick={(e) => e.stopPropagation()}>
           <DialogTitle>
-            <Typography>{title}</Typography>
+            <Typography>
+              {componentTitle} {dialogTitle}
+            </Typography>
           </DialogTitle>
           {children}
         </DialogContent>

--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -1,5 +1,6 @@
 import { Catalog, ControlGroup } from "@easydynamics/oscal-types";
 import { Card, CardContent } from "@mui/material";
+import { Stack } from "@mui/system";
 import React, { useEffect } from "react";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
@@ -9,6 +10,7 @@ import OSCALCatalogGroups from "./OSCALCatalogGroups";
 import { EditableFieldProps } from "./OSCALEditableTextField";
 import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 import OSCALMetadata from "./OSCALMetadata";
+import { OSCALParamsDialog } from "./OSCALParam";
 
 const UNGROUPED_CONTROLS_TITLE = "*Top*";
 
@@ -81,6 +83,9 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = ({
 
   return (
     <OSCALDocumentRoot>
+      <Stack justifyContent="flex-end" direction="row">
+        <OSCALParamsDialog params={catalog.params} />
+      </Stack>
       <OSCALMetadata
         metadata={catalog.metadata}
         isEditable={isEditable}
@@ -90,7 +95,6 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = ({
         parentUrl={parentUrl}
         backMatter={catalog["back-matter"]}
       />
-
       {catalog.groups ? (
         <OSCALCatalogGroups
           groups={catalog.controls ? [defaultGroup, ...(catalog.groups ?? [])] : catalog.groups}
@@ -99,7 +103,6 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = ({
       ) : catalog.controls ? (
         <OSCALCatalogControlsList controls={catalog.controls} urlFragment={urlFragment} />
       ) : undefined}
-
       <OSCALBackMatter
         backMatter={catalog["back-matter"]}
         parentUrl={parentUrl}

--- a/packages/oscal-react-library/src/components/OSCALCatalog.tsx
+++ b/packages/oscal-react-library/src/components/OSCALCatalog.tsx
@@ -1,6 +1,5 @@
 import { Catalog, ControlGroup } from "@easydynamics/oscal-types";
 import { Card, CardContent } from "@mui/material";
-import { Stack } from "@mui/system";
 import React, { useEffect } from "react";
 import { OSCALSection, OSCALSectionHeader } from "../styles/CommonPageStyles";
 import { OSCALAnchorLinkHeader } from "./OSCALAnchorLinkHeader";
@@ -10,7 +9,7 @@ import OSCALCatalogGroups from "./OSCALCatalogGroups";
 import { EditableFieldProps } from "./OSCALEditableTextField";
 import { OSCALDocumentRoot } from "./OSCALLoaderStyles";
 import OSCALMetadata from "./OSCALMetadata";
-import { OSCALParamsDialog } from "./OSCALParam";
+import { OSCALParams } from "./OSCALParam";
 
 const UNGROUPED_CONTROLS_TITLE = "*Top*";
 
@@ -83,9 +82,6 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = ({
 
   return (
     <OSCALDocumentRoot>
-      <Stack justifyContent="flex-end" direction="row">
-        <OSCALParamsDialog params={catalog.params} />
-      </Stack>
       <OSCALMetadata
         metadata={catalog.metadata}
         isEditable={isEditable}
@@ -95,6 +91,14 @@ export const OSCALCatalog: React.FC<OSCALCatalogProps> = ({
         parentUrl={parentUrl}
         backMatter={catalog["back-matter"]}
       />
+      <OSCALSection>
+        <Card>
+          <CardContent>
+            <OSCALSectionHeader>Parameters</OSCALSectionHeader>
+            <OSCALParams params={catalog.params} />
+          </CardContent>
+        </Card>
+      </OSCALSection>
       {catalog.groups ? (
         <OSCALCatalogGroups
           groups={catalog.controls ? [defaultGroup, ...(catalog.groups ?? [])] : catalog.groups}

--- a/packages/oscal-react-library/src/components/OSCALParam.tsx
+++ b/packages/oscal-react-library/src/components/OSCALParam.tsx
@@ -261,7 +261,7 @@ export const OSCALParams: React.FC<OSCALParamsProps> = ({ params }) => {
 };
 
 export const OSCALParamsDialog = (props: OSCALParamsProps) => (
-  <ButtonLaunchedDialog title="Parameters" disabled={!props.params} Icon={DataObjectIcon}>
+  <ButtonLaunchedDialog dialogTitle="Parameters" disabled={!props.params} Icon={DataObjectIcon}>
     <OSCALParams params={props.params} />
   </ButtonLaunchedDialog>
 );

--- a/packages/oscal-react-library/src/components/OSCALProperties.tsx
+++ b/packages/oscal-react-library/src/components/OSCALProperties.tsx
@@ -115,12 +115,13 @@ export const OSCALPropertiesDialog: React.FC<OSCALPropertiesDialogProps> = ({
   const { [NIST_DEFAULT_NAMESPACE]: nist, ...thirdParties } = groupBy(properties ?? [], (prop) =>
     namespaceOf(prop.ns)
   );
+
   return (
     <ButtonLaunchedDialog
       Icon={ConstructionIcon}
       disabled={!properties}
-      title={`${title} Properties`}
-      toolTipTitle={"Properties"}
+      componentTitle={title}
+      dialogTitle={"Properties"}
     >
       {/* Handle NIST properties */}
       <OSCALProperties


### PR DESCRIPTION
Displays parameters at the top of a catalog.

closes #822 

### Testing

https://raw.githubusercontent.com/EasyDynamics/oscal-demo-content/tuckerzp/params/catalogs/basic-test-catalog.json

![image](https://github.com/EasyDynamics/oscal-react-library/assets/39490074/97a437ad-d28b-41a2-a253-70d9c9f82753)