### PR TITLE
feat: add feature flags

### DIFF
--- a/packages/oscal-react-library/src/components/Feature.tsx
+++ b/packages/oscal-react-library/src/components/Feature.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { FeatureFlagConfiguration, FeatureFlags } from "../contexts/FeatureFlags";
+
+export type FeatureFlagKey<T extends FeatureFlagConfiguration> = keyof T;
+
+export interface FeatureProps<T extends FeatureFlagConfiguration = FeatureFlagConfiguration> {
+  feature: FeatureFlagKey<T>;
+  children: React.ReactNode;
+}
+
+function isFeatureEnabled<T extends FeatureFlagConfiguration = FeatureFlagConfiguration>(
+  features: T,
+  feature: string | number | symbol
+): boolean {
+  if (feature in features) {
+    return (features as any)[feature] ?? false;
+  }
+  return false;
+}
+
+export function Feature<T extends FeatureFlagConfiguration = FeatureFlagConfiguration>({
+  feature,
+  children,
+}: FeatureProps<T>) {
+  const { features } = React.useContext(FeatureFlags);
+  if (isFeatureEnabled(features, feature)) {
+    return null;
+  }
+  return children;
+}

--- a/packages/oscal-react-library/src/contexts/FeatureFlags.tsx
+++ b/packages/oscal-react-library/src/contexts/FeatureFlags.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+export interface FeatureFlagConfiguration {
+  isEditingEnabled: boolean;
+  isEnterpriseSupportEnabled: boolean;
+}
+
+const defaultFeatures: FeatureFlagConfiguration = {
+  isEditingEnabled: false,
+  isEnterpriseSupportEnabled: false,
+};
+
+export const FeatureFlags = React.createContext({
+  features: JSON.parse(JSON.stringify(defaultFeatures)) as FeatureFlagConfiguration,
+});
+
+export interface FeatureFlagsProviderProps<
+  T extends FeatureFlagConfiguration = FeatureFlagConfiguration
+> {
+  children: React.ReactNode;
+  flags: T;
+}
+
+export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({ children, flags }) => {
+  const [features, _setFeatures] = React.useState(flags);
+  return <FeatureFlags.Provider value={{ features }}>{children}</FeatureFlags.Provider>;
+};

--- a/packages/oscal-react-library/src/index.ts
+++ b/packages/oscal-react-library/src/index.ts
@@ -18,3 +18,9 @@ export {
   OSCALProfileLoader,
   OSCALDrawerSelector,
 };
+
+export { FeatureFlags, FeatureFlagsProvider } from "./contexts/FeatureFlags";
+export type { FeatureFlagConfiguration, FeatureFlagsProviderProps } from "./contexts/FeatureFlags";
+
+export { Feature } from "./components/Feature";
+export type { FeatureProps } from "./components/Feature";

--- a/packages/oscal-viewer/src/App.js
+++ b/packages/oscal-viewer/src/App.js
@@ -23,6 +23,7 @@ import {
   OSCALComponentLoader,
   OSCALProfileLoader,
   OSCALDrawerSelector,
+  FeatureFlagsProvider,
 } from "@easydynamics/oscal-react-library";
 import logo from "./images/logo-header.svg";
 
