### PR TITLE
chore: Turn off style and dev flags

### DIFF
--- a/packages/oscal-viewer/src/App.js
+++ b/packages/oscal-viewer/src/App.js
@@ -35,8 +35,8 @@ const LogoImage = styled("img")`
   margin-right: 1em;
 `;
 
-const isStyleMode = true;
-const isDevMode = true;
+const isStyleMode = false;
+const isDevMode = false;
 
 const drawerWidth = isDevMode && !isStyleMode ? "20rem" : "0rem";
 const appBarHeight = isDevMode && !isStyleMode ? "5rem" : "0rem";


### PR DESCRIPTION
Currently https://viewer.oscal.io/ just shows the style guide. We would like to see OSCAL Viewer here. This sets the `isStyleMode` and `isDevMode` to `false`, which wasn't turned off in the previous PR.