### PR TITLE
chore(tests): always pass `onResolutionComplete` to documents

### DIFF
--- a/packages/oscal-react-library/src/components/OSCALComponentDefinition.test.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinition.test.js
@@ -9,22 +9,33 @@ test("OSCALComponentDefinition loads", () => {
   render(<OSCALComponentLoader />);
 });
 
-function componentDefinitionRenderer() {
-  render(<OSCALComponentDefinition componentDefinition={componentDefinitionTestData} />);
-}
+describe("OSCALComponentDefinition", () => {
+  it("shows component title", () => {
+    // GIVEN
+    render(
+      <OSCALComponentDefinition
+        componentDefinition={componentDefinitionTestData}
+        onResolutionComplete={() => {}}
+      />
+    );
 
-function testOSCALComponentDefinitionComponent(parentElementName, renderer) {
-  test(`${parentElementName} shows component title`, () => {
-    renderer();
-    const result = screen.getByText("Example Component");
-    expect(result).toBeVisible();
+    // THEN
+    expect(screen.getByText("Example Content")).toBeVisible();
   });
 
-  test(`${parentElementName} shows component description`, async () => {
-    renderer();
+  it("shows component description", async () => {
+    // GIVEN
+    render(
+      <OSCALComponentDefinition
+        componentDefinition={componentDefinitionTestData}
+        onResolutionComplete={() => {}}
+      />
+    );
+
+    // WHEN
     await userEvent.hover(screen.getByText("Example Component"));
+
+    // THEN
     expect(await screen.findByText("An example component.")).toBeInTheDocument();
   });
-}
-
-testOSCALComponentDefinitionComponent("OSCALComponentDefinition", componentDefinitionRenderer);
+});

--- a/packages/oscal-react-library/src/components/OSCALComponentDefinition.test.js
+++ b/packages/oscal-react-library/src/components/OSCALComponentDefinition.test.js
@@ -20,7 +20,7 @@ describe("OSCALComponentDefinition", () => {
     );
 
     // THEN
-    expect(screen.getByText("Example Content")).toBeVisible();
+    expect(screen.getByText("Example Component")).toBeVisible();
   });
 
   it("shows component description", async () => {

--- a/packages/oscal-react-library/src/components/OSCALSsp.test.js
+++ b/packages/oscal-react-library/src/components/OSCALSsp.test.js
@@ -11,7 +11,9 @@ test("OSCALSsp loads", () => {
 });
 
 function sspRenderer() {
-  render(<OSCALSsp system-security-plan={sspTestData} parentUrl="./" />);
+  render(
+    <OSCALSsp system-security-plan={sspTestData} parentUrl="./" onResolutionComplete={() => {}} />
+  );
 }
 
 testOSCALSystemCharacteristics("OSCALSsp", sspRenderer);


### PR DESCRIPTION
We have a bunch of odd failures because `onResolutionComplete` is
required but we don't pass it in the tests. This (hopefully) fixes that.
CDef's tests got reworked in this because it helped to identify the
issue but I did more minimal changes in the other locations.
