### PR TITLE
fix: update type workflow fails on v1.1.0 release

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -48,7 +48,8 @@ jobs:
         run: |
           wget -q ${{ steps.fetch-data.outputs.url }}
           unzip oscal-${{ steps.fetch-data.outputs.version }}.zip
-          cp oscal-${{ steps.fetch-data.outputs.version }}/json/schema/oscal_complete_schema.json .
+          basedir="$(test -d json && echo "." || echo "oscal-${{ steps.fetch-data.outputs.version }}")"
+          cp "$basedir/json/schema/oscal_complete_schema.json" .
           echo "${{ steps.fetch-data.outputs.version }}" > VERSION.txt
       - name: Upload schema artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The v1.1.0 OSCAL release's ZIP file doesn't have a "wrapping" folder named for the release version like previous versions did. Basically, this means that when you explode the ZIP, you get the `json` and `xml` directories directly (instead of having them inside an `oscal-1.1.0` folder as in the past). This change checks to see if a `json` folder exists in the current directory; if so, it looks in there for the complete schema. Otherwise, it looks for an `oscal-VERSION` folder. If neither exists, it's a new case we haven't seen before, so there will be an error anyway.