@@ -231,81 +232,85 @@ function App() {
 
   return (
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={appTheme}>
-        <CssBaseline />
-        <div className="App">
-          <AppBar position="static">
-            <Toolbar>
-              <Grid container alignItems="center">
-                <Grid item md={6} align="left">
-                  <Grid container alignItems="center">
-                    <Grid item align="left">
-                      <OpenNavButton
-                        edge="start"
-                        onClick={handleAppNavOpen}
-                        color="inherit"
-                        aria-label="menu"
+      <FeatureFlagsProvider
+        flags={{ isEditingEnabled: !!isRestMode, isEnterpriseSupportEnabled: false }}
+      >
+        <ThemeProvider theme={appTheme}>
+          <CssBaseline />
+          <div className="App">
+            <AppBar position="static">
+              <Toolbar>
+                <Grid container alignItems="center">
+                  <Grid item md={6} align="left">
+                    <Grid container alignItems="center">
+                      <Grid item align="left">
+                        <OpenNavButton
+                          edge="start"
+                          onClick={handleAppNavOpen}
+                          color="inherit"
+                          aria-label="menu"
+                          size="large"
+                        >
+                          <MenuIcon />
+                        </OpenNavButton>
+                        {navigation}
+                      </Grid>
+                      <Grid item align="left">
+                        <Typography variant="h6">
+                          <Routes>{appBarRoutes}</Routes>
+                        </Typography>
+                      </Grid>
+                      {backendUrl && (
+                        <Grid item align="right" sx={{ mx: 4 }}>
+                          <FormControlLabel
+                            control={
+                              <Switch
+                                checked={isRestMode}
+                                color="warning"
+                                onChange={onChangeRestMode}
+                                name="isRestMode"
+                              />
+                            }
+                            label="REST Mode"
+                          />
+                        </Grid>
+                      )}
+                    </Grid>
+                  </Grid>
+                  <Grid item md={6}>
+                    <Grid container alignItems="center" justifyContent="right">
+                      <Typography variant="body2" sx={{ color: "white", fontStyle: "italic" }}>
+                        Powered by
+                      </Typography>
+                      <Button
+                        href="https://www.easydynamics.com"
+                        target="_blank"
+                        sx={{ color: "white" }}
+                      >
+                        <LogoImage src={logo} alt="Easy Dynamics Logo" />
+                      </Button>
+                      <Typography variant="body2" sx={{ color: "white", mx: 5 }}>
+                        |
+                      </Typography>
+                      <IconButton
+                        href="https://github.com/EasyDynamics/oscal-react-library"
+                        target="_blank"
+                        rel="noreferrer"
                         size="large"
                       >
-                        <MenuIcon />
-                      </OpenNavButton>
-                      {navigation}
+                        <GitHubIcon htmlColor="white" />
+                      </IconButton>
                     </Grid>
-                    <Grid item align="left">
-                      <Typography variant="h6">
-                        <Routes>{appBarRoutes}</Routes>
-                      </Typography>
-                    </Grid>
-                    {backendUrl && (
-                      <Grid item align="right" sx={{ mx: 4 }}>
-                        <FormControlLabel
-                          control={
-                            <Switch
-                              checked={isRestMode}
-                              color="warning"
-                              onChange={onChangeRestMode}
-                              name="isRestMode"
-                            />
-                          }
-                          label="REST Mode"
-                        />
-                      </Grid>
-                    )}
                   </Grid>
                 </Grid>
-                <Grid item md={6}>
-                  <Grid container alignItems="center" justifyContent="right">
-                    <Typography variant="body2" sx={{ color: "white", fontStyle: "italic" }}>
-                      Powered by
-                    </Typography>
-                    <Button
-                      href="https://www.easydynamics.com"
-                      target="_blank"
-                      sx={{ color: "white" }}
-                    >
-                      <LogoImage src={logo} alt="Easy Dynamics Logo" />
-                    </Button>
-                    <Typography variant="body2" sx={{ color: "white", mx: 5 }}>
-                      |
-                    </Typography>
-                    <IconButton
-                      href="https://github.com/EasyDynamics/oscal-react-library"
-                      target="_blank"
-                      rel="noreferrer"
-                      size="large"
-                    >
-                      <GitHubIcon htmlColor="white" />
-                    </IconButton>
-                  </Grid>
-                </Grid>
-              </Grid>
-            </Toolbar>
-          </AppBar>
-          <Container maxWidth={false} component="main">
-            <Routes>{navRoutes}</Routes>
-          </Container>
-        </div>
-      </ThemeProvider>
+              </Toolbar>
+            </AppBar>
+            <Container maxWidth={false} component="main">
+              <Routes>{navRoutes}</Routes>
+            </Container>
+          </div>
+        </ThemeProvider>
+      </FeatureFlagsProvider>
     </StyledEngineProvider>
   );
 }


### PR DESCRIPTION
This adds basic support for feature flags. Only two-state (true/false)
feature flags are enabled where `true` enables the feature and `false`
disables. Usage of the components would look a bit like this:

```tsx
<FeatureFlagsProvider flags={{ isEditingEnabled: true, isEnterpriseSupportEnabled: false }}>
  <SomeParentThing>
    <Feature flag="isEditingEnabled">
      <MyEditingComponent />
    </Feature>
  </SomeParentThing>
</FeatureFlagsProvider>
```

Specifically in our application, `FeatureFlagsProvider` would probably
be defined in the `App` component and then `Feature` used throughout the
library. An `App` may define additional features; however, it's
important that the _library_ only use features defined in
`FeatureFlags.tsx`.
